### PR TITLE
refactor: use typed action creators

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -2,6 +2,9 @@ import { createAction } from 'redux-actions';
 
 import * as Actions from './index';
 import { ConfigJsonModalTabState } from '../edit/configJsonModal';
+import { ICanaryConfig } from '../domain/ICanaryConfig';
+import { ICanaryConfigSummary } from '../domain/ICanaryConfigSummary';
+import { IJudge } from '../domain/IJudge';
 
 const typedPayloadCreator = <T>() => (payload: T): T => payload;
 
@@ -15,6 +18,25 @@ export const editMetricConfirm = createAction(Actions.EDIT_METRIC_CONFIRM);
 export const addGroup = createAction(Actions.ADD_GROUP);
 export const saveConfig = createAction(Actions.SAVE_CONFIG_REQUEST);
 export const dismissSaveConfigError = createAction(Actions.DISMISS_SAVE_CONFIG_ERROR);
-export const setConfigJsonModalTabState = createAction(Actions.SET_CONFIG_JSON_MODAL_TAB_STATE, typedPayloadCreator<ConfigJsonModalTabState>());
-export const setConfigJson = createAction(Actions.SET_CONFIG_JSON, typedPayloadCreator<string>());
+export const setConfigJsonModalTabState = createAction(Actions.SET_CONFIG_JSON_MODAL_TAB_STATE, typedPayloadCreator<{state: ConfigJsonModalTabState}>());
+export const setConfigJson = createAction(Actions.SET_CONFIG_JSON, typedPayloadCreator<{json: string}>());
 export const deleteConfigSuccess = createAction(Actions.DELETE_CONFIG_SUCCESS);
+export const loadConfigRequest = createAction(Actions.LOAD_CONFIG_REQUEST, typedPayloadCreator<{configName: string}>());
+export const saveConfigSuccess = createAction(Actions.SAVE_CONFIG_SUCCESS, typedPayloadCreator<{configName: string}>());
+export const selectConfig = createAction(Actions.SELECT_CONFIG, typedPayloadCreator<{config: ICanaryConfig}>());
+export const renameMetric = createAction(Actions.RENAME_METRIC, typedPayloadCreator<{id: string, name: string}>());
+export const selectGroup = createAction(Actions.SELECT_GROUP, typedPayloadCreator<{name: string}>());
+export const updateGroupWeight = createAction(Actions.UPDATE_GROUP_WEIGHT, typedPayloadCreator<{group: string, weight: number}>());
+export const selectJudgeName = createAction(Actions.SELECT_JUDGE_NAME, typedPayloadCreator<{judge: {name: string}}>());
+export const editMetricBegin = createAction(Actions.EDIT_METRIC_BEGIN, typedPayloadCreator<{id: string}>());
+export const removeMetric = createAction(Actions.REMOVE_METRIC, typedPayloadCreator<{id: string}>());
+export const addMetric = createAction(Actions.ADD_METRIC, typedPayloadCreator<{metric: {name: string, serviceName: string, groups: string[]}}>());
+export const updateConfigName = createAction(Actions.UPDATE_CONFIG_NAME, typedPayloadCreator<{name: string}>());
+export const updateConfigDescription = createAction(Actions.UPDATE_CONFIG_DESCRIPTION, typedPayloadCreator<{description: string}>());
+export const updateScoreThresholds = createAction(Actions.UPDATE_SCORE_THRESHOLDS, typedPayloadCreator<{marginal: number, pass: number}>());
+export const saveConfigFailure = createAction(Actions.SAVE_CONFIG_FAILURE, typedPayloadCreator<{error: Error}>());
+export const deleteConfigFailure = createAction(Actions.DELETE_CONFIG_FAILURE, typedPayloadCreator<{error: Error}>());
+export const updateConfigSummaries = createAction(Actions.UPDATE_CONFIG_SUMMARIES, typedPayloadCreator<{configSummaries: ICanaryConfigSummary[]}>());
+export const updateJudges = createAction(Actions.UPDATE_JUDGES, typedPayloadCreator<{judges: IJudge[]}>());
+export const loadConfigSuccess = createAction(Actions.LOAD_CONFIG_SUCCESS, typedPayloadCreator<{config: ICanaryConfig}>());
+export const loadConfigFailure = createAction(Actions.LOAD_CONFIG_FAILURE, typedPayloadCreator<{error: Error}>());

