### PR TITLE
refactor: move canary score + canary scores components from deck/core

### DIFF
--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -1,0 +1,32 @@
+import { module } from 'angular';
+
+import { HELP_CONTENTS_REGISTRY, HelpContentsRegistry } from '@spinnaker/core';
+
+const helpContents: {[key: string]: string} = {
+  'pipeline.config.canary.clusterPairs': `
+        <p>A <em>cluster pair</em> is used to create a baseline and canary cluster.</p>' +
+        <p>The version currently deployed in the baseline cluster will be used to create a new baseline server group, while the version created in the previous bake or Find AMI stage will be deployed into the canary.</p>`,
+  'pipeline.config.canary.resultStrategy': `
+        <p>The result stategy is used to determine how to roll up a score if multiple clusters are participating in the canary.</p>
+        <p>The <em>lowest</em> strategy means that the cluster with the lowest score is used as the rolled up score</p>
+        <p>The <em>average</em> strategy takes the average of all the canary scores</p>`,
+  'pipeline.config.canary.delayBeforeAnalysis': '<p>The number of minutes until the first ACA measurement interval begins.</p>',
+  'pipeline.config.canary.notificationHours': '<p>Hours at which to send a notification (comma separated)</p>',
+  'pipeline.config.canary.canaryInterval': '<p>The frequency at which a canary score is generated.  The recommended interval is at least 30 minutes.</p>',
+  'pipeline.config.canary.successfulScore': '<p>The minimum score the canary must achieve to be considered successful.</p>',
+  'pipeline.config.canary.unhealthyScore': '<p>The lowest score the canary can attain before it is aborted and disabled as a failure.</p>',
+  'pipeline.config.canary.scaleUpCapacity': '<p>The number of instances to which to scale the canary and control clusters.</p>',
+  'pipeline.config.canary.scaleUpDelay': '<p>The number of minutes to wait before scaling up the canary.</p>',
+  'pipeline.config.canary.baselineVersion': '<p>The Canary stage will inspect the specified cluster to determine which version to deploy as the baseline in each cluster pair.</p>',
+  'pipeline.config.canary.lookback': '<p>With an analysis type of <strong>Growing</strong>, ACA will look at the entire duration of the canary for its analysis.</p><p>When choosing <strong>Sliding Lookback</strong>, the canary will use the most recent number of specified minutes for its analysis report (<b>useful for long running canaries that span multiple days</b>).</p>',
+  'pipeline.config.canary.continueOnUnhealthy': '<p>Continue the pipeline if the ACA comes back as <b>UNHEALTHY</b></p>',
+  'pipeline.config.canary.owner': '<p>The recipient email to which the canary report(s) will be sent.</p>',
+  'pipeline.config.canary.watchers': '<p>Comma separated list of additional emails to receive canary reports.  Owners are automatically subscribed to notification emails.</p>',
+  'pipeline.config.canary.useGlobalDataset': '<p>Uses the global atlas dataset instead of the region specific dataset for ACA</p>',
+};
+
+export const CANARY_HELP = 'spinnaker.kayenta.help.contents';
+module(CANARY_HELP, [HELP_CONTENTS_REGISTRY])
+  .run((helpContentsRegistry: HelpContentsRegistry) => {
+    Object.keys(helpContents).forEach(key => helpContentsRegistry.register(key, helpContents[key]));
+  });

--- a/src/kayenta/canary.module.ts
+++ b/src/kayenta/canary.module.ts
@@ -5,7 +5,9 @@ import {
   ApplicationDataSourceRegistry,
 } from '@spinnaker/core';
 
+import { CANARY_COMPONENTS } from 'kayenta/components/components.module';
 import { CANARY_DATA_SOURCE } from 'kayenta/canary.dataSource';
+import { CANARY_HELP } from 'kayenta/canary.help';
 import { CANARY_STAGES } from 'kayenta/stages/stages.module';
 import { CANARY_STATES } from 'kayenta/canary.states';
 import 'kayenta/metricStore/index';
