### PR TITLE
fix: naming/rendering tweaks

### DIFF
--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -33,7 +33,7 @@ const helpContents: {[key: string]: string} = {
   'pipeline.config.canary.extendedScopeParams': `
         <p>Metric source specific parameters which may be used to further alter the canary scope.</p>
         <p>Also used to provide variable bindings for use in the expansion of custom filter templates within the canary config.</p>`,
-  'pipeline.config.canary.lookback': '<p>With an analysis type of <strong>Growing</strong>, the entire duration of the canary will be considered during the analysis.</p><p>When choosing <strong>Sliding Lookback</strong>, the canary will use the most recent number of specified minutes for its analysis report (<b>useful for long running canaries that span multiple days</b>).</p>',
+  'pipeline.config.canary.lookback': '<p>With an analysis type of <strong>Growing</strong>, the entire duration of the canary will be considered during the analysis.</p><p>When choosing <strong>Sliding</strong>, the canary will use the most recent number of specified minutes for its analysis report (<b>useful for long running canaries that span multiple days</b>).</p>',
   'pipeline.config.canary.continueOnUnhealthy': '<p>Continue the pipeline if the canary analysis comes back as <b>UNHEALTHY</b></p>',
   'pipeline.config.canary.owner': '<p>The recipient email to which the canary report(s) will be sent.</p>',
   'pipeline.config.canary.watchers': '<p>Comma separated list of additional emails to receive canary reports. Owners are automatically subscribed to notification emails.</p>',

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -13,6 +13,7 @@ import Styleguide from 'kayenta/layout/styleguide';
 import FormRow from 'kayenta/layout/formRow';
 import KayentaInput from 'kayenta/layout/kayentaInput';
 import { configTemplatesSelector } from 'kayenta/selectors';
+import { CanarySettings } from 'kayenta/canary.settings';
 
 import './editMetricModal.less';
 
@@ -51,6 +52,10 @@ interface IFilterTemplateSelectorProps {
 function FilterTemplateSelector({ metricStore, template, templates, select }: IFilterTemplateSelectorProps) {
   const config = metricStoreConfigService.getDelegate(metricStore);
   if (!config || !config.useTemplates) {
+    return null;
+  }
+
+  if (!CanarySettings.templatesEnabled) {
     return null;
   }
 

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -14,17 +14,6 @@
     </select>
   </stage-config-field>
 
-  <stage-config-field label="Lifetime"
-                      help-key="pipeline.config.canary.analysisType"
-                      field-columns="3"
-                      ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'realTime'">
-    <input type="text"
-           ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.lifetimeHours"
-           class="form-control input-sm"
-           style="display: inline-block; width: 33%"/>
-    <span class="form-control-static">hours</span>
-  </stage-config-field>
-
   <!--
   TODO: Revisit this when this canary stage ui is used for canaries employing Atlas.
   <stage-config-field label="Result Strategy"
@@ -80,12 +69,12 @@
       <span class="form-control-static"> minutes</span>
     </stage-config-field>
 
-    <stage-config-field label="Analysis Type"
+    <stage-config-field label="Lookback Type"
                         help-key="pipeline.config.canary.lookback"
                         field-columns="3">
       <select class="form-control input-sm"
               ng-model="kayentaCanaryStageCtrl.state.useLookback"
-              ng-options="(useLookback ? 'Sliding Lookback' : 'Growing') for useLookback in [false, true]"
+              ng-options="(useLookback ? 'Sliding' : 'Growing') for useLookback in [false, true]"
               ng-change="kayentaCanaryStageCtrl.onUseLookbackChange()">
       </select>
     </stage-config-field>
@@ -187,6 +176,17 @@
         class="form-control input-sm"
         ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].endTimeIso"
         type="text"/>
+    </stage-config-field>
+
+    <stage-config-field label="Lifetime"
+                        help-key="pipeline.config.canary.analysisType"
+                        field-columns="3"
+                        ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'realTime'">
+      <input type="text"
+             ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.lifetimeHours"
+             class="form-control input-sm"
+             style="display: inline-block; width: 33%"/>
+      <span class="form-control-static">hours</span>
     </stage-config-field>
 
     <stage-config-field label="Resource Type" ng-if="kayentaCanaryStageCtrl.metricStore === 'prometheus'">

--- a/src/kayenta/stages/kayentaStage/kayentaStage.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.ts
@@ -302,7 +302,7 @@ module(KAYENTA_CANARY_STAGE, [
   ])
   .config((pipelineConfigProvider: PipelineConfigProvider) => {
     pipelineConfigProvider.registerStage({
-      label: 'Canary',
+      label: 'Canary Analysis',
       description: 'Runs a canary task',
       key: 'kayentaCanary',
       templateUrl: require('./kayentaStage.html'),


### PR DESCRIPTION
Tweaks/fixes based on suggestions from @dorbin.

- Don't render the template select field if templates aren't enabled.
- Don't overload `Analysis Type` (used for `Real Time / Retrospective` and `Growing / Sliding Lookback`).
- Move canary lifetime under scope.
- Rename the `Canary` stage to `Canary Analysis` stage (perhaps the name could be revisited, but it provides stronger indication that the stage isn't provisioning server groups for you).