### PR TITLE
refactor: move config, canaryExecutionRequest, metricSetPairListId out of canary result object

### DIFF
--- a/src/kayenta/domain/ICanaryExecutionStatusResult.ts
+++ b/src/kayenta/domain/ICanaryExecutionStatusResult.ts
@@ -11,13 +11,17 @@ export interface ICanaryExecutionStatusResult {
   application: string;
   pipelineId: string;
   parentPipelineExecutionId: string;
+  metricSetPairListId: string;
+  config: ICanaryConfig;
+  canaryExecutionRequest: ICanaryExecutionRequest;
+  storageAccountName: string;
 }
 
 export interface ICanaryResult {
   judgeResult: ICanaryJudgeResult;
-  config: ICanaryConfig;
-  canaryExecutionRequest: ICanaryExecutionRequest;
-  metricSetPairListId: string;
+  config: ICanaryConfig; // TODO: deprecated, use same field on parent; remove after 5/1/18
+  canaryExecutionRequest: ICanaryExecutionRequest; // TODO: deprecated, use same field on parent; remove after 5/1/18
+  metricSetPairListId: string; // TODO: deprecated, use same field on parent; remove after 5/1/18
 }
 
 export interface ICanaryExecutionRequest {

--- a/src/kayenta/middleware/epics.ts
+++ b/src/kayenta/middleware/epics.ts
@@ -95,7 +95,7 @@ const loadMetricSetPairEpic = (action$: Observable<Action & any>, store: Middlew
     .filter(typeMatches(Actions.LOAD_METRIC_SET_PAIR_REQUEST))
     .concatMap(action => {
       const run = runSelector(store.getState());
-      return Observable.fromPromise(getMetricSetPair(run.result.metricSetPairListId, action.payload.pairId))
+      return Observable.fromPromise(getMetricSetPair(run.metricSetPairListId || run.result.metricSetPairListId, action.payload.pairId))
         .map(metricSetPair => Creators.loadMetricSetPairSuccess({ metricSetPair }))
         .catch((error: Error) => Observable.of(Creators.loadMetricSetPairFailure({ error })))
     });

--- a/src/kayenta/report/detail/metricResultStats.tsx
+++ b/src/kayenta/report/detail/metricResultStats.tsx
@@ -91,12 +91,13 @@ const MetricResultStats = ({ metricConfig, metricSetPair, run }: IMetricResultSt
       label: 'start',
       getValue: target => <FormattedDate dateIso={metricSetPair.scopes[target].startTimeIso}/>,
       hide: () => {
+        const request = run.canaryExecutionRequest || run.result.canaryExecutionRequest;
         const configuredControlStart =
-          run.result.canaryExecutionRequest.scopes[metricConfig.scopeName].controlScope.start;
+          request.scopes[metricConfig.scopeName].controlScope.start;
         const actualControlStart = metricSetPair.scopes.control.startTimeIso;
 
         const configuredExperimentStart =
-          run.result.canaryExecutionRequest.scopes[metricConfig.scopeName].experimentScope.start;
+          request.scopes[metricConfig.scopeName].experimentScope.start;
         const actualExperimentStart = metricSetPair.scopes.experiment.startTimeIso;
 
         return configuredControlStart === actualControlStart

--- a/src/kayenta/report/detail/reportMetadata.tsx
+++ b/src/kayenta/report/detail/reportMetadata.tsx
@@ -28,7 +28,8 @@ const Label = ({ label, extraClass }: { label: string, extraClass?: string }) =>
 
 // TODO(dpeach): this only supports canary runs with a single scope.
 const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadataGroup[] => {
-  const scopes = Object.values(run.result.canaryExecutionRequest.scopes);
+  const request = run.canaryExecutionRequest || run.result.canaryExecutionRequest;
+  const scopes = Object.values(request.scopes);
   if (scopes.length > 1) {
     return null;
   }
@@ -105,7 +106,7 @@ const ReportMetadata = ({ run }: IReportMetadata) => {
       marginal,
       pass
     },
-  } = run.result.canaryExecutionRequest;
+  } = run.canaryExecutionRequest || run.result.canaryExecutionRequest;
 
   const metadataGroups = (buildScopeMetadataEntries(run) || []);
   metadataGroups.push({

--- a/src/kayenta/report/detail/reportScores.tsx
+++ b/src/kayenta/report/detail/reportScores.tsx
@@ -55,7 +55,9 @@ const mapStateToProps = (state: ICanaryState): IReportScoresStateProps => ({
     ]
   ),
   score: judgeResultSelector(state).score,
-  scoreThresholds: state.selectedRun.run.result.canaryExecutionRequest.thresholds,
+  scoreThresholds: state.selectedRun.run.canaryExecutionRequest ?
+    state.selectedRun.run.canaryExecutionRequest.thresholds :
+    state.selectedRun.run.result.canaryExecutionRequest.thresholds,
   selectedGroup: state.selectedRun.selectedGroup,
 });
 

--- a/src/kayenta/report/detail/sourceLinks.tsx
+++ b/src/kayenta/report/detail/sourceLinks.tsx
@@ -4,6 +4,7 @@ import { SETTINGS } from '@spinnaker/core';
 import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryState } from 'kayenta/reducers';
 import { runSelector, serializedCanaryConfigSelector } from 'kayenta/selectors';
+import { ICanaryExecutionStatusResult } from 'kayenta/domain';
 
 interface ISourceJsonStateProps {
   reportUrl: string;
@@ -25,19 +26,23 @@ const SourceLinks = ({ reportUrl, metricListUrl }: ISourceJsonStateProps) => {
 
 const resolveReportUrl = (state: ICanaryState): string => {
   const canaryConfigId = serializedCanaryConfigSelector(state).id;
-  const canaryRunId = runSelector(state).id;
+  const result: ICanaryExecutionStatusResult = runSelector(state);
+  const canaryRunId = result.id;
   let url = `${SETTINGS.gateUrl}/v2/canaries/canary/${canaryConfigId}/${canaryRunId}`;
-  if (CanarySettings.storageAccountName) {
-    url += `?storageAccountName=${CanarySettings.storageAccountName}`;
+  const storageAccountName = result.storageAccountName || CanarySettings.storageAccountName;
+  if (storageAccountName) {
+    url += `?storageAccountName=${storageAccountName}`;
   }
   return url;
 };
 
 const resolveMetricListUrl = (state: ICanaryState): string => {
-  const metricSetPairListId = runSelector(state).result.metricSetPairListId;
+  const status = runSelector(state);
+  const metricSetPairListId = status.metricSetPairListId || status.result.metricSetPairListId;
   let url = `${SETTINGS.gateUrl}/v2/canaries/metricSetPairList/${metricSetPairListId}`;
-  if (CanarySettings.storageAccountName) {
-    url += `?storageAccountName=${CanarySettings.storageAccountName}`;
+  const storageAccountName = status.storageAccountName || CanarySettings.storageAccountName;
+  if (storageAccountName) {
+    url += `?storageAccountName=${storageAccountName}`;
   }
   return url;
 };

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -17,7 +17,7 @@ const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
     label: 'Config',
     getContent: execution => (
       <ConfigLink
-        configName={execution.result.config.name}
+        configName={execution.config ? execution.config.name : execution.result.config.name}
         application={execution.application}
       />
     ),
@@ -51,7 +51,7 @@ const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
   {
     getContent: execution => (
       <ReportLink
-        configName={execution.result.config.name}
+        configName={execution.config ? execution.config.name : execution.result.config.name}
         executionId={execution.pipelineId}
         application={execution.application}
       />

--- a/src/kayenta/selectors/index.ts
+++ b/src/kayenta/selectors/index.ts
@@ -13,7 +13,7 @@ export const judgeResultSelector = createSelector(
 
 export const configIdSelector = createSelector(
   runSelector,
-  run => run.result.config.id,
+  run => run.config ? run.config.id : run.result.config.id,
 );
 
 export const metricResultsSelector = createSelector(
@@ -23,7 +23,7 @@ export const metricResultsSelector = createSelector(
 
 export const serializedCanaryConfigSelector = createSelector(
   runSelector,
-  run => run.result.config,
+  run => run.config || run.result.config,
 );
 
 export const serializedGroupWeightsSelector = createSelector(

--- a/src/kayenta/service/canaryRun.service.ts
+++ b/src/kayenta/service/canaryRun.service.ts
@@ -12,7 +12,8 @@ export const getCanaryRun = (configId: string, canaryExecutionId: string): Promi
     .useCache()
     .get()
     .then((run: ICanaryExecutionStatusResult) => {
-      run.result.config.id = configId;
+      const config = run.config || run.result.config;
+      config.id = configId;
       run.id = canaryExecutionId;
       run.result.judgeResult.results = sortBy(run.result.judgeResult.results, 'name');
       return run;


### PR DESCRIPTION
@skandragon is making some changes to the payload structure, moving several fields out of the `result` object and up a level. Also, `storageAccountName` is being added as a field on the top level report and should be used to retrieve metrics.

Trying to maintain backwards compatibility for a month or so with the deprecation notice in the code. When those fields are removed, Typescript should flag the other changes that need to be made to remove the bridge code, where we are checking in both spots.

Tested locally against existing canary reports but would appreciate some eyes, as I'm still not super familiar with the codebase.