### PR TITLE
fix: delete config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@spinnaker/amazon": "0.0.5",
-    "@spinnaker/core": "^0.0.31",
+    "@spinnaker/core": "^0.0.39",
     "@spinnaker/google": "^0.0.1",
     "@uirouter/angularjs": "^1.0.4",
     "@uirouter/react-hybrid": "^0.0.5",
@@ -72,6 +72,7 @@
     "react-ga": "^2.1.2",
     "react-redux": "^5.0.5",
     "react-select": "^1.0.0-rc.4",
+    "react-virtualized-select": "3.1.0",
     "react2angular": "1.1.2",
     "redux": "^3.7.1",
     "redux-observable": "^0.14.1",

--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -7,6 +7,8 @@ import {
 
 import { getCanaryConfigSummaries } from './service/canaryConfig.service';
 import { ICanaryConfigSummary } from './domain/index';
+import { canaryStore } from './canary';
+import { UPDATE_CONFIG_SUMMARIES } from './actions/index';
 
 export const CANARY_DATA_SOURCE = 'spinnaker.kayenta.canary.dataSource';
 module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
@@ -17,11 +19,19 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
       return $q.resolve(summaries);
     };
 
+    const afterLoad = (application: Application) => {
+      canaryStore.dispatch({
+        type: UPDATE_CONFIG_SUMMARIES,
+        configSummaries: application.getDataSource('canaryConfigs').data,
+      });
+    };
+
     applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
       optional: true,
       primary: true,
       loader: loadCanaryConfigs,
       onLoad: configsLoaded,
+      afterLoad: afterLoad,
       description: 'Canary analysis configuration and reporting',
       key: 'canaryConfigs',
       sref: '.canary',

--- a/src/kayenta/canary.tsx
+++ b/src/kayenta/canary.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { createStore, applyMiddleware } from 'redux';
-import { Provider, Store } from 'react-redux';
 
 import { Application } from '@spinnaker/core';
 
+import { Provider, Store } from 'react-redux';
 import { ICanaryState, rootReducer } from './reducers';
 import { epicMiddleware } from './epics';
 import CanaryConfigEdit from './edit/edit';
 import { ICanaryConfig, ICanaryConfigSummary, ICanaryMetricConfig } from './domain/index';
 import { ConfigDetailLoadState } from './edit/configDetailLoader';
-import { INITIALIZE, UPDATE_CONFIG_SUMMARIES } from './actions/index';
+import { INITIALIZE } from './actions/index';
 import { SaveConfigState } from './edit/save';
 import { DeleteConfigState } from './edit/deleteModal';
 
@@ -17,19 +17,22 @@ export interface ICanaryProps {
   app: Application;
 }
 
