### PR TITLE
feat: require group on all metrics

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -23,6 +23,7 @@ export const openConfigJsonModal = createAction(Actions.CONFIG_JSON_MODAL_OPEN);
 export const editMetricCancel = createAction(Actions.EDIT_METRIC_CANCEL);
 export const editMetricConfirm = createAction(Actions.EDIT_METRIC_CONFIRM);
 export const updateMetricDirection = createAction<{id: string, direction: string}>(Actions.UPDATE_METRIC_DIRECTION);
+export const updateMetricGroup = createAction<{id: string, group: string}>(Actions.UPDATE_METRIC_GROUP);
 export const addGroup = createAction(Actions.ADD_GROUP);
 export const saveConfig = createAction(Actions.SAVE_CONFIG_REQUEST);
 export const dismissSaveConfigError = createAction(Actions.DISMISS_SAVE_CONFIG_ERROR);

--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -17,6 +17,7 @@ export const EDIT_METRIC_BEGIN = 'edit_metric_begin';
 export const EDIT_METRIC_CONFIRM = 'edit_metric_modal_confirm';
 export const EDIT_METRIC_CANCEL = 'edit_metric_modal_cancel';
 export const UPDATE_METRIC_DIRECTION = 'update_metric_direction';
+export const UPDATE_METRIC_GROUP = 'update_metric_group';
 export const UPDATE_METRIC_SCOPE_NAME = 'update_metric_scope_name';
 export const REMOVE_METRIC = 'remove_metric';
 export const SELECT_CONFIG = 'select_config';

--- a/src/kayenta/edit/changeMetricGroupModal.tsx
+++ b/src/kayenta/edit/changeMetricGroupModal.tsx
@@ -8,7 +8,6 @@ import { noop } from '@spinnaker/core';
 import * as Creators from '../actions/creators';
 import { ICanaryState } from '../reducers/index';
 import { ICanaryMetricConfig } from '../domain/ICanaryConfig';
-import { UNGROUPED } from './groupTabs';
 import Styleguide from '../layout/styleguide';
 
 interface IChangeMetricGroupModalOwnProps {
@@ -62,13 +61,8 @@ function mapStateToProps(state: ICanaryState, { metric }: IChangeMetricGroupModa
   // If a metric belongs to more than one group, allow a move into one of those groups.
   // e.g., a [system, requests] -> [requests] move should be allowed, but
   // don't offer a [system] -> [system] move.
-  let groups = state.selectedConfig.group.list.filter(g => metric.groups.length > 1 || !metric.groups.includes(g));
-  const isGroupedMetric = !!metric.groups.length;
-  if (isGroupedMetric) {
-    groups = groups.concat([UNGROUPED]);
-  }
   return {
-    groups,
+    groups: state.selectedConfig.group.list.filter(g => metric.groups.length > 1 || !metric.groups.includes(g)),
     toGroup: state.selectedConfig.changeMetricGroup.toGroup,
   };
 }

--- a/src/kayenta/edit/groupTabs.tsx
+++ b/src/kayenta/edit/groupTabs.tsx
@@ -6,7 +6,6 @@ import * as Creators from '../actions/creators';
 import { Tabs, Tab } from '../layout/tabs';
 import GroupName from './groupName';
 
-export const UNGROUPED = '(ungrouped)';
 export const ALL = 'all';
 
 
@@ -45,7 +44,6 @@ function GroupTabs({ groupList, selectedGroup, selectGroup, addGroup, editing, e
       <Tabs>
         <GroupTab group=""/>
         {groupList.map(group => <GroupTab key={group} group={group} editable={true}/>)}
-        <GroupTab group={UNGROUPED}/>
         <button className="passive float-right" onClick={addGroup}>Add Group</button>
       </Tabs>
     </section>

--- a/src/kayenta/reducers/group.ts
+++ b/src/kayenta/reducers/group.ts
@@ -13,9 +13,13 @@ export interface IGroupState {
 }
 
 function groupsFromMetrics(metrics: ICanaryMetricConfig[] = []) {
-  return metrics.reduce((groups, metric) => {
+  const results = metrics.reduce((groups, metric) => {
     return groups.concat(metric.groups.filter((group: string) => !groups.includes(group)))
   }, []).sort();
+  if (!results.length) {
+    results.push('Group 1');
+  }
+  return results;
 }
 
 const list = handleActions({

--- a/src/kayenta/reducers/selectedConfig.spec.ts
+++ b/src/kayenta/reducers/selectedConfig.spec.ts
@@ -111,17 +111,6 @@ describe('Reducer: changeMetricGroupConfirmReducer', () => {
     ).toEqual(['b']);
   });
 
-  it('clears groups given group \'(ungrouped)\'', () => {
-    const state = createSelectedConfigState(['myGroup'], '(ungrouped)');
-    const action = createAction('1');
-
-    const updatedState = changeMetricGroupConfirmReducer(state, action);
-
-    expect(
-      updatedState.metricList.find(m => m.id === '1').groups
-    ).toEqual([]);
-  });
-
   const createAction = (metricId: string) => ({
     type: Actions.CHANGE_METRIC_GROUP_CONFIRM,
     payload: {


### PR DESCRIPTION
`groups` is now required and cannot be an empty array, so...let's always include an empty group ("Group 1") if there are no groups (because there are no metrics).

When creating a new metric, we'll just set the group to the first one, unless the user is on a specific tab.

We might consider removing the "change groups" button/modal, depending on user feedback, since it's part of the "Edit" modal now.

I added some validation in the JSON editor, which feels like maybe overkill, as we could probably do a lot of validation in there and should maybe come up with a better way to do that (or don't do it at all, beyond validating the JSON itself is valid - I am fine with that option).