### PR TITLE
fix: npm ignore node modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -48,3 +48,4 @@ settings.gradle
 webpack.common.js
 webpack.config.js
 test/
+node_modules/


### PR DESCRIPTION
@svachalek I think this fixes the issue `react-redux` issue. Not 100% sure why.