+export const canaryStore = createStore<ICanaryState>(
+  rootReducer,
+  applyMiddleware(epicMiddleware)
+);
+
 export default class Canary extends React.Component<ICanaryProps, {}> {
 
   private store: Store<ICanaryState>;
 
   constructor(props: ICanaryProps) {
     super();
-    this.store = createStore<ICanaryState>(
-      rootReducer,
-      applyMiddleware(epicMiddleware)
-    );
+    this.store = canaryStore;
     this.store.dispatch({
       type: INITIALIZE,
       state: {
+        application: props.app,
         configSummaries: [] as ICanaryConfigSummary[],
         selectedConfig: null as ICanaryConfig,
         configLoadState: ConfigDetailLoadState.Loading,
@@ -37,14 +40,6 @@ export default class Canary extends React.Component<ICanaryProps, {}> {
         saveConfigState: SaveConfigState.Saved,
         deleteConfigState: DeleteConfigState.Completed,
       }
-    });
-
-    props.app.getDataSource('canaryConfigs').ready().then(() => {
-      const summaries: ICanaryConfigSummary[] = props.app.getDataSource('canaryConfigs').data;
-      this.store.dispatch({
-        type: UPDATE_CONFIG_SUMMARIES,
-        configSummaries: summaries,
-      });
     });
   }
 

--- a/src/kayenta/reducers/index.ts
+++ b/src/kayenta/reducers/index.ts
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
-
 import { combineReducers, Action } from 'redux';
+import { Application } from '@spinnaker/core';
 import { ICanaryConfig, ICanaryMetricConfig } from '../domain/ICanaryConfig';
 import { ICanaryConfigSummary } from '../domain/ICanaryConfigSummary';
 import { ConfigDetailLoadState } from '../edit/configDetailLoader';
@@ -17,6 +17,7 @@ import { SaveConfigState } from '../edit/save';
 import { DeleteConfigState } from '../edit/deleteModal';
 
 export interface ICanaryState {
+  application: Application;
   configSummaries: ICanaryConfigSummary[];
   selectedConfig: ICanaryConfig;
   configLoadState: ConfigDetailLoadState;
@@ -28,6 +29,16 @@ export interface ICanaryState {
   deleteConfigModalOpen: boolean;
   deleteConfigState: DeleteConfigState,
   deleteConfigErrorMessage: string;
+}
+
+function application(state: Application = null, action: Action & any): Application {
+  switch (action.type) {
+    case INITIALIZE:
+      return action.state.application;
+
+    default:
+      return state;
+  }
 }
 
 function configSummaries(state: ICanaryConfigSummary[] = [], action: Action & any): ICanaryConfigSummary[] {
@@ -56,6 +67,9 @@ function selectedConfig(state: ICanaryConfig = null, action: Action & any): ICan
 
     case UPDATE_CONFIG_DESCRIPTION:
       return Object.assign({}, state, { description: action.description });
+
+    case DELETE_CONFIG_COMPLETED:
+      return null;
 
     default:
       return state;
@@ -244,6 +258,7 @@ function selectedGroup(state: string = null, action: Action & any): string {
 }
 
 export const rootReducer = combineReducers<ICanaryState>({
+  application,
   configSummaries,
   selectedConfig,
   configLoadState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@spinnaker/amazon/-/amazon-0.0.5.tgz#0121bf83ef28e68ee938ccae5e66c996420a675d"
 
-"@spinnaker/core@^0.0.31":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.31.tgz#98783af7946828633a643605f1b24435b21b6398"
+"@spinnaker/core@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.39.tgz#aa5e1df08e8f524da4451ecb71f74b5bf210e3f1"
 
 "@spinnaker/google@^0.0.1":
   version "0.0.1"
@@ -1471,7 +1471,7 @@ class-autobind-decorator@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/class-autobind-decorator/-/class-autobind-decorator-2.2.1.tgz#4d2534e55490db7321988f9ae8f25d253ad34557"
 
-classnames@^2.2.4, classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2113,7 +2113,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0:
+"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
@@ -3942,7 +3942,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5068,7 +5068,7 @@ react-redux@^5.0.5:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
-react-select@^1.0.0-rc.4:
+react-select@^1.0.0-rc.2, react-select@^1.0.0-rc.4:
   version "1.0.0-rc.4"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.0.0-rc.4.tgz#f28f3bab18196ff8f32337bb52ed015773c90663"
   dependencies:
@@ -5083,6 +5083,25 @@ react-test-renderer@^15.5.4:
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
+
+react-virtualized-select@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-virtualized-select/-/react-virtualized-select-3.1.0.tgz#968e89c4d74d98890cacf480378b6abee743c2d8"
+  dependencies:
+    babel-runtime "^6.11.6"
+    prop-types "^15.5.8"
+    react-select "^1.0.0-rc.2"
+    react-virtualized "^9.0.0"
+
+react-virtualized@^9.0.0:
+  version "9.9.0"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.9.0.tgz#799a6f23819eeb82860d59b82fad33d1d420325e"
+  dependencies:
+    babel-runtime "^6.11.6"
+    classnames "^2.2.3"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    loose-envify "^1.3.0"
+    prop-types "^15.5.4"
 
 react2angular@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
When you click the delete button, the app should now:
- route up to the config list state (i.e., away from the detail view)
- if there's a real kayenta running, the deleted config's name should be missing from the config list.

Also properly ties the config list into deck/core's refresh cycle.