### PR TITLE
feat(canary): delete button and modal

### DIFF
--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -1,4 +1,9 @@
 export const CONFIG_LOAD_ERROR = 'config_load_error';
+export const DELETE_CONFIG_DELETING = 'delete_config_deleting';
+export const DELETE_CONFIG_COMPLETED = 'delete_config_completed';
+export const DELETE_CONFIG_ERROR = 'delete_config_error';
+export const DELETE_CONFIG_MODAL_OPEN = 'delete_config_modal_open';
+export const DELETE_CONFIG_MODAL_CLOSE = 'delete_config_modal_close';
 export const DISMISS_SAVE_CONFIG_ERROR = 'dismiss_save_config_error';
 export const INITIALIZE = 'initialize';
 export const LOAD_CONFIG = 'load_config';

--- a/src/kayenta/canary.tsx
+++ b/src/kayenta/canary.tsx
@@ -11,6 +11,7 @@ import { ICanaryConfig, ICanaryConfigSummary, ICanaryMetricConfig } from './doma
 import { ConfigDetailLoadState } from './edit/configDetailLoader';
 import { INITIALIZE, UPDATE_CONFIG_SUMMARIES } from './actions/index';
 import { SaveConfigState } from './edit/save';
+import { DeleteConfigState } from './edit/deleteModal';
 
 export interface ICanaryProps {
   app: Application;
@@ -34,6 +35,7 @@ export default class Canary extends React.Component<ICanaryProps, {}> {
         configLoadState: ConfigDetailLoadState.Loaded,
         metricList: [] as ICanaryMetricConfig[],
         saveConfigState: SaveConfigState.Saved,
+        deleteConfigState: DeleteConfigState.Completed,
       }
     });
 

