### PR TITLE
feat(report): add link to Atlas UI for graphing baseline vs. canary metrics

### DIFF
--- a/src/kayenta/canary.settings.ts
+++ b/src/kayenta/canary.settings.ts
@@ -11,6 +11,7 @@ export interface ICanarySettings {
   featureDisabled: boolean;
   optInAll: boolean;
   atlasWebComponentsUrl: string;
+  atlasGraphBaseUrl: string;
   templatesEnabled: boolean;
 }
 

--- a/src/kayenta/domain/IMetricSetPair.ts
+++ b/src/kayenta/domain/IMetricSetPair.ts
@@ -2,6 +2,10 @@ export interface IMetricSetPair {
   name: string;
   id: string;
   tags: {[key: string]: string};
+  attributes: {
+    control: { [key: string]: string };
+    experiment: { [key: string]: string };
+  };
   values: {[key: string]: number[]};
   scopes: {[key: string]: IMetricSetScope};
 }


### PR DESCRIPTION
We have consumers that need to be able to jump into the Atlas UI to dig deeper into a given metric for troubleshooting/analysis. I'm unsure of what an equivalent sort of link looks like for the other metric stores, and as a result have intentionally made this a bit special-cased to avoid choosing a bad/unhelpful indirection layer. If someone thinks this would be useful for other metric stores and wants to generalize it, that'd be awesome.

<img width="716" alt="screen_shot_2018-06-08_at_2_48_22_pm" src="https://user-images.githubusercontent.com/1850998/41245265-6b3720d4-6d5c-11e8-8382-1c015899bfd7.png">
