### PR TITLE
chore(deps): Upgrade typescript to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "tslint-eslint-rules": "^5.2.0",
     "tslint-loader": "^3.6.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^2.8.3",
+    "typescript": "^3.0.2",
     "url-loader": "^0.5.7",
     "webpack": "^2.5.1",
     "webpack-dev-server": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11366,9 +11366,9 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
It appears that the recent upgrade of `@spinnaker/core` exposed the fact that `deck-kayenta` is running typescript 2, which is a major version behind the deck repo. Seems as if some newer syntax in one of `@spinnaker/core`'s declaration files caused TS 2 to fail. 

fyi @danielpeach