### PR TITLE
feat(executions): indicate canary runs that might be low-confidence

### DIFF
--- a/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
+++ b/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { has } from 'lodash';
+import { get, has } from 'lodash';
 
 import { HoverablePopover, IStage, timestamp, NgReact, ReactInjector } from '@spinnaker/core';
 import { CanaryScore } from 'kayenta/components/canaryScore';
@@ -24,14 +24,24 @@ const canaryRunColumns: ICanaryRunColumn[] = [
   {
     label: 'Canary Result',
     width: 2,
-    getContent: run => (
-      <CanaryScore
-        score={run.context.canaryScore}
-        health={run.health}
-        result={run.result}
-        inverse={false}
-      />
-    ),
+    getContent: run => {
+      return (
+        <span>
+          <CanaryScore
+            score={run.context.canaryScore}
+            health={run.health}
+            result={run.result}
+            inverse={false}
+          />
+          { get(run, ['context', 'warnings'], []).length > 0 && (
+              <HoverablePopover template={<CanaryRunWarningMessages messages={run.context.warnings} />}>
+                <i className="fa fa-exclamation-triangle" style={{ paddingLeft: '8px' }}/>
+              </HoverablePopover>
+            )
+          }
+        </span>
+      );
+    },
   },
   {
     label: 'Duration',
@@ -147,4 +157,16 @@ function ReportLink({ canaryRun }: { canaryRun: IStage }) {
     );
 
   return <i className="fa fa-chart-bar clickable" onClick={onClick}/>;
+}
+
+function CanaryRunWarningMessages({ messages }: { messages: string[] }) {
+  return <div>
+    {
+      messages.map((message, i) =>
+        <p key={`${i}-${message}`}>
+          {message}
+        </p>
+      )
+    }
+  </div>;
 }


### PR DESCRIPTION
Excludes the datadog provider from receiving the indicator as per https://github.com/spinnaker/kayenta/issues/283#issuecomment-397346975

Also: I've made the assumption that all metrics will receive the same number of data points for a given run.  If this isn't correct then I can include mention of exactly which metrics were below the confidence threshold.

The indicator is a small warning triangle:
<img width="427" alt="screen shot 2018-06-21 at 1 49 55 pm" src="https://user-images.githubusercontent.com/34253460/41736293-111804f0-755a-11e8-895e-702fdaf34089.png">

And the message that appears when the triangle is hovered:
<img width="420" alt="screen shot 2018-06-21 at 1 50 07 pm" src="https://user-images.githubusercontent.com/34253460/41736307-151d32dc-755a-11e8-9030-599fdac343fe.png">
