### PR TITLE
fix: handle timing issue where selectedConfig is not set

### DIFF
--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -16,7 +16,7 @@ function ConfigDetailHeader({ selectedConfig }: IConfigDetailStateProps) {
   return (
     <div className="row">
       <div className="col-sm-6">
-        <h2>{selectedConfig.name}</h2>
+        <h2>{selectedConfig ? selectedConfig.name : ''}</h2>
       </div>
       <div className="col-sm-3">
         {/* TODO: config metadata goes here. */}

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -45,10 +45,17 @@ function NameAndDescription({ name, description, changeName, changeDescription }
 }
 
 function mapStateToProps(state: ICanaryState) {
-  return {
-    name: state.selectedConfig.name,
-    description: state.selectedConfig.description,
-  };
+  if (state.selectedConfig) {
+    return {
+      name: state.selectedConfig.name,
+      description: state.selectedConfig.description,
+    };
+  } else {
+    return {
+      name: '',
+      description: ''
+    };
+  }
 }
 
 function mapDispatchToProps(dispatch: (action: Action & any) => void) {


### PR DESCRIPTION
I got some errors this morning that seemed to be due to a timing issue where the controls were being constructed before the config was loaded. It was really consistent at the time but later when I was testing with and without this fix, I couldn't reproduce anymore. Still, it seems like it's possible for there to be no selectedConfig so we should handle it.

I tried using the delete config button to see what happened in that case but it doesn't seem to delete anything? Maybe because I'm not using the real backend. But it looks like the selectedConfig reducer should probably be handling the delete config action, because what if the deleted config is the selected one?