### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "lib/lib.js",
   "typings": "lib/kayenta/index.d.ts",
   "name": "@spinnaker/kayenta",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
   "engines": {
     "node": "7.0.0",
     "npm": "3.10.8",
-    "yarn": "0.23.4"
+    "yarn": ">=0.27.5"
   },
   "scripts": {
     "build": "webpack --bail",


### PR DESCRIPTION
Set yarn version to match deck and deck-nflx builds; otherwise yarn refuses to install it without an override flag.