### PR TITLE
fix: route properly if config does not exist in local cache

### DIFF
--- a/src/kayenta/service/localConfigCache.service.ts
+++ b/src/kayenta/service/localConfigCache.service.ts
@@ -18,7 +18,12 @@ class LocalConfigCache {
   }
 
   public getCanaryConfigById(id: string): Promise<ICanaryConfig> {
-    return Promise.resolve(Array.from(this.configs).find(c => c.name === id));
+    const config = Array.from(this.configs).find(c => c.name === id);
+    if (config) {
+      return Promise.resolve(config);
+    } else {
+      return Promise.reject({ data: { message: 'Config not found.' }});
+    }
   }
 
   public getCanaryConfigSummaries(): Promise<ICanaryConfigSummary[]> {


### PR DESCRIPTION
Fixes issue where loading `.../canary/nonExistentConfig` broke the app when using the local config cache.