### PR TITLE
feat: add score thresholds component with graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "dependencies": {
     "@spinnaker/amazon": "0.0.5",
-    "@spinnaker/core": "0.0.46",
+    "@spinnaker/core": "0.0.52",
     "@spinnaker/google": "^0.0.1",
     "@uirouter/angularjs": "^1.0.4",
-    "@uirouter/react-hybrid": "0.0.12",
+    "@uirouter/react-hybrid": "^0.0.12",
     "@uirouter/visualizer": "^4.0.0",
     "Select2": "git://github.com/select2/select2.git#3.4.8",
     "angular": "~1.6.3",

--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -23,6 +23,11 @@ const helpContents: {[key: string]: string} = {
   'pipeline.config.canary.owner': '<p>The recipient email to which the canary report(s) will be sent.</p>',
   'pipeline.config.canary.watchers': '<p>Comma separated list of additional emails to receive canary reports.  Owners are automatically subscribed to notification emails.</p>',
   'pipeline.config.canary.useGlobalDataset': '<p>Uses the global atlas dataset instead of the region specific dataset for ACA</p>',
+  'pipeline.config.canary.marginalScore': `
+        <p>A canary stage can include multiple canary runs.</p>
+        <p>If a given canary run score is less than or equal to the marginal threshold, the canary stage will fail immediately.</p>
+        <p>If the canary run score is greater than the marginal threshold, the canary stage will not fail and will execute the remaining downstream canary runs.</p>`,
+  'pipeline.config.canary.passingScore': '<p>When all canary runs in a stage have executed, a canary stage is considered a success if the final (that is, the latest) canary run score is greater than or equal to the pass threshold. Otherwise, it is a failure.</p>',
 };
 
 export const CANARY_HELP = 'spinnaker.kayenta.help.contents';

--- a/src/kayenta/domain/ICanaryConfig.ts
+++ b/src/kayenta/domain/ICanaryConfig.ts
@@ -44,6 +44,6 @@ export interface ICanaryClassifierConfig {
 }
 
 export interface ICanaryClassifierThresholdsConfig {
-  pass: number;
-  marginal: number;
+  pass: string;
+  marginal: string;
 }

--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -21,7 +21,7 @@ function ConfigDetailHeader({ selectedConfig }: IConfigDetailStateProps) {
         <h2>{selectedConfig ? selectedConfig.name : ''}</h2>
       </div>
       <div className="col-sm-3">
-        <strong>Edited</strong> <FormattedDate dateIso={selectedConfig.updatedTimestampIso}/>
+        <strong>Edited:</strong> <FormattedDate dateIso={selectedConfig ? selectedConfig.updatedTimestampIso : ''}/>
       </div>
       <div className="col-sm-3">
         <ConfigDetailActionButtons/>

--- a/src/kayenta/edit/copyConfigButton.tsx
+++ b/src/kayenta/edit/copyConfigButton.tsx
@@ -33,6 +33,9 @@ function mapStateToProps(state: ICanaryState) {
 
 function buildConfigCopy(state: ICanaryState): ICanaryConfig {
   const config = mapStateToConfig(state);
+  if (!config) {
+    return null;
+  }
 
   // Probably a rare case, but someone could be lazy about naming their configs.
   let configName = `${config.name}-copy`, i = 1;

--- a/src/kayenta/service/canaryConfig.service.ts
+++ b/src/kayenta/service/canaryConfig.service.ts
@@ -95,8 +95,8 @@ export function buildNewConfig(state: ICanaryState): ICanaryConfig {
     classifier: {
       groupWeights: {} as {[key: string]: number},
       scoreThresholds: {
-        pass: 75,
-        marginal: 50,
+        pass: '75',
+        marginal: '50',
       }
     }
   };

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -17,36 +17,6 @@
     </select>
   </stage-config-field>
 
-  <div class="form-group">
-    <div ng-if="kayentaCanaryStageCtrl.state.detailsLoading" class="col-md-3 col-md-offset-3">
-      <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
-    </div>
-    <div ng-if="!kayentaCanaryStageCtrl.state.detailsLoading">
-      <div class="col-md-2 col-md-offset-1 sm-label-right">
-        <label>Passing Score</label>
-      </div>
-      <div class="col-md-1">
-        <input type="number"
-               max="100"
-               min="{{kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.marginal}}"
-               style="width: 60px;"
-               ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.pass"
-               class="form-control input-sm"/>
-      </div>
-      <div class="col-md-2 col-md-offset-1 sm-label-right">
-        <label>Marginal Score</label>
-      </div>
-      <div class="col-md-2">
-        <input type="number"
-               max="{{kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.pass}}"
-               min="0"
-               style="width: 60px;"
-               ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.marginal"
-               class="form-control input-sm"/>
-      </div>
-    </div>
-  </div>
-
   <h5>Analysis Config</h5>
   <div class="horizontal-rule"></div>
 
@@ -137,4 +107,22 @@
       required
       type="text"/>
   </stage-config-field>
+
+  <h5>Scoring Thresholds</h5>
+  <div class="horizontal-rule"></div>
+
+  <div class="form-group">
+    <div ng-if="kayentaCanaryStageCtrl.state.detailsLoading" class="col-md-3 col-md-offset-4">
+      <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
+    </div>
+
+    <kayenta-canary-scores ng-if="!kayentaCanaryStageCtrl.state.detailsLoading"
+                           on-change="kayentaCanaryStageCtrl.handleScoreThresholdChange"
+                           successful-help-field-id="'pipeline.config.canary.passingScore'"
+                           successful-label="'Pass'"
+                           successful-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.pass"
+                           unhealthy-help-field-id="'pipeline.config.canary.marginalScore'"
+                           unhealthy-label="'Marginal'"
+                           unhealthy-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.marginal"></kayenta-canary-scores>
+  </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@spinnaker/amazon/-/amazon-0.0.5.tgz#0121bf83ef28e68ee938ccae5e66c996420a675d"
 
-"@spinnaker/core@0.0.46":
-  version "0.0.46"
-  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.46.tgz#401977eb7816ead05ffabadc717dce34af941f56"
+"@spinnaker/core@0.0.52":
+  version "0.0.52"
+  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.52.tgz#4f6c134b746d20c9190008bb7ad2571170413c59"
 
 "@spinnaker/google@^0.0.1":
   version "0.0.1"
@@ -368,7 +368,7 @@
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.5.tgz#4fafae8b89e1bee321b0ed32e69ab66547c055c6"
 
-"@uirouter/react-hybrid@0.0.12":
+"@uirouter/react-hybrid@^0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@uirouter/react-hybrid/-/react-hybrid-0.0.12.tgz#c090c3415a551b28a17dbc4b44d6ef38f9f038bf"
   dependencies:


### PR DESCRIPTION
Adds deck/core's score thresholds component to the stage config.

<img width="713" alt="screen shot 2017-08-17 at 10 23 33 am" src="https://user-images.githubusercontent.com/13868700/29417142-2fa50b14-8336-11e7-9358-323549c56e22.png">


