### PR TITLE
fix: support polyfilling for atlas web components

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -11,6 +11,7 @@ var defaultMetricStore = process.env.METRIC_STORE || 'atlas';
 var canaryStagesEnabled = process.env.CANARY_STAGES_ENABLED === 'true';
 var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
 var atlasWebComponentsUrl = process.env.ATLAS_WEB_COMPONENTS_URL;
+var atlasWebComponentsPolyfillUrl = process.env.ATLAS_WEB_COMPONENTS_POLYFILL_URL;
 var canaryAccount = process.env.CANARY_ACCOUNT || 'my-google-account';
 
 window.spinnakerSettings = {
@@ -86,6 +87,7 @@ window.spinnakerSettings = {
     metricStore: defaultMetricStore,
     stagesEnabled: canaryStagesEnabled,
     atlasWebComponentsUrl: atlasWebComponentsUrl,
+    atlasWebComponentsPolyfillUrl: atlasWebComponentsPolyfillUrl,
     templatesEnabled: templatesEnabled,
     showAllConfigs: true,
   },

--- a/src/kayenta/canary.settings.ts
+++ b/src/kayenta/canary.settings.ts
@@ -11,6 +11,7 @@ export interface ICanarySettings {
   featureDisabled: boolean;
   optInAll: boolean;
   atlasWebComponentsUrl: string;
+  atlasWebComponentsPolyfillUrl: string;
   atlasGraphBaseUrl: string;
   templatesEnabled: boolean;
 }

--- a/src/kayenta/metricStore/atlas/atlasMetricConfigurer.tsx
+++ b/src/kayenta/metricStore/atlas/atlasMetricConfigurer.tsx
@@ -40,10 +40,16 @@ if (CanarySettings.atlasWebComponentsUrl) {
   const global = window as any;
   global['React'] = React;
   global['ReactDOM'] = ReactDOM;
+
+  if (CanarySettings.atlasWebComponentsPolyfillUrl) {
+    const polyfillScript = document.createElement('script');
+    polyfillScript.src = CanarySettings.atlasWebComponentsPolyfillUrl;
+    document.head.appendChild(polyfillScript);
+  }
   // download components; they will register when the script executes
-  const script = document.createElement('script');
-  script.src = CanarySettings.atlasWebComponentsUrl;
-  document.head.appendChild(script);
+  const componentScript = document.createElement('script');
+  componentScript.src = CanarySettings.atlasWebComponentsUrl;
+  document.head.appendChild(componentScript);
 }
 
 // Add <atlas-query-selector> to the elements allowed in TSX, using the AtlasQuerySelector interface.


### PR DESCRIPTION
Turns out that on Firefox (and probably Safari?) the Atlas web components we use to configure metrics require some polyfilling to register themselves. I decided to plop this in a setting given that it's a bit niche.