### PR TITLE
chore: bump package to 0.0.32

### DIFF
--- a/build_scripts/checkLicenses.js
+++ b/build_scripts/checkLicenses.js
@@ -8,14 +8,29 @@ const ALLOWED_LICENSES = [
   'Apache-2.0',
   'Apache v2.0',
   'BSD',
+  'BSD*',
   'BSD-2-Clause',
   'BSD-3-Clause',
   'BSD-3-Clause OR MIT',
+  'FreeBSD',
   '(GPL-2.0 OR MIT)',
   'ISC',
   'MIT',
   'MIT*',
+  '(MIT AND CC-BY-3.0)',
   'MPL-2.0 OR Apache-2.0',
+  'Unlicense',
+  'Zlib',
+];
+
+// packages where the license checker makes a bad guess, but the packages themselves have been manually verified to have
+// a valid license
+const IGNORED = [
+  'weak-map@1.0.5', // Apache 2.0 - https://github.com/drses/weak-map
+  'colors@0.6.2', // MIT - https://github.com/Marak/colors.js/blob/master/LICENSE
+  'gl-mat2@1.0.1', // ZLib - https://github.com/stackgl/gl-mat2
+  'gl-mat3@1.0.0', // ZLib - https://github.com/stackgl/gl-mat3
+  'gl-vec3@1.0.3', // ZLib - https://github.com/stackgl/gl-vec3
 ];
 
 const cb = (err, licenses) => {
@@ -27,9 +42,11 @@ const cb = (err, licenses) => {
       .filter(([pkg, properties]) => !ALLOWED_LICENSES.includes(properties.licenses));
     if (unknownLicenses.length) {
       unknownLicenses.forEach(([pkg, properties]) => {
-        console.log(`Package ${pkg} found with license ${properties.licenses}`);
+        if (!IGNORED.includes(pkg)) {
+          console.log(`Package ${pkg} found with license ${properties.licenses}`);
+          process.exitCode = 1;
+        }
       });
-      process.exitCode = 1;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "lib/lib.js",
   "typings": "lib/kayenta/index.d.ts",
   "name": "@spinnaker/kayenta",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some of the new dependencies have packages that the library checker is not finding, so I've put in some manual overrides.

@danielpeach PTAL...