### PR TITLE
fix: prevent adding metric without name, remove metric from list on c…

### DIFF
--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -4,6 +4,7 @@
   button {
     &[disabled] {
       cursor: not-allowed;
+      opacity: 0.4;
     }
   }
 

--- a/src/kayenta/domain/ICanaryConfig.ts
+++ b/src/kayenta/domain/ICanaryConfig.ts
@@ -23,6 +23,7 @@ export interface ICanaryMetricConfig {
   analysisConfigurations: {
     [key: string]: any;
   };
+  isNew?: boolean;
 }
 
 export interface ICanaryMetricSetQueryConfig {

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -66,7 +66,7 @@ function EditMetricModal({ metric, rename, confirm, cancel, updateDirection }: I
         <Modal.Footer>
           <ul className="list-inline pull-right">
             <li><button className="passive" onClick={cancel}>Cancel</button></li>
-            <li><button className="primary" onClick={confirm}>OK</button></li>
+            <li><button className="primary" disabled={!metric.name} onClick={confirm}>OK</button></li>
           </ul>
         </Modal.Footer>
       </Styleguide>

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -79,7 +79,8 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
           query: {
             type: CanarySettings.metricStore
           },
-          groups: (group && group !== UNGROUPED) ? [group] : []
+          groups: (group && group !== UNGROUPED) ? [group] : [],
+          isNew: true,
         }
       }));
     },

--- a/src/kayenta/reducers/selectedConfig.ts
+++ b/src/kayenta/reducers/selectedConfig.ts
@@ -189,13 +189,15 @@ function editingMetricReducer(state: ISelectedConfigState = null, action: Action
       });
 
     case Actions.EDIT_METRIC_CONFIRM:
+      const editing: ICanaryMetricConfig = omit(state.editingMetric, 'isNew');
       return Object.assign({}, state, {
-        metricList: state.metricList.map(metric => metric.id === state.editingMetric.id ? state.editingMetric : metric),
+        metricList: state.metricList.map(metric => metric.id === editing.id ? editing : metric),
         editingMetric: null
       });
 
     case Actions.EDIT_METRIC_CANCEL:
       return Object.assign({}, state, {
+        metricList: state.metricList.filter(metric => !metric.isNew),
         editingMetric: null
       });
 


### PR DESCRIPTION
…ancel

I realized that I couldn't just delete any metric without a name. For an existing metric, deleting a name and then clicking cancel would delete your metric. 