### PR TITLE
fix: prevent race condition when switching between applications

### DIFF
--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -31,6 +31,9 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
     };
 
     const afterConfigsLoad = (application: Application) => {
+      if (application !== canaryStore.getState().data.application) {
+        return;
+      }
       canaryStore.dispatch(Creators.updateConfigSummaries({
         configSummaries: application.getDataSource('canaryConfigs').data as ICanaryConfigSummary[],
       }));
@@ -56,6 +59,9 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
     };
 
     const afterJudgesLoad = (application: Application) => {
+      if (application !== canaryStore.getState().data.application) {
+        return;
+      }
       canaryStore.dispatch(Creators.updateJudges({
         judges: application.getDataSource('canaryJudges').data as IJudge[],
       }));
@@ -86,6 +92,9 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
     };
 
     const afterCanaryExecutionsLoaded = (application: Application) => {
+      if (application !== canaryStore.getState().data.application) {
+        return;
+      }
       canaryStore.dispatch(Creators.loadExecutionsSuccess({
         executions: application.getDataSource('canaryExecutions').data as ICanaryExecutionStatusResult[],
       }));

--- a/src/kayenta/canary.tsx
+++ b/src/kayenta/canary.tsx
@@ -36,13 +36,23 @@ export default class Canary extends React.Component<ICanaryProps> {
   constructor(props: ICanaryProps) {
     super(props);
     this.store = canaryStore;
+    this.initializeAppState(props.app);
+  }
+
+  public componentWillReceiveProps(nextProps: ICanaryProps) {
+    if (this.props.app.name !== nextProps.app.name) {
+      this.initializeAppState(nextProps.app)
+    }
+  }
+
+  private initializeAppState(app: Application): void {
     this.store.dispatch({
       type: INITIALIZE,
       state: {
         data: {
-          application: props.app,
-          configSummaries: props.app.getDataSource('canaryConfigs').data as ICanaryConfigSummary[],
-          judges: props.app.getDataSource('canaryJudges').data as IJudge[],
+          application: app,
+          configSummaries: app.getDataSource('canaryConfigs').data as ICanaryConfigSummary[],
+          judges: app.getDataSource('canaryJudges').data as IJudge[],
         },
       },
     });


### PR DESCRIPTION
This is possibly a larger problem in Deck generally, but it's noticeable in kayenta right now.

If an application is loading its reports, and they take a while, and you switch to a different application, and its reports load before the first application's, when the first application's reports finally load, they will replace the current application's reports in the view.