### PR TITLE
style: adjust report header styles

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -11,6 +11,7 @@ var defaultMetricStore = process.env.METRIC_STORE || 'atlas';
 var canaryStagesEnabled = process.env.CANARY_STAGES_ENABLED === 'true';
 var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
 var atlasWebComponentsUrl = process.env.ATLAS_WEB_COMPONENTS_URL;
+var canaryAccount = process.env.CANARY_ACCOUNT || 'my-google-account';
 
 window.spinnakerSettings = {
   checkForUpdates: true,
@@ -79,8 +80,8 @@ window.spinnakerSettings = {
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis'],
   canary: {
     reduxLogger: reduxLoggerEnabled,
-    metricsAccountName: 'my-google-account',
-    storageAccountName: 'my-google-account',
+    metricsAccountName: canaryAccount,
+    storageAccountName: canaryAccount,
     defaultJudge: 'NetflixACAJudge-v1.0',
     metricStore: defaultMetricStore,
     stagesEnabled: canaryStagesEnabled,

--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -66,6 +66,9 @@
   }
 
   .table-header {
+    &.sticky-header {
+      background-color: var(--color-alabaster);
+    }
     h6 {
       font-weight: 600;
     }

--- a/src/kayenta/components/canaryScore.component.less
+++ b/src/kayenta/components/canaryScore.component.less
@@ -7,6 +7,9 @@
   height: 20px;
   line-height: 14px;
   color: white;
+  &.inverse {
+    padding: 0;
+  }
   &.label-failing {
     background-color: var(--color-alert-light);
     &.inverse {
@@ -36,6 +39,13 @@
     font-size: 100%;
     padding: 0;
   }
+  .score-classification {
+    font-size: 45%;
+    display: block;
+    margin-top: 15px;
+    font-weight: 400;
+    text-transform: uppercase;
+  }
 }
 
 .score-large.score {
@@ -54,10 +64,18 @@
 }
 
 .score.score-report {
-  height: 30px;
-  line-height: 30px;
-  padding: 0 10px 0 10px;
-  font-size: 170%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  padding: 15px;
+  font-size: 200%;
   border-radius: 0;
   min-width: 30px;
+  height: 100%;
+}
+
+.table-row {
+  .score.score-report {
+    display: inline-block;
+  }
 }

--- a/src/kayenta/components/canaryScore.tsx
+++ b/src/kayenta/components/canaryScore.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import { ScoreClassificationLabel } from '../domain/ScoreClassificationLabel';
+
+import { getHealthLabel } from '../service/canaryRun.service';
 
 import './canaryScore.component.less';
 
@@ -9,6 +12,7 @@ export interface ICanaryScoreProps {
   result: string;
   inverse: boolean;
   className?: string;
+  classification?: ScoreClassificationLabel;
 }
 
 export interface ICanaryScoreState {
@@ -27,16 +31,10 @@ export class CanaryScore extends React.Component<ICanaryScoreProps, ICanaryScore
   }
 
   private getLabelState(props: ICanaryScoreProps): ICanaryScoreState {
-    const health = (props.health || '').toLowerCase();
-    const result = (props.result || '').toLowerCase();
     const score = (props.score === 0 || (props.score && props.score > 0)) ? props.score : 'N/A';
-    const healthLabel = health === 'unhealthy' ? 'unhealthy'
-      : result === 'success' ? 'healthy'
-      : result === 'failure' ? 'failing'
-      : 'unknown';
 
     return {
-      healthLabel: healthLabel,
+      healthLabel: getHealthLabel(props.health, props.result),
       score: score
     };
   }
@@ -55,7 +53,12 @@ export class CanaryScore extends React.Component<ICanaryScoreProps, ICanaryScore
       `label-${this.state.healthLabel}`
     ].join(' ');
     return (
-      <span className={classNames(className, this.props.className)}>{this.state.score}</span>
+      <span className={classNames(className, this.props.className)}>
+        {this.state.score}
+        {this.props.classification && (
+          <span className="score-classification">{this.props.classification.toString()}</span>
+        )}
+      </span>
     );
   }
 }