--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -8,7 +8,7 @@ import {
 import { getCanaryConfigSummaries, listJudges } from './service/canaryConfig.service';
 import { ICanaryConfigSummary, IJudge } from './domain/index';
 import { canaryStore } from './canary';
-import { UPDATE_CONFIG_SUMMARIES, UPDATE_JUDGES } from './actions/index';
+import * as Creators from './actions/creators';
 
 export const CANARY_DATA_SOURCE = 'spinnaker.kayenta.canary.dataSource';
 module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
@@ -20,10 +20,9 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
     };
 
     const afterConfigsLoad = (application: Application) => {
-      canaryStore.dispatch({
-        type: UPDATE_CONFIG_SUMMARIES,
-        configSummaries: application.getDataSource('canaryConfigs').data,
-      });
+      canaryStore.dispatch(Creators.updateConfigSummaries({
+        configSummaries: application.getDataSource('canaryConfigs').data as ICanaryConfigSummary[],
+      }));
     };
 
     applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
@@ -48,10 +47,9 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
     };
 
     const afterJudgesLoad = (application: Application) => {
-      canaryStore.dispatch({
-        type: UPDATE_JUDGES,
-        judges: application.getDataSource('canaryJudges').data,
-      });
+      canaryStore.dispatch(Creators.updateJudges({
+        judges: application.getDataSource('canaryJudges').data as IJudge[],
+      }));
     };
 
     applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({

--- a/src/kayenta/edit/configDetailLoader.tsx
+++ b/src/kayenta/edit/configDetailLoader.tsx
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
 import ConfigDetailLoadStates from './configDetailLoadStates';
-import { LOAD_CONFIG_REQUEST } from '../actions/index';
+import * as Creators from '../actions/creators';
 
 interface IConfigLoaderStateParamsProps {
   configNameStream: Observable<IConfigDetailStateParams>;
@@ -50,10 +50,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IConfigLo
   return {
     loadConfig: (stateParams: IConfigDetailStateParams) => {
       if (stateParams.configName) {
-        dispatch({
-          type: LOAD_CONFIG_REQUEST,
-          id: stateParams.configName,
-        });
+        dispatch(Creators.loadConfigRequest({ configName: stateParams.configName }));
       }
     }
   };

--- a/src/kayenta/edit/configJsonModal.tsx
+++ b/src/kayenta/edit/configJsonModal.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Modal } from 'react-bootstrap';
 import { get } from 'lodash';
 
-import { SELECT_CONFIG } from '../actions/index';
 import * as Creators from 'kayenta/actions/creators';
 import { ICanaryState } from '../reducers/index';
 import { jsonUtilityService, NgReact, IJsonDiff } from '@spinnaker/core';
@@ -105,13 +104,10 @@ function ConfigJsonModal({ show, configJson, deserializationError, closeModal, s
 function mapDispatchToProps(dispatch: (action: Action & any) => void): IConfigJsonDispatchProps {
   return {
     closeModal: () => dispatch(Creators.closeConfigJsonModal()),
-    setTabState: (state: ConfigJsonModalTabState) => () => dispatch(Creators.setConfigJsonModalTabState(state)),
-    setConfigJson: (event: React.ChangeEvent<HTMLTextAreaElement>) => dispatch(Creators.setConfigJson(event.target.value)),
+    setTabState: (state: ConfigJsonModalTabState) => () => dispatch(Creators.setConfigJsonModalTabState({ state })),
+    setConfigJson: (event: React.ChangeEvent<HTMLTextAreaElement>) => dispatch(Creators.setConfigJson({ json: event.target.value })),
     updateConfig: (event: any) => {
-      dispatch({
-        type: SELECT_CONFIG,
-        config: JSON.parse(event.target.dataset.serialized),
-      });
+      dispatch(Creators.selectConfig({ config: JSON.parse(event.target.dataset.serialized) }));
     }
   };
 }

--- a/src/kayenta/edit/copyConfigButton.tsx
+++ b/src/kayenta/edit/copyConfigButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
-import { SELECT_CONFIG } from '../actions/index';
+import * as Creators from '../actions/creators';
 import { ICanaryState } from '../reducers/index';
 import { ICanaryConfig } from '../domain/ICanaryConfig';
 import { mapStateToConfig } from '../service/canaryConfig.service';
@@ -52,10 +52,7 @@ function buildConfigCopy(state: ICanaryState): ICanaryConfig {
 function mapDispatchToProps(dispatch: (action: Action & any) => void): ICopyConfigButtonDispatchProps {
   return {
     copyConfig: (event: any) => {
-      dispatch({
-        type: SELECT_CONFIG,
-        config: JSON.parse(event.target.dataset.config),
-      });
+      dispatch(Creators.selectConfig({ config: JSON.parse(event.target.dataset.config) }));
     },
   };
 }

--- a/src/kayenta/edit/createConfigButton.tsx
+++ b/src/kayenta/edit/createConfigButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
-import { SELECT_CONFIG } from '../actions/index';
+import * as Creators from '../actions/creators';
 import { buildNewConfig } from '../service/canaryConfig.service';
 import { ICanaryState } from '../reducers/index';
 
@@ -33,10 +33,7 @@ function mapStateToProps(state: ICanaryState): ICreateConfigButtonStateProps {
 function mapDispatchToProps(dispatch: (action: Action & any) => void): ICreateConfigButtonDispatchProps {
   return {
     createNewConfig: (event: any) => {
-      dispatch({
-        type: SELECT_CONFIG,
-        config: JSON.parse(event.target.dataset.config),
-      });
+      dispatch(Creators.selectConfig({ config: JSON.parse(event.target.dataset.config) }));
     }
   };
 }

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Modal } from 'react-bootstrap';
 
-import { RENAME_METRIC } from '../actions/index';
 import * as Creators from '../actions/creators';
 import {ICanaryState} from '../reducers/index';
 import {ICanaryMetricConfig} from 'kayenta/domain';
@@ -56,7 +55,7 @@ function EditMetricModal({ metric, rename, confirm, cancel }: IEditMetricModalDi
 function mapDispatchToProps(dispatch: any): IEditMetricModalDispatchProps {
   return {
     rename: (event: any) => {
-      dispatch({ type: RENAME_METRIC, id: event.target.dataset.id, name: event.target.value });
+      dispatch(Creators.renameMetric({ id: event.target.dataset.id, name: event.target.value }));
     },
     cancel: () => {
       dispatch(Creators.editMetricCancel());

--- a/src/kayenta/edit/groupTabs.tsx
+++ b/src/kayenta/edit/groupTabs.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
 import { ICanaryState } from '../reducers';
-import { SELECT_GROUP } from '../actions/index';
 import * as Creators from '../actions/creators';
 import { Tabs, Tab } from '../layout/tabs';
 
@@ -51,7 +50,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IGroupTab
   return {
     selectGroup: (event: any) => {
       const name = event.target.dataset.group;
-      dispatch({ type: SELECT_GROUP, name });
+      dispatch(Creators.selectGroup({ name }));
       event.preventDefault();
       event.stopPropagation();
     },

--- a/src/kayenta/edit/groupWeight.tsx
+++ b/src/kayenta/edit/groupWeight.tsx
@@ -6,7 +6,7 @@ import { get, isNumber } from 'lodash';
 import FormRow from '../layout/formRow';
 import { ICanaryState } from '../reducers/index';
 import { ICanaryConfig } from '../domain/ICanaryConfig';
-import { UPDATE_GROUP_WEIGHT } from '../actions/index';
+import * as Creators from '../actions/creators';
 import { mapStateToConfig } from '../service/canaryConfig.service';
 
 interface IGroupWeightOwnProps {
@@ -52,11 +52,10 @@ function mapStateToProps(state: ICanaryState, ownProps: IGroupWeightOwnProps): I
 function mapDispatchToProps(dispatch: (action: Action & any) => void, { group }: IGroupWeightOwnProps): IGroupWeightDispatchProps {
   return {
     handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => {
-      dispatch({
-        type: UPDATE_GROUP_WEIGHT,
+      dispatch(Creators.updateGroupWeight({
         group,
         weight: event.target.value ? parseInt(event.target.value, 10) : null,
-      });
+      }));
     }
   };
 }

--- a/src/kayenta/edit/judgeSelect.tsx
+++ b/src/kayenta/edit/judgeSelect.tsx
@@ -4,7 +4,7 @@ import { Action } from 'redux';
 import { connect } from 'react-redux';
 
 import { ICanaryState } from '../reducers/index';
-import { SELECT_JUDGE_NAME } from '../actions/index';
+import * as Creators from '../actions/creators';
 import FormRow from '../layout/formRow';
 
 interface IJudgeSelectStateProps {
@@ -66,10 +66,7 @@ function mapStateToProps(state: ICanaryState): IJudgeSelectStateProps {
 function mapDispatchToProps(dispatch: (action: Action & any) => void): IJudgeSelectDispatchProps {
   return {
     handleJudgeSelect: (option: Select.Option) => {
-      dispatch({
-        type: SELECT_JUDGE_NAME,
-        judge: { name: option.value },
-      });
+      dispatch(Creators.selectJudgeName({ judge: { name: option.value as string } }));
     }
   };
 }

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -5,7 +5,7 @@ import { ICanaryMetricConfig } from '../domain/ICanaryConfig';
 import { ICanaryState } from '../reducers';
 import { UNGROUPED } from './groupTabs';
 import MetricDetail from './metricDetail';
-import { ADD_METRIC, EDIT_METRIC_BEGIN, REMOVE_METRIC } from '../actions/index';
+import * as Creators from '../actions/creators';
 import { CanarySettings } from 'kayenta/canary.settings';
 
 interface IMetricListStateProps {
@@ -65,8 +65,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
   return {
     addMetric: (event: any) => {
       const group = event.target.dataset.group;
-      dispatch({
-        type: ADD_METRIC,
+      dispatch(Creators.addMetric({
         metric: {
           // TODO: need to block saving an invalid name
           // TODO: for Atlas metrics, attempt to gather name when query changes
@@ -74,21 +73,15 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
           serviceName: CanarySettings.metricStore,
           groups: (group && group !== UNGROUPED) ? [group] : []
         }
-      })
+      }));
     },
 
     editMetric: (event: any) => {
-      dispatch({
-        type: EDIT_METRIC_BEGIN,
-        id: event.target.dataset.id
-      });
+      dispatch(Creators.editMetricBegin({ id: event.target.dataset.id }));
     },
 
     removeMetric: (event: any) => {
-      dispatch({
-        type: REMOVE_METRIC,
-        id: event.target.dataset.id
-      });
+      dispatch(Creators.removeMetric({ id: event.target.dataset.id }));
     }
   };
 }

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -6,10 +6,7 @@ import FormRow from '../layout/formRow';
 import JudgeSelect, { JudgeSelectRenderState } from './judgeSelect';
 import ScoreThresholds from './scoreThresholds';
 import { ICanaryState } from '../reducers/index';
-import {
-  UPDATE_CONFIG_DESCRIPTION,
-  UPDATE_CONFIG_NAME
-} from '../actions/index';
+import * as Creators from '../actions/creators';
 import FormList from '../layout/formList';
 
 interface INameAndDescriptionDispatchProps {
@@ -70,16 +67,14 @@ function mapStateToProps(state: ICanaryState) {
 function mapDispatchToProps(dispatch: (action: Action & any) => void) {
   return {
     changeName: (event: React.ChangeEvent<HTMLInputElement>) => {
-      dispatch({
-        type: UPDATE_CONFIG_NAME,
+      dispatch(Creators.updateConfigName({
         name: event.target.value,
-      });
+      }));
     },
     changeDescription: (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      dispatch({
-        type: UPDATE_CONFIG_DESCRIPTION,
+      dispatch(Creators.updateConfigDescription({
         description: event.target.value,
-      });
+      }));
     },
   };
 }

--- a/src/kayenta/edit/scoreThresholds.tsx
+++ b/src/kayenta/edit/scoreThresholds.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { ICanaryState } from '../reducers';
 import { CanaryScores } from '../components/canaryScores';
-import { UPDATE_SCORE_THRESHOLDS } from '../actions/index';
+import * as Creators from '../actions/creators';
 
 interface IScoreThresholdsStateProps {
   pass: number;
@@ -41,11 +41,10 @@ function mapStateToProps(state: ICanaryState): IScoreThresholdsStateProps {
 function mapDispatchToProps(dispatch: any): IScoreThresholdsDispatchProps {
   return {
     handleThresholdsChange: (thresholds: { unhealthyScore: string, successfulScore: string }) => {
-      dispatch({
-        type: UPDATE_SCORE_THRESHOLDS,
+      dispatch(Creators.updateScoreThresholds({
         marginal: parseInt(thresholds.unhealthyScore, 10),
         pass: parseInt(thresholds.successfulScore, 10),
-      });
+      }));
     }
   };
 }

--- a/src/kayenta/epics/index.ts
+++ b/src/kayenta/epics/index.ts
@@ -19,14 +19,14 @@ const typeMatches = (...actions: string[]) => (action: Action & any) => actions.
 const loadConfigEpic = (action$: Observable<Action & any>) =>
   action$
     .filter(typeMatches(Actions.LOAD_CONFIG_REQUEST, Actions.SAVE_CONFIG_SUCCESS))
-    .concatMap(action => getCanaryConfigById(action.id))
-    .map(config => ({type: Actions.LOAD_CONFIG_SUCCESS, config}))
-    .catch(error => Observable.of({type: Actions.LOAD_CONFIG_FAILURE, error}));
+    .concatMap(action => getCanaryConfigById(action.payload.configName))
+    .map(config => Creators.loadConfigSuccess({ config }))
+    .catch(error => Observable.of(Creators.loadConfigFailure({ error })));
 
 const selectConfigEpic = (action$: Observable<Action & any>) =>
   action$
     .filter(typeMatches(Actions.LOAD_CONFIG_SUCCESS))
-    .map(action => ({type: Actions.SELECT_CONFIG, config: action.config}));
+    .map(action => Creators.selectConfig({ config: action.payload.config }));
 
 const saveConfigEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
   action$
@@ -46,8 +46,8 @@ const saveConfigEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<
           ReactInjector.$state.go('^.configDetail', {configName: config.name}),
           store.getState().data.application.getDataSource('canaryConfigs').refresh(true)
         ))
-        .mapTo({type: Actions.SAVE_CONFIG_SUCCESS, id: config.name})
-        .catch((error: Error) => Observable.of({type: Actions.SAVE_CONFIG_FAILURE, error}));
+        .mapTo(Creators.saveConfigSuccess({ configName: config.name }))
+        .catch((error: Error) => Observable.of(Creators.saveConfigFailure({ error })));
     });
 
 const deleteConfigRequestEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
@@ -55,7 +55,7 @@ const deleteConfigRequestEpic = (action$: Observable<Action & any>, store: Middl
     .filter(typeMatches(Actions.DELETE_CONFIG_REQUEST))
     .concatMap(() => deleteCanaryConfig(store.getState().selectedConfig.config.name))
     .mapTo(Creators.deleteConfigSuccess())
-    .catch((error: Error) => Observable.of({type: Actions.DELETE_CONFIG_FAILURE, error}));
+    .catch((error: Error) => Observable.of(Creators.deleteConfigFailure({ error })));
 
 const deleteConfigSuccessEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
   action$

--- a/src/kayenta/reducers/app.ts
+++ b/src/kayenta/reducers/app.ts
@@ -21,7 +21,7 @@ const configJsonModalOpen = handleActions({
 }, false);
 
 const configJsonModalTabState = handleActions({
-  [Actions.SET_CONFIG_JSON_MODAL_TAB_STATE]: (_state: ConfigJsonModalTabState, action: Action & any) => action.payload,
+  [Actions.SET_CONFIG_JSON_MODAL_TAB_STATE]: (_state: ConfigJsonModalTabState, action: Action & any) => action.payload.state,
   [Actions.CONFIG_JSON_MODAL_OPEN]: () => ConfigJsonModalTabState.Edit,
 }, ConfigJsonModalTabState.Edit);
 

--- a/src/kayenta/reducers/data.ts
+++ b/src/kayenta/reducers/data.ts
@@ -22,25 +22,25 @@ export const application = handleActions({
 
 export const configSummaries = handleActions({
   [Actions.INITIALIZE]: (_state: ICanaryConfigSummary, action: Action & any) => action.state.data.configSummaries,
-  [Actions.UPDATE_CONFIG_SUMMARIES]: (_state: ICanaryConfigSummary, action: Action & any) => action.configSummaries,
+  [Actions.UPDATE_CONFIG_SUMMARIES]: (_state: ICanaryConfigSummary, action: Action & any) => action.payload.configSummaries,
 }, []);
 
 const configs = handleActions({
   [Actions.LOAD_CONFIG_SUCCESS]: (state: ICanaryConfig[], action: Action & any): ICanaryConfig[] => {
-    if (state.some(config => config.name === action.config.name)) {
+    if (state.some(config => config.name === action.payload.config.name)) {
       return without(
         state,
-        state.find(config => config.name === action.config.name)
-      ).concat([action.config]);
+        state.find(config => config.name === action.payload.config.name)
+      ).concat([action.payload.config]);
     } else {
-      return state.concat([action.config]);
+      return state.concat([action.payload.config]);
     }
   },
 }, []);
 
 const judges = handleActions({
   [Actions.INITIALIZE]: (_state: IJudge[], action: Action & any): IJudge[] => action.state.data.judges,
-  [Actions.UPDATE_JUDGES]: (_state: IJudge[], action: Action & any): IJudge[] => action.judges,
+  [Actions.UPDATE_JUDGES]: (_state: IJudge[], action: Action & any): IJudge[] => action.payload.judges,
 }, null);
 
 export const data = combineReducers<IDataState>({

--- a/src/kayenta/reducers/group.ts
+++ b/src/kayenta/reducers/group.ts
@@ -18,9 +18,9 @@ function groupsFromMetrics(metrics: ICanaryMetricConfig[] = []) {
 }
 
 const list = handleActions({
-  [Actions.SELECT_CONFIG]: (_state: string[], action: Action & any) => groupsFromMetrics(action.config.metrics),
+  [Actions.SELECT_CONFIG]: (_state: string[], action: Action & any) => groupsFromMetrics(action.payload.config.metrics),
   [Actions.ADD_METRIC]: (state: string[], action: Action & any) => {
-    const groups = action.metric.groups;
+    const groups = action.payload.metric.groups;
     return state.concat(groups.filter((group: string) => !state.includes(group)));
   },
   [Actions.ADD_GROUP]: (state: string[]) => {
@@ -35,12 +35,12 @@ const list = handleActions({
 }, []);
 
 const selected = handleActions({
-  [Actions.SELECT_GROUP]: (_state: string, action: Action & any) => action.name,
+  [Actions.SELECT_GROUP]: (_state: string, action: Action & any) => action.payload.name,
 }, '');
 
 const groupWeights = handleActions({
-  [Actions.SELECT_CONFIG]: (_state: GroupWeights, action: Action & any) => get(action, 'config.classifier.groupWeights', {}),
-  [Actions.UPDATE_GROUP_WEIGHT]: (state: GroupWeights, action: Action & any) => ({ ...state, [action.group]: action.weight }),
+  [Actions.SELECT_CONFIG]: (_state: GroupWeights, action: Action & any) => get(action, 'payload.config.classifier.groupWeights', {}),
+  [Actions.UPDATE_GROUP_WEIGHT]: (state: GroupWeights, action: Action & any) => ({ ...state, [action.payload.group]: action.payload.weight }),
 }, {});
 
 export const group = combineReducers<IGroupState>({


### PR DESCRIPTION
@svachalek 

The actions that reducers received are still pretty much untyped, but at least what we pass to `dispatch` will be of a consistent type. 