### PR TITLE
fix: make canary data source lazy/auto-activating

### DIFF
--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -75,7 +75,8 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
       loader: loadCanaryJudges,
       onLoad: judgesLoaded,
       afterLoad: afterJudgesLoad,
-      lazy: false,
+      lazy: true,
+      autoActivate: true,
     });
 
     const loadCanaryExecutions = (application: Application) => {
@@ -112,6 +113,7 @@ module(CANARY_DATA_SOURCE, [APPLICATION_DATA_SOURCE_REGISTRY])
       loader: loadCanaryExecutions,
       onLoad: canaryExecutionsLoaded,
       afterLoad: afterCanaryExecutionsLoaded,
-      lazy: false,
+      lazy: true,
+      autoActivate: true,
     });
   });


### PR DESCRIPTION
If these data sources are eager, but the load calls fail, the application will never reach its ready state, which is bad, as we learned tonight.