--- a/src/kayenta/domain/ICanaryJudgeStage.ts
+++ b/src/kayenta/domain/ICanaryJudgeStage.ts
@@ -1,12 +1,10 @@
 import { IExecutionStage } from '@spinnaker/core';
 import { ICanaryJudgeResult } from './ICanaryJudgeResult';
+import { ICanaryClassifierThresholdsConfig } from './ICanaryConfig';
 
 export interface ICanaryJudgeStage extends IExecutionStage {
   context: {
-    orchestratorScoreThresholds: {
-      pass: number;
-      marginal: number;
-    };
+    orchestratorScoreThresholds: ICanaryClassifierThresholdsConfig;
     storageAccountName: string;
     configurationAccountName: string;
     metricSetPairListId: string;

--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -17,7 +17,7 @@ interface IConfigDetailStateProps {
 function ConfigDetailHeader({ selectedConfig }: IConfigDetailStateProps) {
   return (
     <div className="horizontal config-detail-header">
-      <div className="flex-4">
+      <div className="flex-3">
         <h1 className="heading-1 color-text-primary">Configuration{selectedConfig ? `: ${selectedConfig.name}` : ''}</h1>
       </div>
       <div className="flex-1">

--- a/src/kayenta/edit/scoreThresholds.tsx
+++ b/src/kayenta/edit/scoreThresholds.tsx
@@ -1,23 +1,19 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { ICanaryClassifierThresholdsConfig } from '../domain';
 
 import { ICanaryState } from '../reducers';
 import { CanaryScores } from '../components/canaryScores';
 import * as Creators from '../actions/creators';
 
-interface IScoreThresholdsStateProps {
-  pass: number;
-  marginal: number;
-}
-
-interface IScoreThresholdsDispatchProps {
+interface ICanaryClassifierThresholdsConfigDispatchProps {
   handleThresholdsChange: (thresholds: { unhealthyScore: string, successfulScore: string }) => void;
 }
 
 /*
  * Fields for updating score thresholds.
  */
-function ScoreThresholds({ pass, marginal, handleThresholdsChange }: IScoreThresholdsStateProps & IScoreThresholdsDispatchProps) {
+function ScoreThresholds({ pass, marginal, handleThresholdsChange }: ICanaryClassifierThresholdsConfig & ICanaryClassifierThresholdsConfigDispatchProps) {
   return (
     <CanaryScores
       unhealthyHelpFieldId={'pipeline.config.canary.marginalScore'}
@@ -31,14 +27,14 @@ function ScoreThresholds({ pass, marginal, handleThresholdsChange }: IScoreThres
   )
 }
 
-function mapStateToProps(state: ICanaryState): IScoreThresholdsStateProps {
+function mapStateToProps(state: ICanaryState): ICanaryClassifierThresholdsConfig {
   return {
     marginal: state.selectedConfig.thresholds.marginal,
     pass: state.selectedConfig.thresholds.pass,
   };
 }
 
-function mapDispatchToProps(dispatch: any): IScoreThresholdsDispatchProps {
+function mapDispatchToProps(dispatch: any): ICanaryClassifierThresholdsConfigDispatchProps {
   return {
     handleThresholdsChange: (thresholds: { unhealthyScore: string, successfulScore: string }) => {
       dispatch(Creators.updateScoreThresholds({

--- a/src/kayenta/layout/formattedDate.tsx
+++ b/src/kayenta/layout/formattedDate.tsx
@@ -8,7 +8,7 @@ export interface IDateLabelProps {
   format?: string;
 }
 
-const DEFAULT_FORMAT = 'MM/DD/YY @ HH:mm';
+const DEFAULT_FORMAT = 'YYYY-MM-DD HH:mm:ss z';
 
 export default function FormattedDate({ dateIso, format }: IDateLabelProps) {
   if (dateIso) {

--- a/src/kayenta/layout/table/table.tsx
+++ b/src/kayenta/layout/table/table.tsx
@@ -9,13 +9,14 @@ export interface ITableProps<T> {
   columns: ITableColumn<T>[];
   rowKey: (row: T) => string;
   tableBodyClassName?: string;
+  headerClassName?: string;
   rowClassName?: (row: T) => string;
   onRowClick?: (row: T) => void;
   customRow?: (row: T) => JSX.Element;
   className?: string;
 }
 
-export function Table<T>({ rows, columns, rowKey, tableBodyClassName, rowClassName, onRowClick, customRow, className }: ITableProps<T>) {
+export function Table<T>({ rows, columns, rowKey, tableBodyClassName, rowClassName, onRowClick, customRow, className, headerClassName }: ITableProps<T>) {
   const TableRow = ({ row }: { row: T }) => (
     <li
       onClick={onRowClick ? () => onRowClick(row) : null}
@@ -33,8 +34,8 @@ export function Table<T>({ rows, columns, rowKey, tableBodyClassName, rowClassNa
 
   return (
     <div className={className}>
-      <TableHeader columns={columns} className="table-header"/>
       <ul className={classNames(tableBodyClassName, 'list-group')}>
+        <TableHeader columns={columns} className={`table-header sticky-header ${headerClassName}`}/>
         {
           rows.map(r => (
             customRow && customRow(r)

--- a/src/kayenta/layout/table/tableHeader.tsx
+++ b/src/kayenta/layout/table/tableHeader.tsx
@@ -10,7 +10,7 @@ export interface ITableHeaderProps {
 
 export const TableHeader = ({ columns, className }: ITableHeaderProps) => {
   return (
-    <section className={classNames('horizontal', className)}>
+    <div className={classNames('horizontal', className)}>
       {columns.map((c, i) => (
         <div key={c.label || i} className={`flex-${c.width}`}>
           {!c.hide && (
@@ -20,6 +20,6 @@ export const TableHeader = ({ columns, className }: ITableHeaderProps) => {
           )}
         </div>
       ))}
-    </section>
+    </div>
   );
 };

--- a/src/kayenta/navigation/canaryHeader.less
+++ b/src/kayenta/navigation/canaryHeader.less
@@ -2,6 +2,7 @@
   nav {
     h1.heading-1 {
       margin: 0;
+      font-weight: 600;
     }
 
     ul.tabs-basic {

--- a/src/kayenta/reducers/selectedConfig.ts
+++ b/src/kayenta/reducers/selectedConfig.ts
@@ -3,10 +3,10 @@ import { combineActions, handleActions } from 'redux-actions';
 import { get, set, has, omit, chain, pick, fromPairs, flatMap, cloneDeep } from 'lodash';
 
 import * as Actions from '../actions';
+import { ICanaryClassifierThresholdsConfig } from '../domain';
 import { IJudge } from '../domain/IJudge';
 import {
   IGroupWeights,
-  ICanaryClassifierThresholdsConfig,
   ICanaryConfig,
   ICanaryJudgeConfig,
   ICanaryMetricConfig

--- a/src/kayenta/report/detail/allMetricResultsHeader.tsx
+++ b/src/kayenta/report/detail/allMetricResultsHeader.tsx
@@ -1,25 +1,32 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import { ICanaryJudgeScore, ICanaryClassifierThresholdsConfig } from 'kayenta/domain';
+import { mapGroupToColor } from './colors';
 
 import HeaderArrow from './headerArrow';
 
 export interface IAllMetricResultsHeader {
   onClick: () => void;
   className: string;
+  score: ICanaryJudgeScore;
+  scoreThresholds: ICanaryClassifierThresholdsConfig;
 }
 
 /*
 * Clickable header for all metric results.
 */
-export default ({ className, onClick }: IAllMetricResultsHeader) => (
+export default ({ className, onClick, score, scoreThresholds }: IAllMetricResultsHeader) => (
   <section className={className}>
     <div
       onClick={onClick}
+      style={{
+        backgroundColor: mapGroupToColor(score, scoreThresholds)
+      }}
       className={classNames('clickable', 'text-center', 'all-metric-results-header')}
     >
       <h3 className="heading-3 label">ALL</h3>
       <HeaderArrow className="outer" arrowColor="var(--color-titanium)"/>
-      <HeaderArrow className="inner" arrowColor="var(--color-alabaster)"/>
+      <HeaderArrow className="inner" arrowColor={mapGroupToColor(score, scoreThresholds)}/>
     </div>
   </section>
 );

--- a/src/kayenta/report/detail/colors.ts
+++ b/src/kayenta/report/detail/colors.ts
@@ -1,6 +1,7 @@
 import { MetricClassificationLabel } from 'kayenta/domain/MetricClassificationLabel';
 import { ScoreClassificationLabel } from 'kayenta/domain/ScoreClassificationLabel';
 import { ICanaryJudgeGroupScore } from 'kayenta/domain/ICanaryJudgeResult';
+import { ICanaryJudgeScore, ICanaryClassifierThresholdsConfig } from '../../domain';
 
 // Standard Spinnaker styleguide colors.
 const GREEN = 'var(--color-success)';
@@ -24,7 +25,7 @@ export const mapScoreClassificationToColor = (classification: ScoreClassificatio
     [ScoreClassificationLabel.Pass]: GREEN,
   }[classification]);
 
-export const mapGroupToColor = (group: ICanaryJudgeGroupScore, scoreThresholds: { pass: number, marginal: number }): string => {
+export const mapGroupToColor = (group: ICanaryJudgeGroupScore | ICanaryJudgeScore, scoreThresholds: ICanaryClassifierThresholdsConfig): string => {
   if (typeof group.score !== 'number') {
     return YELLOW; // Some kind of error.
   } else if (group.score > scoreThresholds.pass) {

--- a/src/kayenta/report/detail/groupScores.tsx
+++ b/src/kayenta/report/detail/groupScores.tsx
@@ -3,6 +3,7 @@ import * as classNames from 'classnames';
 import { connect, Dispatch } from 'react-redux';
 
 import { ICanaryJudgeGroupScore } from 'kayenta/domain/ICanaryJudgeResult';
+import { ICanaryClassifierThresholdsConfig } from '../../domain';
 import ClickableHeader from './clickableHeader';
 import * as Creators from 'kayenta/actions/creators';
 import { ICanaryState } from 'kayenta/reducers/index';
@@ -17,7 +18,7 @@ export interface IGroupScoresOwnProps {
 
 interface IGroupScoresStateProps {
   groupWeights: IGroupWeights;
-  scoreThresholds: { pass: number, marginal: number };
+  scoreThresholds: ICanaryClassifierThresholdsConfig;
   selectedGroup: string;
 }
 

--- a/src/kayenta/report/detail/header.less
+++ b/src/kayenta/report/detail/header.less
@@ -1,17 +1,22 @@
 .report-header {
+  margin-bottom: 10px;
+  align-items: center;
 
   h1 {
-    margin-top: 16px;
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: 0;
   }
 
   .report-score-wrapper {
-    padding-right: 20px;
-    margin: 11px 0 7px 15px;
-    padding-top: 5px;
+    padding: 5px 20px 0 0;
+    margin-left: 15px;
     border-right: 1px solid var(--color-titanium);
   }
 
   .report-metadata {
+    flex: 1;
     padding-left: 20px;
     padding-top: 10px;
 
@@ -21,6 +26,9 @@
 
     .label {
       padding-left: 0;
+      &.label-lg {
+        font-size: 85%;
+      }
     }
   }
 }

--- a/src/kayenta/report/detail/header.tsx
+++ b/src/kayenta/report/detail/header.tsx
@@ -24,7 +24,7 @@ const ReportHeader = ({ id, name, score }: IReportHeaderStateProps) => (
       </UISref>
     </h1>
     <div className="report-score-wrapper">
-      <ReportScore score={score}/>
+      <ReportScore score={score} showClassification={true}/>
     </div>
     <ReportMetadata/>
   </section>

--- a/src/kayenta/report/detail/multipleResultsTable.tsx
+++ b/src/kayenta/report/detail/multipleResultsTable.tsx
@@ -49,6 +49,7 @@ const MultipleResultsTable = ({ results, select, selectedResult }: IMultipleResu
       rows={results}
       columns={columns}
       className="multiple-results-table"
+      headerClassName="sticky-header-2"
       rowClassName={r => classNames('horizontal', { selected: r.id === selectedResult })}
       rowKey={r => Object.entries(r.tags || {}).map(([key, value]) => `${key}:${value}`).join(':')}
       onRowClick={r => select(r.id)}

--- a/src/kayenta/report/detail/reportScores.less
+++ b/src/kayenta/report/detail/reportScores.less
@@ -1,5 +1,6 @@
 .report-scores {
   height: 40px;
+  margin-bottom: 20px;
   .group-score, .all-metric-results-header {
     height: 30px;
     color: white;
@@ -32,10 +33,6 @@
     border: 1px solid var(--color-titanium);
     width: 70%;
     margin: 0 auto;
-
-    h3 {
-      color: var(--color-text-primary);
-    }
 
     .arrow-down {
       &.inner {

--- a/src/kayenta/report/detail/reportScores.tsx
+++ b/src/kayenta/report/detail/reportScores.tsx
@@ -8,6 +8,7 @@ import {
   ICanaryJudgeGroupScore,
   ICanaryJudgeScore
 } from 'kayenta/domain/ICanaryJudgeResult';
+import { ICanaryClassifierThresholdsConfig } from '../../domain';
 import AllMetricResultsHeader from './allMetricResultsHeader';
 import GroupScores from './groupScores';
 import * as Creators from 'kayenta/actions/creators';
@@ -21,6 +22,7 @@ import './reportScores.less';
 interface IReportScoresStateProps {
   groups: ICanaryJudgeGroupScore[];
   score: ICanaryJudgeScore;
+  scoreThresholds: ICanaryClassifierThresholdsConfig;
   selectedGroup: string;
 }
 
@@ -31,10 +33,12 @@ interface IReportScoresDispatchProps {
 /*
 * Layout for the report scores.
 * */
-const ReportScores = ({ groups, selectedGroup, clearSelectedGroup }: IReportScoresStateProps & IReportScoresDispatchProps) => (
+const ReportScores = ({ groups, selectedGroup, clearSelectedGroup, score, scoreThresholds }: IReportScoresStateProps & IReportScoresDispatchProps) => (
   <section className="horizontal report-scores">
     <AllMetricResultsHeader
       onClick={clearSelectedGroup}
+      score={score}
+      scoreThresholds={scoreThresholds}
       className={classNames('flex-1', 'report-score', { active: !selectedGroup })}
     />
     <GroupScores groups={groups} className="flex-12"/>
@@ -51,6 +55,7 @@ const mapStateToProps = (state: ICanaryState): IReportScoresStateProps => ({
     ]
   ),
   score: judgeResultSelector(state).score,
+  scoreThresholds: state.selectedRun.run.result.canaryExecutionRequest.thresholds,
   selectedGroup: state.selectedRun.selectedGroup,
 });
 

--- a/src/kayenta/report/detail/score.tsx
+++ b/src/kayenta/report/detail/score.tsx
@@ -6,15 +6,18 @@ import { CanaryScore } from 'kayenta/components/canaryScore';
 
 export interface ICanaryJudgeScoreProps {
   score: ICanaryJudgeScore;
+  showClassification?: boolean;
+  inverse?: boolean;
 }
 
-export default ({ score }: ICanaryJudgeScoreProps) => (
+export default ({ score, showClassification, inverse }: ICanaryJudgeScoreProps) => (
   <CanaryScore
     className="score-report"
     score={round(score.score, 2)}
     result={mapKayentaToACA(score).result}
     health={mapKayentaToACA(score).health}
-    inverse={false}
+    classification={showClassification ? score.classification : null}
+    inverse={inverse}
   />
 );
 

--- a/src/kayenta/report/detail/sourceLinks.tsx
+++ b/src/kayenta/report/detail/sourceLinks.tsx
@@ -12,14 +12,16 @@ interface ISourceJsonStateProps {
 
 const SourceLinks = ({ reportUrl, metricListUrl }: ISourceJsonStateProps) => {
   return (
-    <ul className="list-unstyled small">
-      <li>
-        <a target="_blank" href={reportUrl}>Report Source</a>
-      </li>
-      <li>
-        <a target="_blank" href={metricListUrl}>Metrics Source</a>
-      </li>
-    </ul>
+    <p>
+      <ul className="list-unstyled small">
+        <li>
+          <a target="_blank" href={reportUrl}>Report</a>
+        </li>
+        <li>
+          <a target="_blank" href={metricListUrl}>Metrics</a>
+        </li>
+      </ul>
+    </p>
   );
 };
 

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -25,7 +25,13 @@ const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
   },
   {
     label: 'Score',
-    getContent: execution => <Score score={execution.result.judgeResult.score}/>,
+    getContent: execution => (
+      <Score
+        score={execution.result.judgeResult.score}
+        inverse={true}
+        showClassification={false}
+      />
+    ),
     width: 1,
   },
   {

--- a/src/kayenta/service/canaryRun.service.ts
+++ b/src/kayenta/service/canaryRun.service.ts
@@ -37,3 +37,12 @@ export const listCanaryExecutions = (application: string, limit: number, statuse
     .one('executions')
     .withParams({ limit, statuses, storageAccountName })
     .get();
+
+export const getHealthLabel = (health: string, result: string): string => {
+  const healthLC = (health || '').toLowerCase();
+  const resultLC = (result || '').toLowerCase();
+  return healthLC === 'unhealthy' ? 'unhealthy'
+    : resultLC === 'success' ? 'healthy'
+      : resultLC === 'failure' ? 'failing'
+        : 'unknown';
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -125,16 +125,17 @@ function configure(IS_TEST) {
       }),
       new webpack.EnvironmentPlugin({
         API_HOST: 'https://api-prestaging.spinnaker.mgmt.netflix.net',
+        ATLAS_WEB_COMPONENTS_URL: '',
+        CANARY_ACCOUNT: 'my-google-account',
+        CANARY_STAGES_ENABLED: true,
         ENTITY_TAGS_ENABLED: true,
         FEEDBACK_URL: 'https://hootch.test.netflix.net/submit',
         FIAT_ENABLED: false,
         INFRA_STAGES: false,
-        TIMEZONE: 'America/Los_Angeles',
         METRIC_STORE: 'atlas',
-        ATLAS_WEB_COMPONENTS_URL: '',
         REDUX_LOGGER: false,
-        CANARY_STAGES_ENABLED: true,
         TEMPLATES_ENABLED: false,
+        TIMEZONE: 'America/Los_Angeles',
       }),
     ]);
   }


### PR DESCRIPTION
A few changes here, per user feedback:

*Current*
<img width="1364" alt="screen shot 2018-02-23 at 12 17 02 pm" src="https://user-images.githubusercontent.com/73450/36614995-8ad7add2-1893-11e8-9173-bad77de0b74b.png">

*PR*
<img width="1356" alt="screen shot 2018-02-23 at 12 17 17 pm" src="https://user-images.githubusercontent.com/73450/36614999-8e6f0daa-1893-11e8-85e9-a0f8d610e700.png">


* Making the score more prominent in the report header, and adding the classification

* getting date formats consistent with the rest of Deck

* The "All" tab is now colored based on overall canary score

* slight adjustments to the other details in the header to free up room, which is being eaten by the longer timestamps and bigger score (although a lot of this is going to be reworked pretty soon so shouldn't be taken too critically)

* added some padding between the grouping headers and the report details

* sticky headers on tables

* tweaked report list so scores are colored appropriately but otherwise show just the number

* made the main "Canary" heading semibold (will incorporate into spinnaker/styleguide at some point)

* configurable canary account (we use a different account name, so local development is a lot easier if it can come in from the command line)