### PR TITLE
feat: real time automatic mode

### DIFF
--- a/build_scripts/webpack.build.js
+++ b/build_scripts/webpack.build.js
@@ -14,7 +14,7 @@ const exclusionPattern = /(node_modules|\.\.\/deck)/;
 module.exports = {
   context: basePath,
   entry: {
-    lib: path.join(basePath, 'src', 'kayenta', 'index.ts'),
+    lib: ['babel-polyfill', path.join(basePath, 'src', 'kayenta', 'index.ts')],
   },
   output: {
     path: path.join(basePath, 'lib'),
@@ -24,7 +24,10 @@ module.exports = {
     umdNamedDefine: true,
   },
   externals: [
-    nodeExternals({ modulesDir: NODE_MODULE_PATH }),
+    nodeExternals({
+      modulesDir: NODE_MODULE_PATH,
+      whitelist: ['babel-polyfill'],
+    }),
   ],
   resolve: {
     extensions: ['.json', '.js', '.jsx', '.ts', '.tsx', '.css', '.less', '.html'],

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "angular-ui-bootstrap": "^2.5.0",
     "angular-ui-router": "1.0.0",
     "angular-ui-sortable": "^0.17.0",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-polyfill": "^6.26.0",
     "bootstrap": "3.3.7",
     "cachefactory": "^3.0.0",
     "chart.js": "^2.7.0",
@@ -76,7 +78,7 @@
   },
   "devDependencies": {
     "@spinnaker/amazon": "^0.0.104",
-    "@spinnaker/core": "0.0.237",
+    "@spinnaker/core": "0.0.259",
     "@spinnaker/styleguide": "^1.0.1",
     "@types/angular": "1.6.26",
     "@types/angular-mocks": "^1.5.10",

--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -4,10 +4,16 @@ const helpContents: {[key: string]: string} = {
   'pipeline.config.canary.clusterPairs': `
         <p>A <em>cluster pair</em> is used to create a baseline and canary cluster.</p>' +
         <p>The version currently deployed in the baseline cluster will be used to create a new baseline server group, while the version created in the previous bake or Find Image stage will be deployed into the canary.</p>`,
-  'pipeline.config.canary.analysisType': `
-        <p>The analysis type determines whether the canary analysis is performed over data points collected starting from the moment of execution and into the future, or over an explicitly-specified time interval.</p>
-        <p>The <strong>Real Time</strong> analysis type means that the canary analysis will be performed over a time interval beginning at the moment of execution.</p>
-        <p>The <strong>Retrospective</strong> analysis type means that the canary analysis will be performed over an explicitly-specified time interval (likely in the past).</p>`,
+  'pipeline.config.canary.analysisType.realTimeAutomatic': `
+        <p>The <strong>Real Time (Automatic)</strong> analysis type means that the canary analysis will be performed over a time interval beginning at the moment of execution.</p>
+        <p>For this analysis type, Spinnaker will provision and clean up the baseline and canary server groups.</p>`,
+  'pipeline.config.canary.analysisType.realTime': `
+        <p>The <strong>Real Time (Manual)</strong> analysis type means that the canary analysis will be performed over a time interval beginning at the moment of execution.</p>
+        <p>For this analysis type, you are responsible for provisioning and cleaning up the baseline and canary server groups.</p>`,
+  'pipeline.config.canary.analysisType.retrospective': `
+        <p>The <strong>Retrospective</strong> analysis type means that the canary analysis will be performed over an explicitly-specified time interval (likely in the past).</p>
+        <p>For this analysis type, you are responsible for provisioning and cleaning up the baseline and canary server groups.</p>
+  `,
   'pipeline.config.canary.resultStrategy': `
         <p>The result stategy is used to determine how to roll up a score if multiple clusters are participating in the canary.</p>
         <p>The <strong>lowest</strong> strategy means that the cluster with the lowest score is used as the rolled up score.</p>

--- a/src/kayenta/canary.module.ts
+++ b/src/kayenta/canary.module.ts
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import { module } from 'angular';
 
 import { CanarySettings } from 'kayenta/canary.settings';

--- a/src/kayenta/domain/IKayentaStageConfig.ts
+++ b/src/kayenta/domain/IKayentaStageConfig.ts
@@ -1,0 +1,62 @@
+export interface IKayentaStage {
+  canaryConfig: IKayentaStageCanaryConfig;
+  analysisType: KayentaAnalysisType;
+  deployments: IKayentaStageDeployments;
+  isNew: boolean;
+}
+
+export interface IKayentaStageCanaryConfig {
+  beginCanaryAnalysisAfterMins?: string;
+  canaryAnalysisIntervalMins: string;
+  canaryConfigId: string;
+  scopes: IKayentaStageCanaryConfigScope[];
+  combinedCanaryResultStrategy: string;
+  lifetimeHours?: string;
+  lifetimeDuration?: string;
+  lookbackMins?: string;
+  metricsAccountName: string;
+  scoreThresholds: {
+    pass: string;
+    marginal: string;
+  };
+  storageAccountName: string;
+}
+
+export interface IKayentaStageCanaryConfigScope {
+  scopeName: string;
+  controlScope?: string;
+  controlLocation?: string;
+  experimentScope?: string;
+  experimentLocation?: string;
+  startTimeIso?: string;
+  endTimeIso?: string;
+  step?: number;
+  extendedScopeParams: {[key: string]: string};
+}
+
+export interface IKayentaStageDeployments {
+  baseline: {
+    cloudProvider: string;
+    application: string;
+    account: string;
+    cluster: string;
+  };
+  serverGroupPairs: IKayentaServerGroupPair[];
+  delayBeforeCleanup: number;
+}
+
+export interface IKayentaServerGroupPair {
+  control: any;
+  experiment: any;
+}
+
+export interface IKayentaStageLifetime {
+  hours?: number;
+  minutes?: number;
+}
+
+export enum KayentaAnalysisType {
+  RealTimeAutomatic = 'realTimeAutomatic',
+  RealTime = 'realTime',
+  Retrospective = 'retrospective',
+}

--- a/src/kayenta/domain/index.ts
+++ b/src/kayenta/domain/index.ts
@@ -10,3 +10,4 @@ export * from './ISetupCanaryStage';
 export * from './ICanaryExecutionStatusResult';
 export * from './IMetricsServiceMetadata';
 export * from './ICanaryConfigUpdateResponse';
+export * from './IKayentaStageConfig';

--- a/src/kayenta/stages/kayentaStage/AnalysisType.tsx
+++ b/src/kayenta/stages/kayentaStage/AnalysisType.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { HelpField } from '@spinnaker/core';
+
+import { KayentaAnalysisType } from 'kayenta/domain';
+
+export interface IAnalysisTypeProps {
+  type: KayentaAnalysisType;
+  onChange(type: KayentaAnalysisType): void;
+}
+
+const HELP_FIELD_ID_PREFIX = 'pipeline.config.canary.analysisType';
+
+export const AnalysisType = ({ type, onChange }: IAnalysisTypeProps) => {
+  return (
+    <>
+      <div className="radio">
+        <label>
+          <input
+            type="radio"
+            name="analysisType"
+            checked={type === KayentaAnalysisType.RealTimeAutomatic}
+            onChange={() => onChange(KayentaAnalysisType.RealTimeAutomatic)}
+          />
+          Real Time (Automatic)
+          {' '}
+          <HelpField id={`${HELP_FIELD_ID_PREFIX}.${KayentaAnalysisType.RealTimeAutomatic}`}/>
+        </label>
+      </div>
+      <div className="radio">
+        <label>
+          <input
+            type="radio"
+            name="analysisType"
+            checked={type === KayentaAnalysisType.RealTime}
+            onChange={() => onChange(KayentaAnalysisType.RealTime)}
+          />
+          Real Time (Manual)
+          {' '}
+          <HelpField id={`${HELP_FIELD_ID_PREFIX}.${KayentaAnalysisType.RealTime}`}/>
+        </label>
+      </div>
+      <div className="radio">
+        <label>
+          <input
+            type="radio"
+            name="analysisType"
+            checked={type === KayentaAnalysisType.Retrospective}
+            onChange={() => onChange(KayentaAnalysisType.Retrospective)}
+          />
+          Retrospective
+          {' '}
+          <HelpField id={`${HELP_FIELD_ID_PREFIX}.${KayentaAnalysisType.Retrospective}`}/>
+        </label>
+      </div>
+    </>
+  );
+};

--- a/src/kayenta/stages/kayentaStage/analysisType.component.ts
+++ b/src/kayenta/stages/kayentaStage/analysisType.component.ts
@@ -1,0 +1,7 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { AnalysisType } from './AnalysisType';
+
+export const KAYENTA_ANALYSIS_TYPE_COMPONENT = 'spinnaker.kayenta.analysisType.component';
+module(KAYENTA_ANALYSIS_TYPE_COMPONENT, [])
+  .component('kayentaAnalysisType', react2angular(AnalysisType, ['type', 'onChange']));

--- a/src/kayenta/stages/kayentaStage/forAnalysisType.component.ts
+++ b/src/kayenta/stages/kayentaStage/forAnalysisType.component.ts
@@ -1,0 +1,42 @@
+import { IComponentController, module } from 'angular';
+import { $log } from 'ngimport';
+import { IKayentaStage, KayentaAnalysisType } from 'kayenta/domain';
+
+class ForAnalysisTypeController implements IComponentController {
+  private stage: IKayentaStage;
+  private types: string;
+
+  public showForAnalysisType = (): boolean => {
+    if (!this.stage) {
+      $log.warn('No stage bound to <for-analysis-type> component');
+    }
+    if (!this.types) {
+      $log.warn('No types bound to <for-analysis-type> component');
+    }
+
+    return (this.types || '')
+      .split(',')
+      .map(type => {
+        const val = type.trim() as KayentaAnalysisType;
+        if (![KayentaAnalysisType.Retrospective,
+              KayentaAnalysisType.RealTime,
+              KayentaAnalysisType.RealTimeAutomatic].includes(val)) {
+          $log.warn(`${val} is not a Kayenta analysis type.`);
+        }
+        return val;
+      })
+      .includes(this.stage.analysisType);
+  }
+}
+
+export const FOR_ANALYSIS_TYPE_COMPONENT = 'spinnaker.kayenta.forAnalysisType.component';
+module(FOR_ANALYSIS_TYPE_COMPONENT, [])
+  .component('forAnalysisType', {
+    bindings: {
+      types: '@',
+      stage: '<',
+    },
+    controller: ForAnalysisTypeController,
+    transclude: true,
+    template: '<ng-transclude ng-if="$ctrl.showForAnalysisType()"></ng-transclude>',
+  });

--- a/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
@@ -1,0 +1,548 @@
+import { IComponentController, ILogService, IScope } from 'angular';
+import { IModalService } from 'angular-ui-bootstrap';
+import { cloneDeep, first, get, has, isEmpty, isFinite, isString, isNil, map, set, uniq } from 'lodash';
+import {
+  AccountService, AppListExtractor, CloudProviderRegistry, IAccountDetails,
+  NameUtils, ProviderSelectionService, ServerGroupCommandBuilderService
+} from '@spinnaker/core';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { getCanaryConfigById, listKayentaAccounts, } from 'kayenta/service/canaryConfig.service';
+import {
+  ICanaryConfig,
+  ICanaryConfigSummary,
+  IKayentaAccount,
+  IKayentaServerGroupPair,
+  IKayentaStage,
+  IKayentaStageCanaryConfigScope,
+  IKayentaStageLifetime,
+  KayentaAccountType,
+  KayentaAnalysisType
+} from 'kayenta/domain';
+
+export class KayentaStageController implements IComponentController {
+  public state = {
+    useLookback: false,
+    backingDataLoading: false,
+    detailsLoading: false,
+    lifetimeHoursUpdatedToDuration: false,
+    lifetime: { hours: '', minutes: '' },
+  };
+  public canaryConfigSummaries: ICanaryConfigSummary[] = [];
+  public selectedCanaryConfigDetails: ICanaryConfig;
+  public scopeNames: string[] = [];
+  public kayentaAccounts = new Map<KayentaAccountType, IKayentaAccount[]>();
+  public metricStore: string;
+  public providers: string[];
+  public accounts: IAccountDetails[];
+  public clusterList: string[];
+
+  constructor(
+    private $scope: IScope,
+    private $uibModal: IModalService,
+    private $log: ILogService,
+    private providerSelectionService: ProviderSelectionService,
+    private serverGroupCommandBuilder: ServerGroupCommandBuilderService,
+    private serverGroupTransformer: any,
+    public stage: IKayentaStage,
+  ) {
+    'ngInject';
+    this.initialize();
+  }
+
+  private initialize = async (): Promise<void> => {
+    await this.loadBackingData();
+
+    this.stage.canaryConfig = {
+      storageAccountName: first(this.kayentaAccounts.get(KayentaAccountType.ConfigurationStore)) || CanarySettings.storageAccountName,
+      metricsAccountName: first(this.kayentaAccounts.get(KayentaAccountType.MetricsStore)) || CanarySettings.metricsAccountName,
+      ...this.stage.canaryConfig,
+      scoreThresholds: {
+        marginal: null,
+        pass: null,
+        ...get(this.stage, 'canaryConfig.scoreThresholds'),
+      },
+    };
+
+    this.stage.analysisType =
+      this.stage.analysisType || KayentaAnalysisType.RealTimeAutomatic;
+
+    if (!this.stage.canaryConfig.scopes || !this.stage.canaryConfig.scopes.length) {
+      this.stage.canaryConfig.scopes =
+        [{ scopeName: 'default' } as IKayentaStageCanaryConfigScope];
+    }
+
+    const stageLifetime = this.getLifetimeFromStageLifetimeDuration();
+    if (!isNil(stageLifetime.hours)) {
+      this.state.lifetime.hours = String(stageLifetime.hours);
+    }
+    if (!isNil(stageLifetime.minutes)) {
+      this.state.lifetime.minutes = String(stageLifetime.minutes);
+    }
+
+    if (this.stage.canaryConfig.lookbackMins) {
+      this.state.useLookback = true;
+    }
+
+    this.populateScopeNameChoices();
+    this.setMetricStore();
+    this.setClusterList();
+    this.deleteConfigAccountsIfMissing();
+    this.updateLifetimeFromHoursToDuration();
+    this.deleteCanaryConfigIdIfMissing();
+
+    if (this.stage.isNew
+        && this.stage.analysisType === KayentaAnalysisType.RealTimeAutomatic) {
+      await this.initializeRealTimeAutomaticAnalysisType();
+    }
+  };
+
+  private loadBackingData = async (): Promise<void> => {
+    this.state.backingDataLoading = true;
+    try {
+      await this.$scope.application.ready();
+      [
+        this.selectedCanaryConfigDetails,
+        this.kayentaAccounts,
+        this.providers,
+        this.accounts,
+        this.canaryConfigSummaries,
+      ] = await Promise.all([
+        this.loadCanaryConfigDetails(),
+        this.loadKayentaAccounts(),
+        this.loadProviders(),
+        this.loadAccounts(),
+        Promise.resolve(this.$scope.application.getDataSource('canaryConfigs').data)
+      ]);
+    } catch (e) {
+      this.$log.warn('Error loading backing data for Kayenta stage: ', e);
+    } finally {
+      this.state.backingDataLoading = false;
+
+      // This is the price we pay for async/await, since we're not using $q.
+      this.$scope.$applyAsync();
+    }
+  };
+
+  public onUseLookbackChange = (): void => {
+    if (!this.state.useLookback) {
+      delete this.stage.canaryConfig.lookbackMins;
+    }
+  };
+
+  public onCanaryConfigSelect = async (): Promise<void> => {
+    this.selectedCanaryConfigDetails = await this.loadCanaryConfigDetails();
+    this.populateScopeNameChoices();
+    this.setMetricStore();
+    this.overrideScoreThresholds();
+  };
+
+  public isExpression = (val: number | string): boolean => {
+    return isString(val) && val.includes('${');
+  };
+
+  public handleScoreThresholdChange = (
+    scoreThresholds: { successfulScore: string, unhealthyScore: string }
+  ): void => {
+    // Called from a React component.
+    this.$scope.$applyAsync(() => {
+      this.stage.canaryConfig.scoreThresholds.pass = scoreThresholds.successfulScore;
+      this.stage.canaryConfig.scoreThresholds.marginal = scoreThresholds.unhealthyScore;
+    });
+  };
+
+  public handleAnalysisTypeChange = async (type: KayentaAnalysisType): Promise<void> => {
+    this.stage.analysisType = type;
+
+    switch (this.stage.analysisType) {
+      case KayentaAnalysisType.RealTime:
+        delete this.stage.canaryConfig.scopes[0].startTimeIso;
+        delete this.stage.canaryConfig.scopes[0].endTimeIso;
+        delete this.stage.deployments;
+        break;
+      case KayentaAnalysisType.RealTimeAutomatic:
+        delete this.stage.canaryConfig.scopes[0].startTimeIso;
+        delete this.stage.canaryConfig.scopes[0].endTimeIso;
+        this.initializeRealTimeAutomaticAnalysisType();
+        break;
+      case KayentaAnalysisType.Retrospective:
+        delete this.stage.canaryConfig.beginCanaryAnalysisAfterMins;
+        delete this.stage.canaryConfig.lifetimeDuration;
+        delete this.stage.deployments;
+        break;
+    }
+    // Called from React.
+    this.$scope.$applyAsync();
+  };
+
+  private initializeRealTimeAutomaticAnalysisType = async (): Promise<void> => {
+    this.stage.deployments = {
+      ...this.stage.deployments,
+      baseline: {
+        ...(get(this.stage, 'deployments.baseline')),
+        cloudProvider: this.providers[0],
+        application: this.$scope.application.name,
+        cluster: null,
+        account: null,
+      },
+      serverGroupPairs: [],
+      delayBeforeCleanup: 0,
+    };
+    this.accounts = await this.loadAccounts();
+    this.setClusterList();
+  };
+
+  private loadCanaryConfigDetails = async (): Promise<ICanaryConfig> => {
+    if (!has(this.stage, 'canaryConfig.canaryConfigId')) {
+      return null;
+    }
+    const id = this.stage.canaryConfig.canaryConfigId;
+
+    this.state.detailsLoading = true;
+    try {
+      return getCanaryConfigById(id);
+    } catch (e) {
+      this.$log.warn(`Could not load canary config with id ${id}: `, e);
+      return null;
+    } finally {
+      this.state.detailsLoading = false;
+    }
+  };
+
+  private setMetricStore = (): void => {
+    this.metricStore = get(
+      this.selectedCanaryConfigDetails,
+      'metrics[0].query.type'
+    );
+  };
+
+  // Should only be called when selecting a canary config.
+  // Expected stage behavior:
+  // On stage load, use the stage's score thresholds rather than the canary config's
+  // thresholds.
+  // When selecting a canary config, set the stage's thresholds equal
+  // to the canary config's thresholds unless they are undefined.
+  // In that case, fall back on the stage's thresholds.
+  private overrideScoreThresholds = (): void => {
+    if (!this.selectedCanaryConfigDetails) {
+      return;
+    }
+
+    if (!this.stage.canaryConfig.scoreThresholds) {
+      this.stage.canaryConfig.scoreThresholds = { marginal: null, pass: null };
+    }
+
+    this.stage.canaryConfig.scoreThresholds.marginal = get(
+      this.selectedCanaryConfigDetails, 'classifier.scoreThresholds.marginal',
+      this.stage.canaryConfig.scoreThresholds.marginal || ''
+    ).toString();
+    this.stage.canaryConfig.scoreThresholds.pass = get(
+      this.selectedCanaryConfigDetails, 'classifier.scoreThresholds.pass',
+      this.stage.canaryConfig.scoreThresholds.pass || ''
+    ).toString();
+  };
+
+  private populateScopeNameChoices = (): void => {
+    if (!this.selectedCanaryConfigDetails) {
+      return;
+    }
+
+    const scopeNames =
+      uniq(map(this.selectedCanaryConfigDetails.metrics, metric => metric.scopeName || 'default'));
+    this.scopeNames = !isEmpty(scopeNames) ? scopeNames : ['default'];
+
+    if (!isEmpty(this.stage.canaryConfig.scopes) && !scopeNames.includes(this.stage.canaryConfig.scopes[0].scopeName)) {
+      delete this.stage.canaryConfig.scopes[0].scopeName;
+    } else if (isEmpty(this.stage.canaryConfig.scopes)) {
+      this.stage.canaryConfig.scopes = [{ scopeName: scopeNames[0] }] as IKayentaStageCanaryConfigScope[];
+    }
+  };
+
+  private loadKayentaAccounts = async (): Promise<Map<KayentaAccountType, IKayentaAccount[]>> => {
+    const mapped = new Map<KayentaAccountType, IKayentaAccount[]>();
+    const accounts = await listKayentaAccounts();
+
+    accounts.forEach(account => {
+      account.supportedTypes.forEach(type => {
+        if (mapped.has(type)) {
+          mapped.set(type, mapped.get(type).concat([account]));
+        } else {
+          mapped.set(type, [account]);
+        }
+      });
+    });
+
+    return mapped;
+  };
+
+  private deleteConfigAccountsIfMissing = (): void => {
+    if ((this.kayentaAccounts.get(KayentaAccountType.ObjectStore) || [])
+          .every(account => account.name !== this.stage.canaryConfig.storageAccountName)) {
+      delete this.stage.canaryConfig.storageAccountName;
+    }
+    if ((this.kayentaAccounts.get(KayentaAccountType.MetricsStore) || [])
+          .every(account => account.name !== this.stage.canaryConfig.metricsAccountName)) {
+      delete this.stage.canaryConfig.metricsAccountName;
+    }
+  };
+
+  private deleteCanaryConfigIdIfMissing = (): void => {
+    if (this.canaryConfigSummaries
+        .every(s => s.id !== this.stage.canaryConfig.canaryConfigId)) {
+      delete this.stage.canaryConfig.canaryConfigId;
+    }
+  };
+
+  public populateScopeWithExpressions = (): void => {
+    this.stage.canaryConfig.scopes[0].controlScope =
+      '${ #stage(\'Clone Server Group\')[\'context\'][\'source\'][\'serverGroupName\'] }';
+    this.stage.canaryConfig.scopes[0].controlLocation =
+      '${ deployedServerGroups[0].region }';
+    this.stage.canaryConfig.scopes[0].experimentScope =
+      '${ deployedServerGroups[0].serverGroup }';
+    this.stage.canaryConfig.scopes[0].experimentLocation =
+      '${ deployedServerGroups[0].region }';
+  };
+
+  public onLifetimeChange = (): void => {
+    const { hours, minutes } = this.getStateLifetime();
+    this.stage.canaryConfig.lifetimeDuration = `PT${hours}H${minutes}M`;
+  };
+
+  private updateLifetimeFromHoursToDuration = (): void => {
+    if (has(this.stage, ['canaryConfig', 'lifetimeHours'])) {
+      const hours = parseInt(this.stage.canaryConfig.lifetimeHours, 10);
+      if (isFinite(hours)) {
+        const fractional =
+          parseFloat(this.stage.canaryConfig.lifetimeHours) - hours;
+        const minutes = Math.floor(fractional * 60);
+        this.stage.canaryConfig.lifetimeDuration = `PT${hours}H`;
+        if (isFinite(minutes)) {
+          this.stage.canaryConfig.lifetimeDuration += `${minutes}M`;
+        }
+        this.state.lifetimeHoursUpdatedToDuration = true;
+      }
+      delete this.stage.canaryConfig.lifetimeHours;
+    }
+  };
+
+  private getStateLifetime = (): IKayentaStageLifetime => {
+    let hours = parseInt(this.state.lifetime.hours, 10);
+    let minutes = parseInt(this.state.lifetime.minutes, 10);
+    if (!isFinite(hours) || hours < 0) {
+      hours = 0;
+    }
+    if (!isFinite(minutes) || minutes < 0) {
+      minutes = 0;
+    }
+    return { hours, minutes };
+  };
+
+  private getLifetimeFromStageLifetimeDuration = (): IKayentaStageLifetime => {
+    const duration = get(this.stage, ['canaryConfig', 'lifetimeDuration']);
+    if (!isString(duration)) {
+      return {};
+    }
+    const lifetimeComponents = duration.match(/PT(\d+)H(?:(\d+)M)?/i);
+    if (lifetimeComponents == null) {
+      return {};
+    }
+    const hours = parseInt(lifetimeComponents[1], 10);
+    if (!isFinite(hours) || hours < 0) {
+      return {};
+    }
+    let minutes = parseInt(lifetimeComponents[2], 10);
+    if (!isFinite(minutes) || minutes < 0) {
+      minutes = 0;
+    }
+    return { hours, minutes };
+  };
+
+  public isLifetimeRequired = (): boolean => {
+    const lifetime = this.getStateLifetime();
+    return lifetime.hours === 0 && lifetime.minutes === 0;
+  };
+
+  public getLifetimeClassnames = (): string => {
+    if (this.state.lifetimeHoursUpdatedToDuration) {
+      return 'alert alert-warning';
+    }
+    return '';
+  };
+
+  private loadProviders = async (): Promise<string[]> => {
+    const providers = await AccountService.listProviders(this.$scope.application);
+    // TODO(dpeach): allow providers other than gce.
+    return this.providers = providers.filter(p => p === 'gce');
+  };
+
+  public handleProviderChange = async (): Promise<void> => {
+    set(this.stage, 'deployments.baseline.account', null);
+    set(this.stage, 'deployments.baseline.cluster', null);
+    this.accounts = await this.loadAccounts();
+    this.setClusterList();
+  };
+
+  public loadAccounts = (): Promise<IAccountDetails[]> => {
+    if (!has(this.stage, 'deployments.baseline.cloudProvider')) {
+      return null;
+    }
+
+    return Promise.resolve(AccountService.listAccounts(this.stage.deployments.baseline.cloudProvider));
+  };
+
+  private setClusterList = (): void => {
+    this.clusterList =
+      AppListExtractor.getClusters([this.$scope.application], sg =>
+        has(this.stage, 'deployments.baseline.account')
+          ? sg.account === this.stage.deployments.baseline.account
+          : true
+      );
+  };
+
+  public getRegion = (serverGroup: any): string => {
+    if (serverGroup.region) {
+      return serverGroup.region;
+    }
+    const availabilityZones = serverGroup.availabilityZones;
+    return availabilityZones
+      ? Object.keys(availabilityZones).length
+        ? Object.keys(availabilityZones)[0]
+        : 'n/a'
+      : 'n/a';
+  };
+
+  public getServerGroupName = (serverGroup: any): string => {
+    return NameUtils.getClusterName(
+      serverGroup.application,
+      serverGroup.stack,
+      serverGroup.freeFormDetails);
+  };
+
+  public addPair = async (): Promise<void> => {
+    this.stage.deployments.serverGroupPairs = this.stage.deployments.serverGroupPairs || [];
+    const provider =
+      await (
+        has(this.stage, 'deployments.baseline.cloudProvider')
+          ? Promise.resolve(this.stage.deployments.baseline.cloudProvider)
+          : Promise.resolve(this.providerSelectionService.selectProvider(this.$scope.application, 'serverGroup'))
+      );
+    this.stage.deployments.baseline.cloudProvider = provider;
+    const config = CloudProviderRegistry.getValue(provider, 'serverGroup');
+
+    const command: any =
+      await this.serverGroupCommandBuilder.buildNewServerGroupCommandForPipeline(
+        provider,
+        null,
+        null
+      );
+
+    command.viewState = {
+      ...command.viewState,
+      requiresTemplateSelection: true,
+      disableStrategySelection: true,
+      hideClusterNamePreview: true,
+      readOnlyFields: {
+        credentials: true,
+        region: true,
+        subnet: true,
+        useSourceCapacity: true
+      },
+      overrides: {
+        capacity: {
+          min: 1,
+          max: 1,
+          desired: 1,
+        },
+        useSourceCapacity: false,
+      },
+    };
+
+    delete command.strategy;
+    try {
+      const result = await this.$uibModal
+        .open({
+          templateUrl: config.cloneServerGroupTemplateUrl,
+          controller: `${config.cloneServerGroupController} as ctrl`,
+          size: 'lg',
+          resolve: {
+            title: () => 'Add Server Group Pair',
+            application: () => this.$scope.application,
+            serverGroupCommand: () => command,
+          },
+        })
+        .result;
+
+      const control = this.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(result),
+        experiment = cloneDeep(control);
+
+      const cleanup = (serverGroup: any, type: string) => {
+        delete serverGroup.backingData;
+        if (serverGroup.freeFormDetails
+            && serverGroup.freeFormDetails.split('-').pop() === type) {
+          return;
+        }
+        serverGroup.freeFormDetails =
+          `${serverGroup.freeFormDetails
+            ? `${serverGroup.freeFormDetails}-`
+            : ''}${type}`;
+      };
+
+      cleanup(control, 'control');
+      cleanup(experiment, 'experiment');
+      this.stage.deployments.serverGroupPairs = [{ control, experiment }];
+    } catch (e) {
+      this.$log.warn('Error creating server group pair for Kayenta stage: ', e)
+    }
+  };
+
+  public editServerGroup = async (
+    serverGroup: any,
+    index: number,
+    type: keyof IKayentaServerGroupPair
+  ): Promise<void> => {
+    serverGroup.provider = serverGroup.provider || serverGroup.cloudProvider;
+    const config = CloudProviderRegistry.getValue(serverGroup.cloudProvider, 'serverGroup');
+    try {
+      const result = await this.$uibModal.open({
+        templateUrl: config.cloneServerGroupTemplateUrl,
+        controller: `${config.cloneServerGroupController} as ctrl`,
+        size: 'lg',
+        resolve: {
+          title: () => `Configure ${type[0].toUpperCase() + type.substring(1)} Server Group`,
+          application: () => this.$scope.application,
+          serverGroupCommand: async () => {
+            const command =
+              await this.serverGroupCommandBuilder.buildServerGroupCommandFromPipeline(
+                this.$scope.application,
+                serverGroup,
+                null,
+                null
+              );
+            command.viewState = {
+              ...command.viewState,
+              disableStrategySelection: true,
+              hideClusterNamePreview: true,
+              readOnlyFields: {
+                credentials: true,
+                region: true,
+                subnet: true,
+                useSourceCapacity: true
+              },
+            };
+            delete command.strategy;
+            return command;
+          }
+          },
+        }).result;
+
+      this.stage.deployments.serverGroupPairs[index][type] =
+        this.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(result);
+    } catch (e) {
+      this.$log.warn('Error editing server group pair for Kayenta stage: ', e)
+    }
+  };
+
+  public deletePair = (index: number): void => {
+    (this.stage.deployments.serverGroupPairs || []).splice(index, 1);
+  };
+}

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -1,4 +1,9 @@
-<div class="form-horizontal canary-config-view">
+<loading-spinner
+  size="'medium'"
+  ng-if="kayentaCanaryStageCtrl.state.backingDataLoading">
+</loading-spinner>
+
+<div ng-if="!kayentaCanaryStageCtrl.state.backingDataLoading" class="form-horizontal canary-config-view">
   <div class="alert alert-warning" ng-if="kayentaCanaryStageCtrl.state.lifetimeHoursUpdatedToDuration">
     <p>
       <strong>Kayenta now supports analysis lifetimes shorter than 1 hour.</strong>
@@ -9,65 +14,87 @@
     </p>
   </div>
 
-  <h4>Canary Config</h4>
-
-  <stage-config-field label="Analysis Type"
-                      help-key="pipeline.config.canary.analysisType"
-                      field-columns="3">
-    <select
-      class="form-control input-sm"
-      ng-model="kayentaCanaryStageCtrl.stage.analysisType"
-      ng-change="kayentaCanaryStageCtrl.handleAnalysisTypeChange()"
-    >
-      <option value="realTime">Real Time</option>
-      <option value="retrospective">Retrospective</option>
-    </select>
-  </stage-config-field>
-
-  <!--
-  TODO: Revisit this when this canary stage ui is used for canaries employing Atlas.
-  <stage-config-field label="Result Strategy"
-                      help-key="pipeline.config.canary.resultStrategy"
-                      field-columns="3">
-    <select class="form-control input-sm"
-            ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.combinedCanaryResultStrategy">
-      <option value="LOWEST">lowest</option>
-      <option value="AVERAGE">average</option>
-    </select>
-  </stage-config-field>
-  -->
-
   <kayenta-stage-config-section title="Analysis Config">
-    <stage-config-field label="Config Name">
-      <div ng-if="!kayentaCanaryStageCtrl.state.backingDataLoading">
-        <ui-select required
-                   ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.canaryConfigId"
-                   on-select="kayentaCanaryStageCtrl.onCanaryConfigSelect()"
-                   class="visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
-                   style="width:300px">
-          <ui-select-match>{{$select.selected.name}}</ui-select-match>
-          <ui-select-choices repeat="summary.id as summary in kayentaCanaryStageCtrl.canaryConfigSummaries | filter: $select.search">
-            {{summary.name}}
-          </ui-select-choices>
-        </ui-select>
-      </div>
-      <div ng-if="kayentaCanaryStageCtrl.state.backingDataLoading" class="col-md-3">
-        <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
-      </div>
+
+    <stage-config-field label="Analysis Type"
+                        field-columns="3">
+      <kayenta-analysis-type
+        type="kayentaCanaryStageCtrl.stage.analysisType"
+        on-change="kayentaCanaryStageCtrl.handleAnalysisTypeChange"
+      ></kayenta-analysis-type>
     </stage-config-field>
 
-    <stage-config-field label="Delay"
-                        help-key="pipeline.config.canary.delayBeforeAnalysis"
-                        field-columns="5"
-                        ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'realTime'">
-      <input type="text"
-             ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.beginCanaryAnalysisAfterMins"
-             class="form-control input-sm"
-             style="display: inline-block; width: 19%"/>
-      <span class="form-control-static">
-        minutes before starting analysis
-      </span>
+    <stage-config-field label="Config Name">
+      <ui-select required
+                 ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.canaryConfigId"
+                 on-select="kayentaCanaryStageCtrl.onCanaryConfigSelect()"
+                 class="visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                 style="width:300px">
+        <ui-select-match>{{$select.selected.name}}</ui-select-match>
+        <ui-select-choices repeat="summary.id as summary in kayentaCanaryStageCtrl.canaryConfigSummaries | filter: $select.search">
+          {{summary.name}}
+        </ui-select-choices>
+      </ui-select>
     </stage-config-field>
+
+    <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTime, realTimeAutomatic">
+      <stage-config-field label="Lifetime"
+                          help-key="pipeline.config.canary.analysisType"
+                          field-columns="8"
+                          ng-class="kayentaCanaryStageCtrl.getLifetimeClassnames()"
+                          style="padding-left: 0; padding-right: 0;">
+        <input type="text"
+               ng-model="kayentaCanaryStageCtrl.state.lifetime.hours"
+               ng-required="kayentaCanaryStageCtrl.isLifetimeRequired()"
+               class="form-control input-sm"
+               style="display: inline-block; width: 11%"
+               ng-change="kayentaCanaryStageCtrl.onLifetimeChange()" />
+        <span class="form-control-static">
+        hours
+        </span>
+          <input type="text"
+                 ng-model="kayentaCanaryStageCtrl.state.lifetime.minutes"
+                 ng-required="kayentaCanaryStageCtrl.isLifetimeRequired()"
+                 class="form-control input-sm"
+                 style="display: inline-block; width: 11%; margin-left: 12px;"
+                 ng-change="kayentaCanaryStageCtrl.onLifetimeChange()" />
+          <span class="form-control-static">
+          minutes
+        </span>
+      </stage-config-field>
+    </for-analysis-type>
+
+    <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="retrospective">
+      <stage-config-field label="Start Time"
+                          help-key="pipeline.config.canary.startTimeIso">
+        <input
+          class="form-control input-sm"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].startTimeIso"
+          type="text"/>
+      </stage-config-field>
+
+      <stage-config-field label="End Time"
+                          help-key="pipeline.config.canary.endTimeIso">
+        <input
+          class="form-control input-sm"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].endTimeIso"
+          type="text"/>
+      </stage-config-field>
+    </for-analysis-type>
+
+    <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTime, realTimeAutomatic">
+      <stage-config-field label="Delay"
+                          help-key="pipeline.config.canary.delayBeforeAnalysis"
+                          field-columns="5">
+        <input type="text"
+               ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.beginCanaryAnalysisAfterMins"
+               class="form-control input-sm"
+               style="display: inline-block; width: 19%"/>
+        <span class="form-control-static">
+          minutes before starting analysis
+        </span>
+      </stage-config-field>
+    </for-analysis-type>
 
     <stage-config-field label="Interval"
                         help-key="pipeline.config.canary.canaryInterval"
@@ -77,6 +104,17 @@
              class="form-control input-sm"
              style="width: 33%; display: inline-block"/>
       <span class="form-control-static"> minutes</span>
+    </stage-config-field>
+
+    <!--TODO(dpeach): add help text here-->
+    <stage-config-field label="Step"
+                        field-columns="3">
+      <input
+        class="form-control input-sm"
+        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].step"
+        type="number"
+        style="width: 33%; display: inline-block"/>
+      <span class="form-control-static"> seconds</span>
     </stage-config-field>
 
     <stage-config-field label="Lookback Type"
@@ -115,8 +153,41 @@
     </stage-config-field>
   </kayenta-stage-config-section>
 
-  <kayenta-stage-config-section title="Metric Scope">
-    <section-header>
+  <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTimeAutomatic">
+    <kayenta-stage-config-section title="Baseline Version">
+      <stage-config-field label="Provider" ng-if="kayentaCanaryStageCtrl.providers.length > 1
+                                                && kayentaCanaryStageCtrl.stage.isNew">
+        <provider-selector providers="kayentaCanaryStageCtrl.providers"
+                           component="kayentaCanaryStageCtrl.stage.deployments.baseline"
+                           on-change="kayentaCanaryStageCtrl.handleProviderChange()"
+                           field="cloudProvider"
+                           read-only="!kayentaCanaryStageCtrl.stage.isNew"></provider-selector>
+      </stage-config-field>
+
+      <stage-config-field label="Account">
+        <account-select-field
+          component="kayentaCanaryStageCtrl.stage.deployments.baseline"
+          field="account"
+          accounts="kayentaCanaryStageCtrl.accounts"
+          on-change="kayentaCanaryStageCtrl.setClusterList()"
+          provider="kayentaCanaryStageCtrl.stage.deployments.baseline.cloudProvider"
+          required>
+        </account-select-field>
+      </stage-config-field>
+
+      <stage-config-field label="Cluster">
+        <cluster-selector
+          ng-if="application.serverGroups.loaded"
+          clusters="kayentaCanaryStageCtrl.clusterList"
+          required="true"
+          model="kayentaCanaryStageCtrl.stage.deployments.baseline.cluster">
+        </cluster-selector>
+      </stage-config-field>
+    </kayenta-stage-config-section>
+  </for-analysis-type>
+
+  <kayenta-stage-config-section title="Baseline + Canary Server Groups">
+    <section-header ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'realTime'">
       <span
         uib-tooltip="Click to populate with expressions for resolving control
                      and experiment scopes from an upstream clone stage."
@@ -124,95 +195,97 @@
         class="fa fa-magic clickable"></span>
     </section-header>
 
-    <stage-config-field label="Baseline"
-                        help-key="pipeline.config.canary.baselineGroup">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].controlScope"
-        required
-        type="text"/>
-    </stage-config-field>
+    <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTime, retrospective">
+      <stage-config-field label="Baseline"
+                          help-key="pipeline.config.canary.baselineGroup">
+        <input
+          class="form-control input-sm"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].controlScope"
+          required
+          type="text"/>
+      </stage-config-field>
 
-    <stage-config-field label="Baseline Location"
-                        help-key="pipeline.config.canary.baselineLocation">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].controlLocation"
-        required
-        type="text"/>
-    </stage-config-field>
+      <stage-config-field label="Baseline Location"
+                          help-key="pipeline.config.canary.baselineLocation">
+        <input
+          class="form-control input-sm"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].controlLocation"
+          required
+          type="text"/>
+      </stage-config-field>
 
-    <stage-config-field label="Canary"
-                        help-key="pipeline.config.canary.canaryGroup">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].experimentScope"
-        required
-        type="text"/>
-    </stage-config-field>
+      <stage-config-field label="Canary"
+                          help-key="pipeline.config.canary.canaryGroup">
+        <input
+          class="form-control input-sm"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].experimentScope"
+          required
+          type="text"/>
+      </stage-config-field>
 
-    <stage-config-field label="Canary Location"
-                        help-key="pipeline.config.canary.canaryLocation">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].experimentLocation"
-        required
-        type="text"/>
-    </stage-config-field>
+      <stage-config-field label="Canary Location"
+                          help-key="pipeline.config.canary.canaryLocation">
+        <input
+          class="form-control input-sm"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].experimentLocation"
+          required
+          type="text"/>
+      </stage-config-field>
+    </for-analysis-type>
 
-    <stage-config-field label="Step"
-                        field-columns="3">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].step"
-        type="number"
-        style="width: 33%; display: inline-block"/>
-      <span class="form-control-static"> seconds</span>
-    </stage-config-field>
+    <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTimeAutomatic">
+      <div class="row">
+        <div style="margin: 10px 10px 0 50px;">
+          <div class="well well-sm">
+            <table class="table">
+              <thead>
+              <tr>
+                <th>Location</th>
+                <th>Baseline</th>
+                <th>Canary</th>
+                <th>Actions</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr ng-repeat="clusterPair in kayentaCanaryStageCtrl.stage.deployments.serverGroupPairs">
+                <td>
+                  <account-tag account="clusterPair.control.account"></account-tag>
+                  {{kayentaCanaryStageCtrl.getRegion(clusterPair.control)}}
+                </td>
+                <td>
+                  {{kayentaCanaryStageCtrl.getServerGroupName(clusterPair.control)}}
+                  <br/>
+                  <a href ng-click="kayentaCanaryStageCtrl.editServerGroup(clusterPair.control, $index, 'control')">Edit</a>
+                </td>
+                <td>
+                  {{kayentaCanaryStageCtrl.getServerGroupName(clusterPair.experiment)}}
+                  <br/>
+                  <a href ng-click="kayentaCanaryStageCtrl.editServerGroup(clusterPair.experiment, $index, 'experiment')">Edit</a>
+                </td>
+                <td>
+                  <a href ng-click="kayentaCanaryStageCtrl.deletePair($index);">
+                    <span class="glyphicon glyphicon-trash" uib-tooltip="Delete Pair"></span>
+                  </a>
+                </td>
+              </tr>
+              </tbody>
+              <tfoot>
+              <tr ng-if="!kayentaCanaryStageCtrl.stage.deployments.serverGroupPairs.length">
+                <td colspan="4">
+                  <button class="btn btn-block btn-sm add-new" ng-click="kayentaCanaryStageCtrl.addPair()">
+                    <span class="glyphicon glyphicon-plus-sign"></span> Create baseline / canary pair
+                  </button>
+                </td>
+              </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      </div>
+    </for-analysis-type>
+  </kayenta-stage-config-section>
 
-    <stage-config-field label="Start Time"
-                        help-key="pipeline.config.canary.startTimeIso"
-                        ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'retrospective'">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].startTimeIso"
-        type="text"/>
-    </stage-config-field>
-
-    <stage-config-field label="End Time"
-                        help-key="pipeline.config.canary.endTimeIso"
-                        ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'retrospective'">
-      <input
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].endTimeIso"
-        type="text"/>
-    </stage-config-field>
-
-    <stage-config-field label="Lifetime"
-                        help-key="pipeline.config.canary.analysisType"
-                        field-columns="8"
-                        ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'realTime'"
-                        ng-class="kayentaCanaryStageCtrl.getLifetimeClassnames()"
-                        style="padding-left: 0; padding-right: 0;">
-      <input type="text"
-             ng-model="kayentaCanaryStageCtrl.state.lifetime.hours"
-             ng-required="kayentaCanaryStageCtrl.isLifetimeRequired()"
-             class="form-control input-sm"
-             style="display: inline-block; width: 11%"
-             ng-change="kayentaCanaryStageCtrl.onLifetimeChange()" />
-      <span class="form-control-static">
-        hours
-      </span>
-      <input type="text"
-             ng-model="kayentaCanaryStageCtrl.state.lifetime.minutes"
-             ng-required="kayentaCanaryStageCtrl.isLifetimeRequired()"
-             class="form-control input-sm"
-             style="display: inline-block; width: 11%; margin-left: 12px;"
-             ng-change="kayentaCanaryStageCtrl.onLifetimeChange()" />
-      <span class="form-control-static">
-        minutes
-      </span>
-    </stage-config-field>
+  <kayenta-stage-config-section title="Metric Scope">
 
     <stage-config-field label="Resource Type" ng-if="kayentaCanaryStageCtrl.metricStore === 'prometheus'">
       <select
@@ -240,32 +313,24 @@
   </kayenta-stage-config-section>
 
   <kayenta-stage-config-section title="Scoring Thresholds">
-    <div class="form-group">
-      <div ng-if="kayentaCanaryStageCtrl.state.detailsLoading" class="col-md-3 col-md-offset-4">
-        <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
-      </div>
-
-      <kayenta-canary-scores ng-if="!kayentaCanaryStageCtrl.state.detailsLoading"
-                             on-change="kayentaCanaryStageCtrl.handleScoreThresholdChange"
-                             successful-help-field-id="'pipeline.config.canary.passingScore'"
-                             successful-label="'Pass'"
-                             successful-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.pass"
-                             unhealthy-help-field-id="'pipeline.config.canary.marginalScore'"
-                             unhealthy-label="'Marginal'"
-                             unhealthy-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.marginal"></kayenta-canary-scores>
+    <div ng-if="kayentaCanaryStageCtrl.state.detailsLoading" class="col-md-3 col-md-offset-4">
+      <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
     </div>
+
+    <kayenta-canary-scores ng-if="!kayentaCanaryStageCtrl.state.detailsLoading"
+                           on-change="kayentaCanaryStageCtrl.handleScoreThresholdChange"
+                           successful-help-field-id="'pipeline.config.canary.passingScore'"
+                           successful-label="'Pass'"
+                           successful-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.pass"
+                           unhealthy-help-field-id="'pipeline.config.canary.marginalScore'"
+                           unhealthy-label="'Marginal'"
+                           unhealthy-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.marginal"></kayenta-canary-scores>
   </kayenta-stage-config-section>
 
   <kayenta-stage-config-section title="Advanced Settings">
-    <div class="form-group">
-      <div ng-if="kayentaCanaryStageCtrl.state.backingDataLoading" class="col-md-3 col-md-offset-4">
-        <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
-      </div>
-    </div>
 
     <stage-config-field label="Metrics Account"
-                        help-key="pipeline.config.metricsAccount"
-                        ng-if="!kayentaCanaryStageCtrl.state.backingDataLoading">
+                        help-key="pipeline.config.metricsAccount">
       <select
         class="form-control input-sm"
         ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.metricsAccountName"
@@ -274,8 +339,7 @@
       </select>
     </stage-config-field>
     <stage-config-field label="Storage Account"
-                        help-key="pipeline.config.storageAccount"
-                        ng-if="!kayentaCanaryStageCtrl.state.backingDataLoading">
+                        help-key="pipeline.config.storageAccount">
       <select
         class="form-control input-sm"
         ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.storageAccountName"
@@ -285,20 +349,15 @@
     </stage-config-field>
 
     <stage-config-field label="Scope Name">
-      <div ng-if="!kayentaCanaryStageCtrl.state.backingDataLoading">
-        <ui-select required
-                   ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].scopeName"
-                   class="visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
-                   style="width:300px">
-          <ui-select-match>{{$select.selected}}</ui-select-match>
-          <ui-select-choices repeat="scopeName in kayentaCanaryStageCtrl.scopeNames | filter: $select.search">
-            {{scopeName}}
-          </ui-select-choices>
-        </ui-select>
-      </div>
-      <div ng-if="kayentaCanaryStageCtrl.state.backingDataLoading" class="col-md-3">
-        <h3><span us-spinner="{radius:3, width:1, length: 4}"></span></h3>
-      </div>
+      <ui-select required
+                 ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].scopeName"
+                 class="visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                 style="width:300px">
+        <ui-select-match>{{$select.selected}}</ui-select-match>
+        <ui-select-choices repeat="scopeName in kayentaCanaryStageCtrl.scopeNames | filter: $select.search">
+          {{scopeName}}
+        </ui-select-choices>
+      </ui-select>
     </stage-config-field>
 
     <div class="alert alert-warning" ng-if="kayentaCanaryStageCtrl.stage.canaryConfig.scopes.length > 1">

--- a/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
@@ -5,7 +5,7 @@ import {
   Application, IExecution, IExecutionStage, ITransformer,
   OrchestratedItemTransformer
 } from '@spinnaker/core';
-import { KAYENTA_CANARY, RUN_CANARY } from './stageTypes';
+import { KAYENTA_CANARY, RUN_CANARY, WAIT } from './stageTypes';
 
 export class KayentaStageTransformer implements ITransformer {
 
@@ -15,7 +15,10 @@ export class KayentaStageTransformer implements ITransformer {
       if (stage.type === KAYENTA_CANARY) {
         OrchestratedItemTransformer.defineProperties(stage);
 
-        const syntheticCanaryStages = execution.stages.filter(s => s.parentStageId === stage.id);
+        const syntheticCanaryStages = execution.stages.filter(s =>
+          s.parentStageId === stage.id
+           && [WAIT, RUN_CANARY].includes(s.type)
+        );
         stagesToRenderAsTasks = stagesToRenderAsTasks.concat(syntheticCanaryStages);
 
         stage.exceptions = [];

--- a/src/kayenta/stages/kayentaStage/kayentaStage.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.ts
@@ -1,344 +1,25 @@
-import { module, IComponentController, IScope } from 'angular';
-import {
-  isString,
-  isFinite,
-  isNil,
-  get,
-  has,
-  isEmpty,
-  map,
-  uniq,
-  difference,
-} from 'lodash';
-import autoBindMethods from 'class-autobind-decorator';
+import { module } from 'angular';
+import { get, has, isEmpty, map, uniq, difference } from 'lodash';
 
-import {
-  IPipeline,
-  Registry
-} from '@spinnaker/core';
+import { IPipeline, Registry } from '@spinnaker/core';
 
-import { CanarySettings } from 'kayenta/canary.settings';
-import {
-  getCanaryConfigById,
-  listKayentaAccounts,
-} from 'kayenta/service/canaryConfig.service';
-import { ICanaryConfig, ICanaryConfigSummary, IKayentaAccount, KayentaAccountType } from 'kayenta/domain/index';
+import { getCanaryConfigById } from 'kayenta/service/canaryConfig.service';
+import { IKayentaStage, KayentaAnalysisType } from 'kayenta/domain';
 import { CANARY_SCORES_CONFIG_COMPONENT } from 'kayenta/components/canaryScores.component';
 import { KayentaStageTransformer, KAYENTA_STAGE_TRANSFORMER } from './kayentaStage.transformer';
+import { KayentaStageController } from './kayentaStage.controller';
 import { KAYENTA_STAGE_EXECUTION_DETAILS_CONTROLLER } from './kayentaStageExecutionDetails.controller';
 import { KAYENTA_STAGE_CONFIG_SECTION } from './kayentaStageConfigSection.component';
+import { KAYENTA_ANALYSIS_TYPE_COMPONENT } from './analysisType.component';
+import { FOR_ANALYSIS_TYPE_COMPONENT } from './forAnalysisType.component';
 
-interface IKayentaStage {
-  canaryConfig: IKayentaStageCanaryConfig;
-  analysisType: KayentaAnalysisType;
-}
-
-interface IKayentaStageCanaryConfig {
-  beginCanaryAnalysisAfterMins?: string;
-  canaryAnalysisIntervalMins: string;
-  canaryConfigId: string;
-  scopes: IKayentaStageCanaryConfigScope[];
-  combinedCanaryResultStrategy: string;
-  lifetimeHours?: string;
-  lifetimeDuration?: string;
-  lookbackMins?: string;
-  metricsAccountName: string;
-  scoreThresholds: {
-    pass: string;
-    marginal: string;
-  };
-  storageAccountName: string;
-}
-
-interface IKayentaStageCanaryConfigScope {
-  scopeName: string;
-  controlScope: string;
-  controlLocation: string;
-  experimentScope: string;
-  experimentLocation: string;
-  startTimeIso?: string;
-  endTimeIso?: string;
-  step?: number;
-  extendedScopeParams: {[key: string]: string};
-}
-
-interface IKayentaStageLifetime {
-  hours?: number;
-  minutes?: number;
-}
-
-enum KayentaAnalysisType {
-  RealTime = 'realTime',
-  Retrospective = 'retrospective',
-}
-
-@autoBindMethods
-class CanaryStage implements IComponentController {
-  public state = {
-    useLookback: false,
-    backingDataLoading: false,
-    detailsLoading: false,
-    lifetimeHoursUpdatedToDuration: false,
-    lifetime: { hours: '', minutes: '' },
-  };
-  public canaryConfigSummaries: ICanaryConfigSummary[] = [];
-  public selectedCanaryConfigDetails: ICanaryConfig;
-  public scopeNames: string[] = [];
-  public kayentaAccounts = new Map<KayentaAccountType, IKayentaAccount[]>();
-  public metricStore: string;
-
-  constructor(private $scope: IScope, public stage: IKayentaStage) {
-    'ngInject';
-    this.initialize();
-  }
-
-  public onUseLookbackChange(): void {
-    if (!this.state.useLookback) {
-      delete this.stage.canaryConfig.lookbackMins;
-    }
-  }
-
-  public onCanaryConfigSelect(): void {
-    this.loadCanaryConfigDetails().then(() => this.overrideScoreThresholds());
-  }
-
-  public isExpression(val: number | string): boolean {
-    return isString(val) && val.includes('${');
-  }
-
-  public handleScoreThresholdChange(scoreThresholds: { successfulScore: string, unhealthyScore: string }): void {
-    // Called from a React component.
-    this.$scope.$apply(() => {
-      this.stage.canaryConfig.scoreThresholds.pass = scoreThresholds.successfulScore;
-      this.stage.canaryConfig.scoreThresholds.marginal = scoreThresholds.unhealthyScore;
-    });
-  }
-
-  public handleAnalysisTypeChange(): void {
-    switch (this.stage.analysisType) {
-      case KayentaAnalysisType.RealTime:
-        delete this.stage.canaryConfig.scopes[0].startTimeIso;
-        delete this.stage.canaryConfig.scopes[0].endTimeIso;
-        break;
-      case KayentaAnalysisType.Retrospective:
-        delete this.stage.canaryConfig.beginCanaryAnalysisAfterMins;
-        delete this.stage.canaryConfig.lifetimeDuration;
-        break;
-    }
-  }
-
-  private initialize(): void {
-    this.stage.canaryConfig = this.stage.canaryConfig || {} as IKayentaStageCanaryConfig;
-    this.stage.canaryConfig.storageAccountName =
-      this.stage.canaryConfig.storageAccountName || CanarySettings.storageAccountName;
-    this.stage.canaryConfig.metricsAccountName =
-      this.stage.canaryConfig.metricsAccountName || CanarySettings.metricsAccountName;
-    this.stage.canaryConfig.combinedCanaryResultStrategy =
-      this.stage.canaryConfig.combinedCanaryResultStrategy || 'LOWEST';
-    this.stage.analysisType =
-      this.stage.analysisType || KayentaAnalysisType.RealTime;
-
-    this.updateLifetimeFromHoursToDuration();
-    const stageLifetime = this.getLifetimeFromStageLifetimeDuration();
-    if (!isNil(stageLifetime.hours)) {
-      this.state.lifetime.hours = String(stageLifetime.hours);
-    }
-    if (!isNil(stageLifetime.minutes)) {
-      this.state.lifetime.minutes = String(stageLifetime.minutes);
-    }
-
-    if (this.stage.canaryConfig.lookbackMins) {
-      this.state.useLookback = true;
-    }
-
-    if (!this.stage.canaryConfig.scopes || !this.stage.canaryConfig.scopes.length) {
-      this.stage.canaryConfig.scopes =
-        [{ scopeName: 'default' } as IKayentaStageCanaryConfigScope];
-    }
-
-    this.loadBackingData();
-  }
-
-  private loadCanaryConfigDetails(): Promise<void> {
-    if (!this.stage.canaryConfig.canaryConfigId) {
-      return Promise.resolve(null);
-    }
-
-    this.state.detailsLoading = true;
-    return getCanaryConfigById(this.stage.canaryConfig.canaryConfigId).then(configDetails => {
-      this.state.detailsLoading = false;
-      this.selectedCanaryConfigDetails = configDetails;
-      this.populateScopeNameChoices(configDetails);
-      this.metricStore = get(configDetails, 'metrics[0].query.type');
-    }).catch(() => {
-      this.state.detailsLoading = false;
-    });
-  }
-
-  // Should only be called when selecting a canary config.
-  // Expected stage behavior:
-  // On stage load, use the stage's score thresholds rather than the canary config's
-  // thresholds.
-  // When selecting a canary config, set the stage's thresholds equal
-  // to the canary config's thresholds unless they are undefined.
-  // In that case, fall back on the stage's thresholds.
-  private overrideScoreThresholds(): void {
-    if (!this.selectedCanaryConfigDetails) {
-      return;
-    }
-
-    if (!this.stage.canaryConfig.scoreThresholds) {
-      this.stage.canaryConfig.scoreThresholds = { marginal: null, pass: null };
-    }
-
-    this.stage.canaryConfig.scoreThresholds.marginal = get(
-      this.selectedCanaryConfigDetails, 'classifier.scoreThresholds.marginal',
-      this.stage.canaryConfig.scoreThresholds.marginal || ''
-    ).toString();
-    this.stage.canaryConfig.scoreThresholds.pass = get(
-      this.selectedCanaryConfigDetails, 'classifier.scoreThresholds.pass',
-      this.stage.canaryConfig.scoreThresholds.pass || ''
-    ).toString();
-  }
-
-  private populateScopeNameChoices(configDetails: ICanaryConfig): void {
-    const scopeNames = uniq(map(configDetails.metrics, metric => metric.scopeName || 'default'));
-    this.scopeNames = !isEmpty(scopeNames) ? scopeNames : ['default'];
-
-    if (!isEmpty(this.stage.canaryConfig.scopes) && !scopeNames.includes(this.stage.canaryConfig.scopes[0].scopeName)) {
-      delete this.stage.canaryConfig.scopes[0].scopeName;
-    } else if (isEmpty(this.stage.canaryConfig.scopes)) {
-      this.stage.canaryConfig.scopes = [{ scopeName: scopeNames[0] }] as IKayentaStageCanaryConfigScope[];
-    }
-  }
-
-  private loadBackingData(): void {
-    this.state.backingDataLoading = true;
-    Promise.all([
-      this.$scope.application.ready().then(() => {
-        this.setCanaryConfigSummaries(this.$scope.application.getDataSource('canaryConfigs').data);
-        this.deleteCanaryConfigIdIfMissing();
-        this.loadCanaryConfigDetails();
-      }),
-      listKayentaAccounts().then(this.setKayentaAccounts).then(this.deleteConfigAccountsIfMissing),
-    ]).then(() => this.state.backingDataLoading = false)
-      .catch(() => this.state.backingDataLoading = false);
-  }
-
-  private setKayentaAccounts(accounts: IKayentaAccount[]): void {
-    accounts.forEach(account => {
-      account.supportedTypes.forEach(type => {
-        if (this.kayentaAccounts.has(type)) {
-          this.kayentaAccounts.set(type, this.kayentaAccounts.get(type).concat([account]));
-        } else {
-          this.kayentaAccounts.set(type, [account]);
-        }
-      });
-    });
-  }
-
-  private deleteConfigAccountsIfMissing(): void {
-    if ((this.kayentaAccounts.get(KayentaAccountType.ObjectStore) || [])
-          .every(account => account.name !== this.stage.canaryConfig.storageAccountName)) {
-      delete this.stage.canaryConfig.storageAccountName;
-    }
-    if ((this.kayentaAccounts.get(KayentaAccountType.MetricsStore) || [])
-          .every(account => account.name !== this.stage.canaryConfig.metricsAccountName)) {
-      delete this.stage.canaryConfig.metricsAccountName;
-    }
-  }
-
-  private setCanaryConfigSummaries(summaries: ICanaryConfigSummary[]): void {
-    this.canaryConfigSummaries = summaries;
-  }
-
-  private deleteCanaryConfigIdIfMissing(): void {
-    if (this.canaryConfigSummaries.every(s => s.id !== this.stage.canaryConfig.canaryConfigId)) {
-      delete this.stage.canaryConfig.canaryConfigId;
-    }
-  }
-
-  public populateScopeWithExpressions(): void {
-    this.stage.canaryConfig.scopes[0].controlScope =
-      '${ #stage(\'Clone Server Group\')[\'context\'][\'source\'][\'serverGroupName\'] }';
-    this.stage.canaryConfig.scopes[0].controlLocation =
-      '${ deployedServerGroups[0].region }';
-    this.stage.canaryConfig.scopes[0].experimentScope =
-      '${ deployedServerGroups[0].serverGroup }';
-    this.stage.canaryConfig.scopes[0].experimentLocation =
-      '${ deployedServerGroups[0].region }';
-  }
-
-  public onLifetimeChange(): void {
-    const { hours, minutes } = this.getStateLifetime();
-    this.stage.canaryConfig.lifetimeDuration = `PT${hours}H${minutes}M`;
-  }
-
-  private updateLifetimeFromHoursToDuration(): void {
-    if (has(this.stage, ['canaryConfig', 'lifetimeHours'])) {
-      const hours = parseInt(this.stage.canaryConfig.lifetimeHours, 10);
-      if (isFinite(hours)) {
-        const fractional =
-          parseFloat(this.stage.canaryConfig.lifetimeHours) - hours;
-        const minutes = Math.floor(fractional * 60);
-        this.stage.canaryConfig.lifetimeDuration = `PT${hours}H`;
-        if (isFinite(minutes)) {
-          this.stage.canaryConfig.lifetimeDuration += `${minutes}M`;
-        }
-        this.state.lifetimeHoursUpdatedToDuration = true;
-      }
-      delete this.stage.canaryConfig.lifetimeHours;
-    }
-  }
-
-  private getStateLifetime(): IKayentaStageLifetime {
-    let hours = parseInt(this.state.lifetime.hours, 10);
-    let minutes = parseInt(this.state.lifetime.minutes, 10);
-    if (!isFinite(hours) || hours < 0) {
-      hours = 0;
-    }
-    if (!isFinite(minutes) || minutes < 0) {
-      minutes = 0;
-    }
-    return { hours, minutes };
-  }
-
-  private getLifetimeFromStageLifetimeDuration(): IKayentaStageLifetime {
-    const duration = get(this.stage, ['canaryConfig', 'lifetimeDuration']);
-    if (!isString(duration)) {
-      return {};
-    }
-    const lifetimeComponents = duration.match(/PT(\d+)H(?:(\d+)M)?/i);
-    if (lifetimeComponents == null) {
-      return {};
-    }
-    const hours = parseInt(lifetimeComponents[1], 10);
-    if (!isFinite(hours) || hours < 0) {
-      return {};
-    }
-    let minutes = parseInt(lifetimeComponents[2], 10);
-    if (!isFinite(minutes) || minutes < 0) {
-      minutes = 0;
-    }
-    return { hours, minutes };
-  }
-
-  public isLifetimeRequired(): boolean {
-    const lifetime = this.getStateLifetime();
-    return lifetime.hours === 0 && lifetime.minutes === 0;
-  }
-
-  public getLifetimeClassnames(): string {
-    if (this.state.lifetimeHoursUpdatedToDuration) {
-      return 'alert alert-warning';
-    }
-    return '';
-  }
-}
-
-const requiredForAnalysisType = (analysisType: KayentaAnalysisType, fieldName: string, fieldLabel?: string): (p: IPipeline, s: IKayentaStage) => string => {
+const requiredForAnalysisTypes = (
+  analysisTypes: KayentaAnalysisType[] = [],
+  fieldName: string,
+  fieldLabel?: string
+): (p: IPipeline, s: IKayentaStage) => string => {
   return (_pipeline: IPipeline, stage: IKayentaStage): string => {
-    if (stage.analysisType === analysisType) {
+    if (analysisTypes.includes(stage.analysisType)) {
       if (!has(stage, fieldName) || get(stage, fieldName) === '') {
         return `<strong>${fieldLabel || fieldName}</strong> is a required field for Kayenta Canary stages.`;
       }
@@ -347,7 +28,10 @@ const requiredForAnalysisType = (analysisType: KayentaAnalysisType, fieldName: s
   }
 };
 
-const allScopesMustBeConfigured = (_pipeline: IPipeline, stage: IKayentaStage): Promise<string> => {
+const allScopesMustBeConfigured = (
+  _pipeline: IPipeline,
+  stage: IKayentaStage
+): Promise<string> => {
   return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then(configDetails => {
     let definedScopeNames = uniq(map(configDetails.metrics, metric => metric.scopeName || 'default'));
     definedScopeNames = !isEmpty(definedScopeNames) ? definedScopeNames : ['default'];
@@ -365,7 +49,10 @@ const allScopesMustBeConfigured = (_pipeline: IPipeline, stage: IKayentaStage): 
   });
 };
 
-const allConfiguredScopesMustBeDefined = (_pipeline: IPipeline, stage: IKayentaStage): Promise<string> => {
+const allConfiguredScopesMustBeDefined = (
+  _pipeline: IPipeline,
+  stage: IKayentaStage
+): Promise<string> => {
   return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then(configDetails => {
     let definedScopeNames = uniq(map(configDetails.metrics, metric => metric.scopeName || 'default'));
     definedScopeNames = !isEmpty(definedScopeNames) ? definedScopeNames : ['default'];
@@ -386,9 +73,11 @@ const allConfiguredScopesMustBeDefined = (_pipeline: IPipeline, stage: IKayentaS
 export const KAYENTA_CANARY_STAGE = 'spinnaker.kayenta.canaryStage';
 module(KAYENTA_CANARY_STAGE, [
     CANARY_SCORES_CONFIG_COMPONENT,
+    KAYENTA_ANALYSIS_TYPE_COMPONENT,
     KAYENTA_STAGE_CONFIG_SECTION,
     KAYENTA_STAGE_TRANSFORMER,
     KAYENTA_STAGE_EXECUTION_DETAILS_CONTROLLER,
+    FOR_ANALYSIS_TYPE_COMPONENT,
   ])
   .config(() => {
     'ngInject';
@@ -402,19 +91,84 @@ module(KAYENTA_CANARY_STAGE, [
       executionDetailsUrl: require('./kayentaStageExecutionDetails.html'),
       validators: [
         { type: 'requiredField', fieldName: 'canaryConfig.canaryConfigId', fieldLabel: 'Config Name' },
-        { type: 'requiredField', fieldName: 'canaryConfig.scopes[0].controlScope', fieldLabel: 'Baseline Scope' },
-        { type: 'requiredField', fieldName: 'canaryConfig.scopes[0].experimentScope', fieldLabel: 'Canary Scope' },
         { type: 'requiredField', fieldName: 'canaryConfig.metricsAccountName', fieldLabel: 'Metrics Account' },
         { type: 'requiredField', fieldName: 'canaryConfig.storageAccountName', fieldLabel: 'Storage Account' },
-        { type: 'custom', validate: requiredForAnalysisType(KayentaAnalysisType.RealTime, 'canaryConfig.lifetimeDuration', 'Lifetime') },
-        { type: 'custom', validate: requiredForAnalysisType(KayentaAnalysisType.Retrospective, 'canaryConfig.scopes[0].startTimeIso', 'Start Time') },
-        { type: 'custom', validate: requiredForAnalysisType(KayentaAnalysisType.Retrospective, 'canaryConfig.scopes[0].endTimeIso', 'End Time') },
-        { type: 'custom', validate: allScopesMustBeConfigured },
-        { type: 'custom', validate: allConfiguredScopesMustBeDefined },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.RealTimeAutomatic],
+            'deployments.serverGroupPairs[0].control',
+            'Baseline & Canary Server Groups'
+          )
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.RealTimeAutomatic],
+            'deployments.baseline.cluster',
+            'Baseline Cluster'
+          )
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.RealTimeAutomatic],
+            'deployments.baseline.account',
+            'Baseline Account'
+          )
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.RealTime, KayentaAnalysisType.Retrospective],
+            'canaryConfig.scopes[0].controlScope',
+            'Baseline Scope'
+          )
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.RealTime, KayentaAnalysisType.Retrospective],
+            'canaryConfig.scopes[0].experimentScope',
+            'Baseline Scope'
+          )
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.RealTime, KayentaAnalysisType.RealTimeAutomatic],
+            'canaryConfig.lifetimeDuration',
+            'Lifetime'
+          ),
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.Retrospective],
+            'canaryConfig.scopes[0].startTimeIso',
+            'Start Time'
+          )
+        },
+        {
+          type: 'custom',
+          validate: requiredForAnalysisTypes(
+            [KayentaAnalysisType.Retrospective],
+            'canaryConfig.scopes[0].endTimeIso',
+            'End Time'
+          )
+        },
+        {
+          type: 'custom',
+          validate: allScopesMustBeConfigured
+        },
+        {
+          type: 'custom',
+          validate: allConfiguredScopesMustBeDefined
+        },
       ]
     });
   })
-  .controller('KayentaCanaryStageCtrl', CanaryStage)
+  .controller('KayentaCanaryStageCtrl', KayentaStageController)
   .run((kayentaStageTransformer: KayentaStageTransformer) => {
     'ngInject';
     Registry.pipeline.registerTransformer(kayentaStageTransformer);

--- a/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
@@ -69,10 +69,6 @@
           <div class="col-md-6">{{stage.context.canaryConfig.lifetimeHours}} hours</div>
         </div>
         <div class="row">
-          <div class="col-md-4 sm-label-right compact">Result Strategy</div>
-          <div class="col-md-6">{{stage.context.canaryConfig.combinedCanaryResultStrategy | lowercase}}</div>
-        </div>
-        <div class="row">
           <div class="col-md-4 sm-label-right compact">Pass</div>
           <div class="col-md-6">{{stage.context.canaryConfig.scoreThresholds.pass}}</div>
         </div>

--- a/src/kayenta/stages/kayentaStage/stageTypes.ts
+++ b/src/kayenta/stages/kayentaStage/stageTypes.ts
@@ -1,3 +1,4 @@
 export const KAYENTA_CANARY = 'kayentaCanary';
 export const RUN_CANARY = 'runCanary';
 export const WAIT = 'wait';
+export const DEPLOY_CANARY_SERVER_GROUPS = 'deployCanaryServerGroups';

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,7 +4,6 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const path = require('path');
 const NODE_MODULE_PATH = path.join(__dirname, 'node_modules');
-const fs = require('fs');
 const inclusionPattern = [
   path.resolve(__dirname, 'src'),
   path.resolve(NODE_MODULE_PATH, '@spinnaker/styleguide'),
@@ -109,7 +108,7 @@ function configure(IS_TEST) {
         'angular-cache', 'angular-messages', 'angular-sanitize', 'bootstrap',
         'clipboard', 'd3', 'jquery-ui', 'moment-timezone', 'rxjs', 'react', 'angular2react',
         'react2angular', 'react-bootstrap', 'react-dom', 'react-ga', 'ui-router-visualizer', 'ui-select',
-        '@uirouter/angularjs'
+        '@uirouter/angularjs', 'babel-polyfill'
       ],
       spinnaker: ['@spinnaker/core']
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,9 +77,9 @@
   version "0.0.104"
   resolved "https://registry.yarnpkg.com/@spinnaker/amazon/-/amazon-0.0.104.tgz#e1b3305cc11f1029deba0a2003be2a4f2ba1973e"
 
-"@spinnaker/core@0.0.237":
-  version "0.0.237"
-  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.237.tgz#ec80ac2f31f5c4bf8d2233d8a98b11c63eb6801e"
+"@spinnaker/core@0.0.259":
+  version "0.0.259"
+  resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.259.tgz#614d15dec343b40b90387302f3ed28929198c39c"
 
 "@spinnaker/styleguide@^1.0.1":
   version "1.0.1"
@@ -1232,6 +1232,16 @@ babel-helper-regex@^6.24.1:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
@@ -1268,6 +1278,18 @@ babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
@@ -1451,6 +1473,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-es2015@^6.18.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
@@ -1492,7 +1522,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0:
+babel-runtime@^6.0.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2793,6 +2823,10 @@ core-js@^2.0.0:
 core-js@^2.2.0, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
+core-js@^2.5.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -9416,7 +9450,7 @@ regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
 
-regenerator-runtime@^0.10.0:
+regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 


### PR DESCRIPTION
First pass at this, definitely some problems. The diff is not as bad as it looks, since it's mostly refactoring and moving things around. Most of the added logic / templates are from `canaryStage.js` in the main deck repo. I am definitely open to refactoring / moving towards react / testing but wanted to get this in.

Looks like this:

![real_time_automatic](https://user-images.githubusercontent.com/13868700/44409407-50f44880-a530-11e8-9b63-c5229fa478f1.png)

Known problems:
1). The machine type selector doesn't work when copying a GCE server group from a template, or when editing a GCE server group. It does work when creating one from scratch. This is a current bug for the GCE deploy stage, which is why I'm not fixing it here.
2). For stackdriver, we still expose "resource type", even though it feels as if, at least configuring canary for GCE, we should auto-pick `gce_instance`. I think that selector is going away from the stage config anyways, which is why it's there.
3). Only works for GCE, though that's only because I don't know the new AWS react server group wizard. I can take a look at that soon or maybe @erikmunson can help me out.

Depends on https://github.com/spinnaker/orca/pull/2346 and https://github.com/spinnaker/deck/pull/5642