### PR TITLE
feat: group weight configuration

### DIFF
--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -31,3 +31,4 @@ export const UPDATE_STACKDRIVER_METRIC_TYPE = 'update_stackdriver_metric_query';
 export const UPDATE_JUDGES = 'update_judges';
 export const SELECT_JUDGE = 'select_judge';
 export const UPDATE_SCORE_THRESHOLDS = 'update_score_thresholds';
+export const UPDATE_GROUP_WEIGHT = 'update_group_weight';

--- a/src/kayenta/canary.tsx
+++ b/src/kayenta/canary.tsx
@@ -46,8 +46,9 @@ export default class Canary extends React.Component<ICanaryProps, {}> {
             pass: null,
           },
           group: {
-            selected: null,
+            selected: '',
             list: [] as string[],
+            groupWeights: {},
           },
           load: {
             state: null,

--- a/src/kayenta/edit/configDetail.tsx
+++ b/src/kayenta/edit/configDetail.tsx
@@ -6,6 +6,7 @@ import MetricList from './metricList';
 import EditMetricModal from './editMetricModal';
 import NameAndDescription from './nameAndDescription'
 import TitledSection from '../layout/titledSection';
+import GroupWeights from './groupWeights';
 
 /*
  * Top-level config detail layout
@@ -21,6 +22,9 @@ export default function ConfigDetail() {
         <GroupTabs/>
         <MetricList/>
         <EditMetricModal/>
+      </TitledSection>
+      <TitledSection title="Group Weights">
+        <GroupWeights/>
       </TitledSection>
     </section>
   );

--- a/src/kayenta/edit/groupWeight.tsx
+++ b/src/kayenta/edit/groupWeight.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Action } from 'redux';
+import { get, isNumber } from 'lodash';
+
+import FormRow from '../layout/formRow';
+import { ICanaryState } from '../reducers/index';
+import { ICanaryConfig } from '../domain/ICanaryConfig';
+import { UPDATE_GROUP_WEIGHT } from '../actions/index';
+import { mapStateToConfig } from '../service/canaryConfig.service';
+
+interface IGroupWeightOwnProps {
+  group: string;
+}
+
+interface IGroupWeightStateProps {
+  config: ICanaryConfig;
+}
+
+interface IGroupWeightDispatchProps {
+  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+/*
+* Component for configuring a group weight.
+* */
+function GroupWeight({ group, config, handleInputChange }: IGroupWeightOwnProps & IGroupWeightStateProps & IGroupWeightDispatchProps) {
+  const groupWeight = getGroupWeights(config)[group] || 0;
+  return (
+    <FormRow label={group}>
+      <input
+        type="number"
+        className="input-sm form-control"
+        value={isNumber(groupWeight) ? groupWeight : ''}
+        onChange={handleInputChange}
+      />
+    </FormRow>
+  );
+}
+
+function getGroupWeights(config: ICanaryConfig): {[key: string]: number} {
+  return get(config, 'classifier.groupWeights', {});
+}
+
+function mapStateToProps(state: ICanaryState, ownProps: IGroupWeightOwnProps): IGroupWeightOwnProps & IGroupWeightStateProps {
+  return {
+    ...ownProps,
+    config: mapStateToConfig(state),
+  };
+}
+
+function mapDispatchToProps(dispatch: (action: Action & any) => void, { group }: IGroupWeightOwnProps): IGroupWeightDispatchProps {
+  return {
+    handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch({
+        type: UPDATE_GROUP_WEIGHT,
+        group,
+        weight: event.target.value ? parseInt(event.target.value, 10) : null,
+      });
+    }
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(GroupWeight);

--- a/src/kayenta/edit/groupWeights.tsx
+++ b/src/kayenta/edit/groupWeights.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { flatMap, uniq } from 'lodash';
+
+import GroupWeight from './groupWeight';
+import { ICanaryState } from '../reducers/index';
+import { mapStateToConfig } from '../service/canaryConfig.service';
+import FormList from '../layout/formList';
+
+interface IGroupWeightsStateProps {
+  groups: string[];
+}
+
+/*
+* Component for rendering list of group weight configurers.
+*/
+function GroupWeights({ groups }: IGroupWeightsStateProps) {
+  const hasGroups = groups.length > 0;
+  return (
+    <section>
+      <FormList>
+        {hasGroups
+          ? groups.map(group => <GroupWeight key={group} group={group}/>)
+          : [<p>You have not configured any grouped metrics.</p>]
+        }
+      </FormList>
+    </section>
+  );
+}
+
+function mapStateToProps(state: ICanaryState): IGroupWeightsStateProps {
+  const config = mapStateToConfig(state);
+  const metrics = config ? config.metrics : [] ;
+  const groups = uniq(flatMap(metrics, metric => metric.groups || []));
+  return {
+    groups,
+  };
+}
+
+export default connect(mapStateToProps)(GroupWeights);

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -10,6 +10,7 @@ import {
   UPDATE_CONFIG_DESCRIPTION,
   UPDATE_CONFIG_NAME
 } from '../actions/index';
+import FormList from '../layout/formList';
 
 interface INameAndDescriptionDispatchProps {
   changeName: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -26,7 +27,7 @@ interface INameAndDescriptionStateProps {
  */
 function NameAndDescription({ name, description, changeName, changeDescription }: INameAndDescriptionDispatchProps & INameAndDescriptionStateProps) {
   return (
-    <form role="form" className="form-horizontal container-fluid">
+    <FormList>
       <FormRow label="Configuration Name">
         <input
           type="text"
@@ -47,7 +48,7 @@ function NameAndDescription({ name, description, changeName, changeDescription }
         <JudgeSelect/>
       </FormRow>
       <ScoreThresholds/>
-    </form>
+    </FormList>
   );
 }
 

--- a/src/kayenta/layout/formList.tsx
+++ b/src/kayenta/layout/formList.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+export interface IFormListProps {
+  children: JSX.Element[];
+}
+
+/*
+* Mostly exists to centralize styles for form components.
+* */
+export default function FormList({ children }: IFormListProps) {
+  return (
+    <ul className="list-group">
+      {children.map((c, i) =>
+        <li key={i} className="list-group-item">
+          <form role="form" className="form-horizontal container-fluid">
+            <div className="col-md-11">{c}</div>
+          </form>
+        </li>
+      )}
+    </ul>
+  );
+}

--- a/src/kayenta/reducers/group.ts
+++ b/src/kayenta/reducers/group.ts
@@ -1,0 +1,78 @@
+import { Action, combineReducers } from 'redux';
+import { get } from 'lodash';
+
+import * as Actions from '../actions';
+import { ICanaryMetricConfig } from '../domain/ICanaryConfig';
+
+export interface IGroupState {
+  list: string[];
+  selected: string;
+  groupWeights: {[group: string]: number};
+}
+
+function list(state: string[] = [], action: Action & any): string[] {
+  function groupsFromMetrics(metrics: ICanaryMetricConfig[] = []) {
+    return metrics.reduce((groups, metric) => {
+      return groups.concat(metric.groups.filter((group: string) => !groups.includes(group)))
+    }, []).sort();
+  }
+
+  switch (action.type) {
+    case Actions.INITIALIZE:
+      return groupsFromMetrics(action.state.selectedConfig.metricList);
+
+    case Actions.SELECT_CONFIG:
+      return groupsFromMetrics(action.config.metrics);
+
+    case Actions.ADD_METRIC:
+      const groups = action.metric.groups;
+      return state.concat(groups.filter((group: string) => !state.includes(group)));
+
+    case Actions.ADD_GROUP:
+      let n = 1;
+      let name = null;
+      do {
+        name = 'Group ' + n;
+        n++;
+      } while (state.includes(name));
+      return state.concat([name]);
+
+    default:
+      return state;
+  }
+}
+
+function selected(state: string = null, action: Action & any): string {
+  switch (action.type) {
+    case Actions.INITIALIZE:
+      return action.state.selectedConfig.group.selected;
+
+    case Actions.SELECT_GROUP:
+      return action.name;
+
+    default:
+      return state;
+  }
+}
+
+function groupWeights(state: {[group: string]: number} = {}, action: Action & any): {[group: string]: number} {
+  switch (action.type) {
+    case Actions.INITIALIZE:
+      return action.state.selectedConfig.group.groupWeights;
+
+    case Actions.SELECT_CONFIG:
+      return get(action, 'config.classifier.groupWeights', {});
+
+    case Actions.UPDATE_GROUP_WEIGHT:
+      return { ...state, [action.group]: action.weight };
+
+    default:
+      return state;
+  }
+}
+
+export const group = combineReducers<IGroupState>({
+  list,
+  selected,
+  groupWeights,
+});

--- a/src/kayenta/reducers/selectedConfig.ts
+++ b/src/kayenta/reducers/selectedConfig.ts
@@ -11,6 +11,7 @@ import {
   ICanaryMetricConfig
 } from '../domain/ICanaryConfig';
 import { CanarySettings } from '../canary.settings';
+import { IGroupState, group } from './group';
 
 export interface ISelectedConfigState {
   config: ICanaryConfig;
@@ -158,51 +159,6 @@ function destroy(state: IDestroyState = { state: DeleteConfigState.Completed, er
 
     case Actions.DELETE_CONFIG_FAILURE:
       return makeDestroyState(DeleteConfigState.Error, get(action, 'error.data.message', null));
-
-    default:
-      return state;
-  }
-}
-
-interface IGroupState {
-  list: string[];
-  selected: string;
-}
-
-function makeGroupState(list: string[], selected: string = null): IGroupState {
-  return { list, selected };
-}
-
-function group(state: IGroupState = { selected: null, list: [] }, action: Action & any): IGroupState {
-  function groupsFromMetrics(metrics: ICanaryMetricConfig[] = []) {
-    return metrics.reduce((groups, metric) => {
-      return groups.concat(metric.groups.filter((group: string) => !groups.includes(group)))
-    }, []).sort();
-  }
-
-  switch (action.type) {
-    case Actions.INITIALIZE:
-      return makeGroupState(groupsFromMetrics(action.state.selectedConfig.metricList), action.state.selectedConfig.group.selected);
-
-    case Actions.SELECT_GROUP:
-      return makeGroupState(state.list, action.name);
-
-    case Actions.SELECT_CONFIG:
-      return makeGroupState(groupsFromMetrics(action.config.metrics), state.selected);
-
-    case Actions.ADD_METRIC: {
-      const groups = action.metric.groups;
-      return makeGroupState(state.list.concat(groups.filter((group: string) => !state.list.includes(group))), state.selected);
-    }
-
-    case Actions.ADD_GROUP:
-      let n = 1;
-      let name = null;
-      do {
-        name = 'Group ' + n;
-        n++;
-      } while (state.list.includes(name));
-      return makeGroupState(state.list.concat([name]), state.selected);
 
     default:
       return state;

--- a/src/kayenta/service/canaryConfig.service.ts
+++ b/src/kayenta/service/canaryConfig.service.ts
@@ -77,6 +77,7 @@ export function mapStateToConfig(state: ICanaryState): ICanaryConfig {
         metrics: configState.metricList.map((metric, i) => i === 0 ? firstMetric : metric),
         classifier: Object.assign({}, configState.config.classifier || {}, {
           scoreThresholds: configState.thresholds,
+          groupWeights: configState.group.groupWeights,
         }),
       }
     );


### PR DESCRIPTION
@svachalek wanted to get your opinion on the UX before I think about this much more.

Can either use input fields or the sliders. The sliders don't move to the right if you don't have any weight to allocate.
![group_weights_1](https://user-images.githubusercontent.com/13868700/29369274-24144538-8270-11e7-8b61-dbb3cf486275.png)

If you do have weight to allocate, they do move to the right, and you get these little tick marks showing how far you can move them.
![group_weights_2](https://user-images.githubusercontent.com/13868700/29369303-3cae44fe-8270-11e7-8f87-06cbf28ca354.png)

