### PR TITLE
fix: find canary config id from execution instead of app / config name pair

### DIFF
--- a/src/kayenta/report/list/configLink.tsx
+++ b/src/kayenta/report/list/configLink.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ICanaryState } from 'kayenta/reducers';
-import { resolveConfigIdFromNameAndApplication } from 'kayenta/selectors';
+import { resolveConfigIdFromExecutionId } from 'kayenta/selectors';
 import { Link } from './link';
 
 interface IConfigLinkOwnProps {
   configName: string;
+  executionId: string;
   application: string;
 }
 
@@ -27,7 +28,7 @@ export const ConfigLink = ({ configId, configName }: IConfigLinkOwnProps & IConf
 
 const mapStateToProps = (state: ICanaryState, ownProps: IConfigLinkOwnProps): IConfigLinkStateProps & IConfigLinkOwnProps => {
   return {
-    configId: resolveConfigIdFromNameAndApplication(state, ownProps.configName, ownProps.application),
+    configId: resolveConfigIdFromExecutionId(state, ownProps.executionId),
     ...ownProps,
   };
 };

--- a/src/kayenta/report/list/reportLink.tsx
+++ b/src/kayenta/report/list/reportLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ICanaryState } from 'kayenta/reducers';
-import { resolveConfigIdFromNameAndApplication } from 'kayenta/selectors';
+import { resolveConfigIdFromExecutionId } from 'kayenta/selectors';
 import { Link } from './link';
 
 interface IReportLinkOwnProps {
@@ -29,7 +29,7 @@ export const ReportLink = ({ configId, executionId }: IReportLinkOwnProps & IRep
 
 const mapStateToProps = (state: ICanaryState, ownProps: IReportLinkOwnProps): IReportLinkStateProps & IReportLinkOwnProps => {
   return {
-    configId: resolveConfigIdFromNameAndApplication(state, ownProps.configName, ownProps.application),
+    configId: resolveConfigIdFromExecutionId(state, ownProps.executionId),
     ...ownProps,
   };
 };

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -18,6 +18,7 @@ const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
     getContent: execution => (
       <ConfigLink
         configName={execution.config ? execution.config.name : execution.result.config.name}
+        executionId={execution.pipelineId}
         application={execution.application}
       />
     ),

--- a/src/kayenta/selectors/index.ts
+++ b/src/kayenta/selectors/index.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { get } from 'lodash';
 
 import { ICanaryState } from '../reducers/index';
 import { ICanaryConfig } from 'kayenta/domain/index';
@@ -56,9 +57,8 @@ export const configTemplatesSelector = createSelector(
 
 export const editingTemplateSelector = (state: ICanaryState) => state.selectedConfig.editingTemplate;
 
-// TODO(dpeach): temporary workaround because a config doesn't return with its own ID.
-export const resolveConfigIdFromNameAndApplication = (state: ICanaryState, configName: string, application: string): string => {
-  const config = state.data.configSummaries.find(summary =>
-    summary.name === configName && summary.applications.includes(application));
-  return config && config.id;
+export const resolveConfigIdFromExecutionId = (state: ICanaryState, executionId: string): string => {
+  const executions = get(state, ['data', 'executions', 'data'], [])
+  const execution = executions.find(ex => ex.pipelineId === executionId);
+  return execution.canaryConfigId;
 };


### PR DESCRIPTION
fixes https://github.com/spinnaker/deck-kayenta/issues/292