### PR TITLE
fix: use metric.query.type instead of metric.serviceName

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -2,7 +2,7 @@ import { createAction } from 'redux-actions';
 
 import * as Actions from './index';
 import { ConfigJsonModalTabState } from '../edit/configJsonModal';
-import { ICanaryConfig } from '../domain/ICanaryConfig';
+import {ICanaryConfig, ICanaryMetricConfig} from '../domain/ICanaryConfig';
 import { ICanaryConfigSummary } from '../domain/ICanaryConfigSummary';
 import { IJudge } from '../domain/IJudge';
 import { IMetricSetPair } from '../domain/IMetricSetPair';
@@ -34,7 +34,7 @@ export const updateGroupWeight = createAction(Actions.UPDATE_GROUP_WEIGHT, typed
 export const selectJudgeName = createAction(Actions.SELECT_JUDGE_NAME, typedPayloadCreator<{judge: {name: string}}>());
 export const editMetricBegin = createAction(Actions.EDIT_METRIC_BEGIN, typedPayloadCreator<{id: string}>());
 export const removeMetric = createAction(Actions.REMOVE_METRIC, typedPayloadCreator<{id: string}>());
-export const addMetric = createAction(Actions.ADD_METRIC, typedPayloadCreator<{metric: {name: string, serviceName: string, groups: string[]}}>());
+export const addMetric = createAction(Actions.ADD_METRIC, typedPayloadCreator<{metric: ICanaryMetricConfig}>());
 export const updateConfigName = createAction(Actions.UPDATE_CONFIG_NAME, typedPayloadCreator<{name: string}>());
 export const updateConfigDescription = createAction(Actions.UPDATE_CONFIG_DESCRIPTION, typedPayloadCreator<{description: string}>());
 export const updateScoreThresholds = createAction(Actions.UPDATE_SCORE_THRESHOLDS, typedPayloadCreator<{marginal: number, pass: number}>());

--- a/src/kayenta/domain/ICanaryConfig.ts
+++ b/src/kayenta/domain/ICanaryConfig.ts
@@ -18,7 +18,6 @@ export interface ICanaryConfig {
 export interface ICanaryMetricConfig {
   id: string;
   name: string;
-  serviceName: string;
   query: ICanaryMetricSetQueryConfig;
   groups: string[];
   analysisConfigurations: {

--- a/src/kayenta/edit/metricConfigurerDelegator.tsx
+++ b/src/kayenta/edit/metricConfigurerDelegator.tsx
@@ -12,14 +12,14 @@ interface IMetricConfigurerDelegatorStateProps {
 * Should find and render the appropriate metric configurer for a given metric store.
 * */
 function MetricConfigurerDelegator({ editingMetric }: IMetricConfigurerDelegatorStateProps) {
-  const config = metricStoreConfigService.getDelegate(editingMetric.serviceName);
+  const config = metricStoreConfigService.getDelegate(editingMetric.query.type);
   if (config && config.metricConfigurer) {
     const MetricConfigurer = config.metricConfigurer;
     return <MetricConfigurer/>;
   } else {
     return (
       <p>
-        Metric configuration has not been implemented for {editingMetric.serviceName}.
+        Metric configuration has not been implemented for {editingMetric.query.type}.
       </p>
     );
   }

--- a/src/kayenta/edit/metricDetail.tsx
+++ b/src/kayenta/edit/metricDetail.tsx
@@ -14,8 +14,8 @@ export interface IMetricDetailProps {
  * Configures all the available settings for a single metric.
  */
 export default function MetricDetail({ metric, showGroups, edit, remove }: IMetricDetailProps) {
-  const config = metricStoreConfigService.getDelegate(metric.serviceName);
-  const queryFinder = config && config.queryFinder ? config.queryFinder : (_metric: ICanaryMetricConfig) => `queryFinder not yet implemented for ${metric.serviceName}`;
+  const config = metricStoreConfigService.getDelegate(metric.query.type);
+  const queryFinder = config && config.queryFinder ? config.queryFinder : (_metric: ICanaryMetricConfig) => `queryFinder not yet implemented for ${config.name}`;
 
   return (
     <section className="horizontal metric-list-row">

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -73,8 +73,12 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
         metric: {
           // TODO: need to block saving an invalid name
           // TODO: for Atlas metrics, attempt to gather name when query changes
+          id: '[new]',
+          analysisConfigurations: [],
           name: '',
-          serviceName: CanarySettings.metricStore,
+          query: {
+            type: CanarySettings.metricStore
+          },
           groups: (group && group !== UNGROUPED) ? [group] : []
         }
       }));

--- a/src/kayenta/report/metricResultScope.tsx
+++ b/src/kayenta/report/metricResultScope.tsx
@@ -40,7 +40,7 @@ const mapStateToProps = (state: ICanaryState): IMetricResultScopeStateProps => (
   metricConfig: selectedMetricConfigSelector(state),
   metricSetPair: state.selectedRun.metricSetPair.pair,
   run: runSelector(state),
-  service: selectedMetricConfigSelector(state).serviceName,
+  service: selectedMetricConfigSelector(state).query.type
 });
 
 export default connect(mapStateToProps)(MetricResultScope);

--- a/src/kayenta/scratch/atlas_canary_config.json
+++ b/src/kayenta/scratch/atlas_canary_config.json
@@ -14,7 +14,6 @@
   "metrics": [
     {
       "name": "cpu",
-      "serviceName": "atlas",
       "query": {
         "type": "atlas",
         "q": "name,randomValue,:eq"
@@ -28,7 +27,6 @@
     },
     {
       "name": "requests",
-      "serviceName": "atlas",
       "query": {
         "type": "atlas",
         "q": "name,apache.http.requests,:eq,:sum"

--- a/src/kayenta/scratch/stackdriver_canary_config.json
+++ b/src/kayenta/scratch/stackdriver_canary_config.json
@@ -11,7 +11,6 @@
   },
   "metrics": [
     {
-      "serviceName": "stackdriver",
       "name": "cpu",
       "groups": [
         "system"


### PR DESCRIPTION
Just found today that we're using a mix of serviceName and query.type. It seems the server is only using query.type, so updated the UI to match.