### PR TITLE
chore: bump to 0.0.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "lib/lib.js",
   "typings": "lib/kayenta/index.d.ts",
   "name": "@spinnaker/kayenta",
-  "version": "0.0.48",
+  "version": "0.0.50",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
we skipped a version because somebody published without a commit.