### PR TITLE
fix: revert deck/core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "dependencies": {
     "@spinnaker/amazon": "0.0.5",
-    "@spinnaker/core": "^0.0.39",
+    "@spinnaker/core": "0.0.33",
     "@spinnaker/google": "^0.0.1",
     "@uirouter/angularjs": "^1.0.4",
-    "@uirouter/react-hybrid": "^0.0.5",
+    "@uirouter/react-hybrid": "0.0.5",
     "@uirouter/visualizer": "^4.0.0",
     "Select2": "git://github.com/select2/select2.git#3.4.8",
     "angular": "~1.6.3",

--- a/src/kayenta/canary.tsx
+++ b/src/kayenta/canary.tsx
@@ -33,7 +33,7 @@ export default class Canary extends React.Component<ICanaryProps, {}> {
       type: INITIALIZE,
       state: {
         application: props.app,
-        configSummaries: [] as ICanaryConfigSummary[],
+        configSummaries: props.app.getDataSource('canaryConfigs').data as ICanaryConfigSummary[],
         selectedConfig: null as ICanaryConfig,
         configLoadState: ConfigDetailLoadState.Loading,
         metricList: [] as ICanaryMetricConfig[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@spinnaker/amazon/-/amazon-0.0.5.tgz#0121bf83ef28e68ee938ccae5e66c996420a675d"
 
-"@spinnaker/core@^0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.39.tgz#aa5e1df08e8f524da4451ecb71f74b5bf210e3f1"
+"@spinnaker/core@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.33.tgz#01367d4514cd3daacd835c0877c6b497d3ab17a9"
 
 "@spinnaker/google@^0.0.1":
   version "0.0.1"
@@ -368,7 +368,7 @@
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.5.tgz#4fafae8b89e1bee321b0ed32e69ab66547c055c6"
 
-"@uirouter/react-hybrid@^0.0.5":
+"@uirouter/react-hybrid@0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@uirouter/react-hybrid/-/react-hybrid-0.0.5.tgz#4c325e0076e5cc5c837cfd664403b6c6f4149968"
   dependencies:


### PR DESCRIPTION
Fixes issue where the main tabs (e.g., pipelines, clusters, etc.) weren't loading.

Not a great situation, and needs be resolved soon:
- `spinnaker/core` after 0.0.33 depends on a recent version of `uirouter/react-hybrid`.
- That version of `uirouter/react-hybrid` doesn't work with `react-redux`.