@@ -19,7 +21,9 @@ templates.keys().forEach(function (key) {
 export const KAYENTA_MODULE = 'spinnaker.kayenta';
 module(KAYENTA_MODULE, [
   APPLICATION_DATA_SOURCE_REGISTRY,
+  CANARY_COMPONENTS,
   CANARY_DATA_SOURCE,
+  CANARY_HELP,
   CANARY_STAGES,
   CANARY_STATES,
 ]).run((applicationDataSourceRegistry: ApplicationDataSourceRegistry) => {

--- a/src/kayenta/components/canary.less
+++ b/src/kayenta/components/canary.less
@@ -1,0 +1,24 @@
+@import (reference) "~coreColors";
+
+div.canary-score {
+  div.progress {
+    border-radius: 0;
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    height: 10px;
+    margin: 20px 0 10px;
+  }
+  div.progress-bar {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+  }
+  div.progress-bar-danger {
+    background-color: @unhealthy_red;
+  }
+  div.progress-bar.progress-bar-warning {
+    background-color: @mid_light_grey;
+  }
+  div.progress-bar.progress-bar-success {
+    background-color: @healthy_green;
+  }
+}

--- a/src/kayenta/components/canaryScore.component.less
+++ b/src/kayenta/components/canaryScore.component.less
@@ -1,0 +1,54 @@
+@import (reference) "~coreImports";
+@import (reference) "~coreColors";
+
+.score.label {
+  font-size: 110%;
+  padding: 3px 6px;
+  display: inline-block;
+  height: 20px;
+  line-height: 14px;
+  &.label-failing {
+    background-color: @unhealthy_orange;
+    &.inverse {
+      color: @unhealthy_orange;
+    }
+  }
+  &.label-healthy {
+    background-color: @healthy_green_border;
+    &.inverse {
+      color: @healthy_green_border;
+    }
+  }
+  &.label-unhealthy {
+    background-color: @unhealthy_red;
+    &.inverse {
+      color: @unhealthy_red;
+    }
+  }
+  &.label-unknown {
+    background-color: @unknown-label-color;
+    &.inverse {
+      color: @unknown-label-color;
+    }
+  }
+  &.inverse {
+    background-color: transparent;
+    font-size: 100%;
+    padding: 0;
+  }
+}
+
+.score-large.score {
+  height: 48px;
+}
+
+.score-large .score.label {
+  height: 48px;
+  line-height: 48px;
+  padding: 0 10px 0 10px;
+  font-size: 200%;
+  border-radius: 0;
+  margin: 0 0 5px 10px;
+  min-width: 48px;
+  display: inline-block;
+}

--- a/src/kayenta/components/canaryScore.component.ts
+++ b/src/kayenta/components/canaryScore.component.ts
@@ -1,0 +1,8 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { CanaryScore } from './canaryScore';
+
+export const CANARY_SCORE_COMPONENT = 'spinnaker.kayenta.score.component';
+module(CANARY_SCORE_COMPONENT, [])
+  .component('kayentaCanaryScore', react2angular(CanaryScore, ['score', 'health', 'result', 'inverse']));

--- a/src/kayenta/components/canaryScore.tsx
+++ b/src/kayenta/components/canaryScore.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import './canaryScore.component.less';
+
+export interface ICanaryScoreProps {
+  score: number | string;
+  health?: string;
+  result: string;
+  inverse: boolean;
+}
+
+export interface ICanaryScoreState {
+  score: number | string;
+  healthLabel: string;
+}
+
+export class CanaryScore extends React.Component<ICanaryScoreProps, ICanaryScoreState> {
+  public static defaultProps: Partial<ICanaryScoreProps> = {
+    health: ''
+  };
+
+  constructor(props: ICanaryScoreProps) {
+    super(props);
+    this.state = this.getLabelState(props);
+  }
+
+  private getLabelState(props: ICanaryScoreProps): ICanaryScoreState {
+    const health = (props.health || '').toLowerCase();
+    const result = (props.result || '').toLowerCase();
+    const score = (props.score === 0 || (props.score && props.score > 0)) ? props.score : 'N/A';
+    const healthLabel = health === 'unhealthy' ? 'unhealthy'
+      : result === 'success' ? 'healthy'
+      : result === 'failure' ? 'failing'
+      : 'unknown';
+
+    return {
+      healthLabel: healthLabel,
+      score: score
+    };
+  }
+
+  public componentWillReceiveProps(props: ICanaryScoreProps) {
+    this.setState(this.getLabelState(props));
+  }
+
+  public render() {
+    const className = [
+      this.props.inverse ? 'inverse' : '',
+      'score',
+      'label',
+      'label-default',
+      `label-${this.state.healthLabel}`
+    ].join(' ');
+    return (
+      <span className={className}>{this.state.score}</span>
+    );
+  }
+}

--- a/src/kayenta/components/canaryScores.component.ts
+++ b/src/kayenta/components/canaryScores.component.ts
@@ -1,0 +1,8 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { CanaryScores } from './canaryScores';
+
+export const CANARY_SCORES_CONFIG_COMPONENT = 'spinnaker.kayenta.canaryScores.component';
+module(CANARY_SCORES_CONFIG_COMPONENT, [])
+  .component('kayentaCanaryScores', react2angular(CanaryScores, ['onChange', 'successfulHelpFieldId', 'successfulLabel', 'successfulScore', 'unhealthyHelpFieldId', 'unhealthyLabel', 'unhealthyScore']));

--- a/src/kayenta/components/canaryScores.tsx
+++ b/src/kayenta/components/canaryScores.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import { isString } from 'lodash';
+import autoBindMethods from 'class-autobind-decorator';
+
+import { HelpField } from '@spinnaker/core';
+
+export interface IScoreConfig {
+  successfulScore: string;
+  unhealthyScore: string;
+}
+
+export interface ICanaryScoresProps {
+  onChange: (scoreConfig: IScoreConfig) => void;
+  successfulHelpFieldId?: string;
+  successfulLabel?: string;
+  successfulScore: string;
+  unhealthyHelpFieldId?: string;
+  unhealthyLabel?: string;
+  unhealthyScore: string;
+}
+
+@autoBindMethods
+export class CanaryScores extends React.Component<ICanaryScoresProps> {
+
+  public render() {
+    const hasExpressions = this.isExpression(this.props.unhealthyScore) || this.isExpression(this.props.successfulScore);
+
+    let successful: number, unhealthy: number;
+    if (!hasExpressions) {
+      successful = parseInt(this.props.successfulScore, 10);
+      unhealthy = parseInt(this.props.unhealthyScore, 10);
+    }
+
+    const invalid = !(successful && unhealthy);
+
+    return (
+      <div>
+        {hasExpressions && (
+          <div className="form-group">
+            <div className="col-md-2 col-md-offset-1 sm-label-right">
+              <label>Canary Scores</label>
+            </div>
+            <div className="col-md-9 form-control-static">
+              Expressions are currently being used for canary scores.
+            </div>
+          </div>
+        )}
+        {!hasExpressions && (
+          <div className="canary-score">
+            <div className="form-group">
+              <div className="col-md-2 col-md-offset-1 sm-label-right">
+                <label>{this.props.unhealthyLabel || 'Unhealthy Score'}</label>
+                <HelpField id={this.props.unhealthyHelpFieldId || 'pipeline.config.canary.unhealthyScore'}/>
+              </div>
+              <div className="col-md-2">
+                <input
+                  type="number"
+                  required={true}
+                  value={Number.isNaN(unhealthy) ? '' : unhealthy}
+                  onChange={this.handleUnhealthyChange}
+                  className={`form-control input-sm ${this.isUnhealthyScoreValid(successful, unhealthy) ? '' : 'ng-invalid ng-invalid-validate-min'}`}
+                />
+              </div>
+              <div className="col-md-2 col-md-offset-1 sm-label-right">
+                <label>{this.props.successfulLabel || 'Successful Score'}</label>
+                <HelpField id={this.props.successfulHelpFieldId || 'pipeline.config.canary.successfulScore'}/>
+              </div>
+              <div className="col-md-2">
+                <input
+                  type="number"
+                  required={true}
+                  value={Number.isNaN(successful) ? '' : successful}
+                  onChange={this.handleSuccessfulChange}
+                  className={`form-control input-sm ${this.isSuccessfulScoreValid(successful, unhealthy) ? '' : 'ng-invalid ng-invalid-validate-max'}`}
+                />
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-md-offset-1 col-md-10">
+                <div className="progress">
+                  <div className="progress-bar progress-bar-danger" style={{width: `${invalid ? 0 : unhealthy}%`}}/>
+                  <div className="progress-bar progress-bar-warning" style={{width: `${invalid ? 0 : 100 - (unhealthy + (100 - successful))}%`}}/>
+                  <div className="progress-bar progress-bar-success" style={{width: `${invalid ? 0 : 100 - successful}%`}}/>
+                  <div className="progress-bar progress-bar-warning" style={{width: `${invalid ? 100 : 0}%`}}/>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  private handleSuccessfulChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    this.props.onChange({
+      successfulScore: event.target.value,
+      unhealthyScore: this.props.unhealthyScore,
+    });
+  }
+
+  private handleUnhealthyChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    this.props.onChange({
+      successfulScore: this.props.successfulScore,
+      unhealthyScore: event.target.value,
+    });
+  }
+
+  private isSuccessfulScoreValid(successfulScore: number, unhealthyScore: number): boolean {
+    return successfulScore && (!unhealthyScore || successfulScore > unhealthyScore) && successfulScore <= 100;
+  }
+
+  private isUnhealthyScoreValid(successfulScore: number, unhealthyScore: number): boolean {
+    return unhealthyScore && (!successfulScore || unhealthyScore < successfulScore) && unhealthyScore >= 0;
+  }
+
+  private isExpression(scoreValue: string): boolean {
+    return isString(scoreValue) && scoreValue.includes('${');
+  }
+}

--- a/src/kayenta/components/components.module.ts
+++ b/src/kayenta/components/components.module.ts
@@ -1,0 +1,12 @@
+import { module } from 'angular';
+
+import { CANARY_SCORE_COMPONENT } from './canaryScore.component';
+import { CANARY_SCORES_CONFIG_COMPONENT } from './canaryScores.component';
+
+import './canary.less';
+
+export const CANARY_COMPONENTS = 'spinnaker.kayenta.components.module';
+module(CANARY_COMPONENTS, [
+  CANARY_SCORE_COMPONENT,
+  CANARY_SCORES_CONFIG_COMPONENT,
+]);


### PR DESCRIPTION
Moving the relevant canary components from deck/core into here, since they're not exported in the `@spinnaker/core` package right now, they're a pain to move around, and they should probably end up here anyway.