### PR TITLE
chore: Render names of control and experiment resources when using ex…

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.controller.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.controller.ts
@@ -11,6 +11,8 @@ import { CANARY_RUN_SUMMARIES_COMPONENT } from './canaryRunSummaries.component';
 class KayentaStageExecutionDetailsController {
 
   public canaryRuns: IExecutionStage[];
+  public resolvedControl: string;
+  public resolvedExperiment: string;
 
   constructor(public $scope: IScope,
               private $stateParams: StateParams,
@@ -27,12 +29,18 @@ class KayentaStageExecutionDetailsController {
   private initialize(): void {
     this.executionDetailsSectionService.synchronizeSection(this.$scope.configSections, () => this.initialized());
     this.setCanaryRuns();
+    this.resolveControlAndExperimentNames();
   }
 
   private setCanaryRuns(): void {
     // The kayentaStageTransformer pushes related 'runCanary' and 'wait' stages
     // into the 'kayentaCanary' tasks list.
     this.canaryRuns = this.$scope.stage.tasks.filter((t: IExecutionStage) => t.type === RUN_CANARY);
+  }
+
+  private resolveControlAndExperimentNames(): void {
+    this.resolvedControl = this.canaryRuns.length ? this.canaryRuns[0].context.controlScope : this.$scope.stage.context.canaryConfig.controlScope;
+    this.resolvedExperiment = this.canaryRuns.length ? this.canaryRuns[0].context.experimentScope : this.$scope.stage.context.canaryConfig.experimentScope;
   }
 
   private initialized(): void {

--- a/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
@@ -29,11 +29,11 @@
         <div class="horizontal-rule"></div>
         <div class="row">
           <div class="col-md-4 sm-label-right compact">Baseline</div>
-          <div class="col-md-8" style="word-wrap: break-word">{{stage.context.canaryConfig.controlScope}}</div>
+          <div class="col-md-8" style="word-wrap: break-word">{{ kayentaStageDetailsCtrl.resolvedControl }}</div>
         </div>
         <div class="row">
           <div class="col-md-4 sm-label-right compact">Canary</div>
-          <div class="col-md-8" style="word-wrap: break-word">{{stage.context.canaryConfig.experimentScope}}</div>
+          <div class="col-md-8" style="word-wrap: break-word">{{ kayentaStageDetailsCtrl.resolvedExperiment }}</div>
         </div>
         <div class="row" ng-if="stage.context.canaryConfig.step">
           <div class="col-md-4 sm-label-right compact">Step</div>


### PR DESCRIPTION
…pressions.

With this change, the expression will still be rendered up until the first Run Canary task is initiated; then the server group names will be rendered. We could probably embed the same attributes in the Wait tasks and render the names earlier too.