### PR TITLE
fix: commit tab name change if user navigates away while editing

### DIFF
--- a/src/kayenta/edit/groupName.tsx
+++ b/src/kayenta/edit/groupName.tsx
@@ -29,7 +29,7 @@ export interface IGroupNameOwnProps {
 function GroupName({ editing, edit, group, onClick, handleUpdate, handleSubmit, defaultGroup }: IGroupNameStateProps & IGroupNameDispatchProps & IGroupNameOwnProps) {
   if (editing) {
     return (
-      <form onSubmit={handleSubmit} data-group={group} data-edit={edit}>
+      <form onSubmit={handleSubmit} onBlur={handleSubmit} data-group={group} data-edit={edit}>
         <DisableableInput
           autoFocus={true}
           value={edit}
@@ -58,7 +58,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IGroupNam
       dispatch(Creators.editGroupUpdate({ edit: event.target.value }));
     },
     handleSubmit: (event: any) => {
-      dispatch(Creators.editGroupConfirm({ ...event.target.dataset }));
+      dispatch(Creators.editGroupConfirm({ ...event.currentTarget.dataset }));
       event.stopPropagation();
       event.preventDefault();
     },


### PR DESCRIPTION
fixes https://github.com/spinnaker/deck-kayenta/issues/286

Before, strange input box follows user around UI:

![fyezv933d0n](https://user-images.githubusercontent.com/34253460/39017770-23bd2cdc-43f2-11e8-83cc-5ecf8cdaad8b.png)

After, change to tab name is committed and user is prompted to cancel the change if they want to navigate away:

<img width="922" alt="screen shot 2018-04-19 at 4 50 49 pm" src="https://user-images.githubusercontent.com/34253460/39017719-fe5236d6-43f1-11e8-8c2f-fb11e5c7600e.png">