--- a/src/kayenta/edit/deleteModal.tsx
+++ b/src/kayenta/edit/deleteModal.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Button, Modal } from 'react-bootstrap';
+import * as classNames from 'classnames';
+
+import { SubmitButton } from '@spinnaker/core';
+
+import {
+  DELETE_CONFIG_MODAL_CLOSE,
+  DELETE_CONFIG_DELETING
+} from '../actions/index';
+import { ICanaryState } from '../reducers/index';
+
+interface IDeleteModalDispatchProps {
+  closeDeleteConfigModal: () => void;
+  deleteConfig: () => void;
+}
+
+interface IDeleteModalStateProps {
+  show: boolean;
+  selectedConfigName: string;
+  deleteConfigState: DeleteConfigState;
+  deleteConfigErrorMessage: string;
+}
+
+export enum DeleteConfigState {
+  Deleting,
+  Completed,
+  Error,
+}
+
+/*
+ * Modal to confirm canary config deletion.
+ */
+function DeleteConfigModal({ show, selectedConfigName, deleteConfigState, deleteConfigErrorMessage, closeDeleteConfigModal, deleteConfig }: IDeleteModalDispatchProps & IDeleteModalStateProps) {
+  return (
+    <Modal show={show} onHide={null}>
+      <Modal.Header>
+        <Modal.Title>Really delete {selectedConfigName}?</Modal.Title>
+      </Modal.Header>
+      { deleteConfigState === DeleteConfigState.Error && (
+        <Modal.Body>
+          {/*TODO: create generic error message component */}
+          <span className={classNames('alert', 'alert-danger')}>
+            {buildErrorMessage(deleteConfigErrorMessage)}
+          </span>
+        </Modal.Body>
+      )}
+      <Modal.Footer>
+        <Button onClick={closeDeleteConfigModal}>Cancel</Button>
+        <SubmitButton
+          label="Delete"
+          submitting={deleteConfigState === DeleteConfigState.Deleting}
+          onClick={deleteConfig}
+        />
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+function buildErrorMessage(deleteConfigErrorMessage: string): string {
+  const message = 'The was an error deleting your config';
+  return deleteConfigErrorMessage
+    ? message + `: ${deleteConfigErrorMessage}.`
+    : message + '.';
+}
+
+function mapDispatchToProps(dispatch: any): IDeleteModalDispatchProps {
+  return {
+    closeDeleteConfigModal: () => {
+      dispatch({type: DELETE_CONFIG_MODAL_CLOSE});
+    },
+    deleteConfig: () => {
+      dispatch({type: DELETE_CONFIG_DELETING})
+    },
+  };
+}
+
+function mapStateToProps(state: ICanaryState): IDeleteModalStateProps {
+  return {
+    show: state.deleteConfigModalOpen,
+    selectedConfigName: state.selectedConfig ? state.selectedConfig.name : null,
+    deleteConfigState: state.deleteConfigState,
+    deleteConfigErrorMessage: state.deleteConfigErrorMessage,
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteConfigModal);

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { ICanaryMetricConfig } from '../domain/ICanaryConfig';
 import { ICanaryState } from '../reducers';
 import MetricDetail from './metricDetail';
+import OpenDeleteModalButton from './openDeleteModalButton';
 import { ADD_METRIC, RENAME_METRIC } from '../actions/index';
 
 interface IMetricListStateProps {
@@ -21,6 +22,8 @@ function MetricList({ metrics, changeName, addMetric }: IMetricListStateProps & 
   return (
     <section>
       <h2>Metrics</h2>
+      {/*TODO: this button should not go here, but there is no good spot for it now.*/}
+      <OpenDeleteModalButton/>
       <ul className="list-group">
         {metrics.map((metric, index) => (
           // TODO: put id on metric? name can change by edit, index can change by remove operation

--- a/src/kayenta/edit/openDeleteModalButton.tsx
+++ b/src/kayenta/edit/openDeleteModalButton.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Button } from 'react-bootstrap';
+
+import { DELETE_CONFIG_MODAL_OPEN } from '../actions/index';
+import DeleteConfigModal from './deleteModal';
+
+interface IDeleteButtonDispatchProps {
+  openDeleteConfigModal: () => void;
+}
+
+/*
+ * Button for opening the delete canary config confirmation modal.
+ */
+function DeleteConfigButton({ openDeleteConfigModal }: IDeleteButtonDispatchProps) {
+  return (
+    <div>
+      <Button onClick={openDeleteConfigModal}>Delete</Button>
+      {/* Is this how people place modals in the component tree? */}
+      <DeleteConfigModal/>
+    </div>
+  );
+}
+
+function mapDispatchToProps(dispatch: any): IDeleteButtonDispatchProps {
+  return {
+    openDeleteConfigModal: () => {
+      dispatch({type: DELETE_CONFIG_MODAL_OPEN});
+    }
+  };
+}
+
+export default connect(null, mapDispatchToProps)(DeleteConfigButton);

--- a/src/kayenta/epics/index.ts
+++ b/src/kayenta/epics/index.ts
@@ -3,13 +3,14 @@ import 'rxjs/add/observable/concat';
 import { MiddlewareAPI } from 'redux';
 import { createEpicMiddleware, combineEpics } from 'redux-observable';
 import {
+  deleteCanaryConfig,
   getCanaryConfigById, mapStateToConfig,
   updateCanaryConfig
 } from '../service/canaryConfig.service';
 import {
   CONFIG_LOAD_ERROR,
   LOAD_CONFIG, SAVE_CONFIG_ERROR, SAVE_CONFIG_SAVING, SAVE_CONFIG_SAVED,
-  SELECT_CONFIG
+  SELECT_CONFIG, DELETE_CONFIG_DELETING, DELETE_CONFIG_COMPLETED, DELETE_CONFIG_ERROR
 } from '../actions/index';
 import { ICanaryState } from '../reducers/index';
 
@@ -31,9 +32,19 @@ const saveConfigEpic = (action$: Observable<any>, store: MiddlewareAPI<ICanarySt
         .catch(error => ({type: SAVE_CONFIG_ERROR, error}))
     );
 
+const deleteConfigEpic = (action$: Observable<any>, store: MiddlewareAPI<ICanaryState>) =>
+  action$
+    .filter(action => action.type === DELETE_CONFIG_DELETING)
+    .concatMap(() =>
+      deleteCanaryConfig(store.getState().selectedConfig.name)
+        .then(() => ({type: DELETE_CONFIG_COMPLETED}))
+        .catch(error => ({type: DELETE_CONFIG_ERROR, error}))
+    );
+
 const rootEpic = combineEpics(
   selectConfigEpic,
-  saveConfigEpic
+  saveConfigEpic,
+  deleteConfigEpic
 );
 
 export const epicMiddleware = createEpicMiddleware(rootEpic);

--- a/src/kayenta/reducers/index.ts
+++ b/src/kayenta/reducers/index.ts
@@ -8,8 +8,12 @@ import {
   ADD_METRIC, SELECT_CONFIG, UPDATE_CONFIG_SUMMARIES,
   CONFIG_LOAD_ERROR, DISMISS_SAVE_CONFIG_ERROR, INITIALIZE, LOAD_CONFIG,
   RENAME_METRIC, SAVE_CONFIG_ERROR, SAVE_CONFIG_SAVING, SAVE_CONFIG_SAVED,
+  DELETE_CONFIG_MODAL_OPEN,
+  DELETE_CONFIG_MODAL_CLOSE, DELETE_CONFIG_DELETING, DELETE_CONFIG_COMPLETED,
+  DELETE_CONFIG_ERROR,
 } from '../actions/index';
 import { SaveConfigState } from '../edit/save';
+import { DeleteConfigState } from '../edit/deleteModal';
 
 export interface ICanaryState {
   configSummaries: ICanaryConfigSummary[];
@@ -18,6 +22,9 @@ export interface ICanaryState {
   metricList: ICanaryMetricConfig[];
   saveConfigState: SaveConfigState;
   saveConfigErrorMessage: string;
+  deleteConfigModalOpen: boolean;
+  deleteConfigState: DeleteConfigState,
+  deleteConfigErrorMessage: string;
 }
 
 function configSummaries(state: ICanaryConfigSummary[] = [], action: Action & any): ICanaryConfigSummary[] {
@@ -132,11 +139,62 @@ function saveConfigErrorMessage(state: string = null, action: Action & any): str
   }
 }
 
+function deleteConfigModalOpen(state = false, action: Action & any): boolean {
+  switch (action.type) {
+    case DELETE_CONFIG_MODAL_OPEN:
+      return true;
+
+    case DELETE_CONFIG_MODAL_CLOSE:
+      return false;
+
+    case DELETE_CONFIG_COMPLETED:
+      return false;
+
+    default:
+      return state;
+  }
+}
+
+function deleteConfigState(state = DeleteConfigState.Completed, action: Action & any): DeleteConfigState {
+  switch (action.type) {
+    case DELETE_CONFIG_DELETING:
+      return DeleteConfigState.Deleting;
+
+    case DELETE_CONFIG_COMPLETED:
+      return DeleteConfigState.Completed;
+
+    case DELETE_CONFIG_ERROR:
+      return DeleteConfigState.Error;
+
+    default:
+      return state;
+  }
+}
+
+function deleteConfigErrorMessage(state: string = null, action: Action & any): string {
+  switch (action.type) {
+    case DELETE_CONFIG_DELETING:
+      return null;
+
+    case DELETE_CONFIG_COMPLETED:
+      return null;
+
+    case DELETE_CONFIG_ERROR:
+      return get(action, 'error.data.message', null);
+
+    default:
+      return state;
+  }
+}
+
 export const rootReducer = combineReducers<ICanaryState>({
   configSummaries,
   selectedConfig,
   configLoadState,
   metricList,
   saveConfigState,
-  saveConfigErrorMessage
+  saveConfigErrorMessage,
+  deleteConfigModalOpen,
+  deleteConfigState,
+  deleteConfigErrorMessage,
 });

--- a/src/kayenta/service/canaryConfig.service.ts
+++ b/src/kayenta/service/canaryConfig.service.ts
@@ -39,6 +39,14 @@ export function updateCanaryConfig(config: ICanaryConfig): Promise<string> {
   }
 }
 
+export function deleteCanaryConfig(id: string): Promise<void> {
+  if (CanarySettings.liveCalls) {
+    return ReactInjector.API.one('v2/canaryConfig').one(id).remove();
+  } else {
+    return Promise.resolve(null);
+  }
+}
+
 // Not sure if this is the right way to go about this. We have pieces of the config
 // living on different parts of the store. Before, e.g., updating the config, we should
 // reconstitute it into a single object that reflects the user's changes.


### PR DESCRIPTION
Depends on https://github.com/spinnaker/gate/pull/430.

(At least) two things that need to be done: 
- When you delete a config, you should be routed to the main config list.
- The delete button should sit in a layout that matches our mocks - I'm going to work on that.


