### PR TITLE
fix: overall score

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
@@ -57,17 +57,17 @@ export class KayentaStageTransformer implements ITransformer {
         // If we made it through the final scheduled canary run, this should
         // be the same as the value returned from `getLastCanaryRunScore`,
         // but this is also how Orca determines the overall score.
-        kayentaStage.overallScore = last(kayentaStage.getValueFor('canaryScores'));
+        kayentaStage.context.overallScore = last(kayentaStage.getValueFor('canaryScores'));
       } else {
-        kayentaStage.overallScore = this.getLastCanaryRunScore(runCanaryStages);
+        kayentaStage.context.overallScore = this.getLastCanaryRunScore(runCanaryStages);
       }
-      kayentaStage.overallScore = round(kayentaStage.overallScore, 2);
+      kayentaStage.context.overallScore = round(kayentaStage.context.overallScore, 2);
 
       if (!kayentaStage.isCanceled) {
         if (kayentaStage.status === 'SUCCEEDED') {
-          kayentaStage.overallResult = 'success';
+          kayentaStage.context.overallResult = 'success';
         } else {
-          kayentaStage.overallHealth = 'unhealthy';
+          kayentaStage.context.overallHealth = 'unhealthy';
         }
       }
     }

--- a/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
@@ -4,9 +4,9 @@
     <div class="row">
       <div class="col-md-2 canary-summary">
         <div class="score score-large">
-          <kayenta-canary-score score="stage.overallScore"
-                                health="stage.overallHealth"
-                                result="stage.overallResult"></kayenta-canary-score>
+          <kayenta-canary-score score="stage.context.overallScore"
+                                health="stage.context.overallHealth"
+                                result="stage.context.overallResult"></kayenta-canary-score>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes https://github.com/spinnaker/kayenta/issues/291 (the remaining issues had already been solved).

@anotherchrisberry I moved the overall score down to `kayentaStage.context` (I think it makes sense for it to live down there, so that's fine), but any mutations to the top-level stage object within the transformer are lost by the time it makes it to the execution controller. Any ideas? I'm assuming it's related to your recent changes around context.