### PR TITLE
feature: disable canary if no config is present

### DIFF
--- a/src/kayenta/canary.module.ts
+++ b/src/kayenta/canary.module.ts
@@ -23,9 +23,13 @@ const modules = [
 ];
 
 export const KAYENTA_MODULE = 'spinnaker.kayenta';
-module(
-  KAYENTA_MODULE,
-  CanarySettings.stagesEnabled
-    ? [CANARY_STAGES, ...modules]
-    : modules
-);
+if (CanarySettings.featureDisabled) {
+  module(KAYENTA_MODULE, []);
+} else {
+  module(
+    KAYENTA_MODULE,
+    CanarySettings.stagesEnabled
+      ? [CANARY_STAGES, ...modules]
+      : modules
+  );
+}

--- a/src/kayenta/canary.settings.ts
+++ b/src/kayenta/canary.settings.ts
@@ -11,6 +11,7 @@ export interface ICanarySettings {
   reportsEnabled: boolean;
   stagesEnabled: boolean;
   graphImplementation: string;
+  featureDisabled: boolean;
 }
 
-export const CanarySettings = <ICanarySettings>SETTINGS.canary;
+export const CanarySettings = SETTINGS.canary || { featureDisabled: true };


### PR DESCRIPTION
If this module is added to an existing Spinnaker installation, it will fail to start because of exceptions caused by the undefined canary settings block. It would be nice if we could find suitable defaults but I think because the metric system and some other major variables are impossible to predict, it's better to just force the admins to go in and create settings.