### PR TITLE
fix: switch array to object in canary metric config

### DIFF
--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -74,7 +74,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
           // TODO: need to block saving an invalid name
           // TODO: for Atlas metrics, attempt to gather name when query changes
           id: '[new]',
-          analysisConfigurations: [],
+          analysisConfigurations: {},
           name: '',
           query: {
             type: CanarySettings.metricStore


### PR DESCRIPTION
Close this if this is wrong - but if so, we'll need to make an update in Kayenta.