### PR TITLE
 feat(executions): Re-org execution list, add locations and scopes

### DIFF
--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -115,10 +115,13 @@
     }
   }
 
+  // As of 9/31/2018 this must be applied to a <th> for sticky table headers to work (not a <tr>/<thead>)
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=702927
   .native-table-header {
     position: sticky;
     top: 0;
     background-color: var(--color-alabaster);
+    // Borders don't work w/ position: sticky in this case
     box-shadow: 0 1px 0 var(--color-divider);
   }
 

--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -77,7 +77,7 @@
   }
 
   .table-row {
-    > div {
+    > div, > td {
       padding: .8rem 0;
     }
 
@@ -113,6 +113,13 @@
     &.background-white {
       background-color: var(--color-white);
     }
+  }
+
+  .native-table-header {
+    position: sticky;
+    top: 0;
+    background-color: var(--color-alabaster);
+    box-shadow: 0 1px 0 var(--color-divider);
   }
 
   .metric-list {

--- a/src/kayenta/domain/ICanaryExecutionStatusResult.ts
+++ b/src/kayenta/domain/ICanaryExecutionStatusResult.ts
@@ -1,6 +1,8 @@
 import { ICanaryJudgeResult } from './ICanaryJudgeResult';
 import { ICanaryClassifierThresholdsConfig, ICanaryConfig } from './ICanaryConfig';
 
+export const CANARY_EXECUTION_NO_PIPELINE_STATUS = 'no-parent-pipeline-execution';
+
 export interface ICanaryExecutionStatusResult {
   id: string // Added by Deck on load.
   complete: boolean;

--- a/src/kayenta/domain/ICanaryExecutionStatusResult.ts
+++ b/src/kayenta/domain/ICanaryExecutionStatusResult.ts
@@ -42,4 +42,5 @@ export interface ICanaryScope {
   start: string;
   end: string;
   step: number;
+  extendedScopeParams?: { [param: string]: string };
 }

--- a/src/kayenta/domain/ICanaryExecutionStatusResult.ts
+++ b/src/kayenta/domain/ICanaryExecutionStatusResult.ts
@@ -29,12 +29,16 @@ export interface ICanaryResult {
 export interface ICanaryExecutionRequest {
   thresholds: ICanaryClassifierThresholdsConfig;
   scopes: {
-    [scopeName: string]: {
-      controlScope: ICanaryScope;
-      experimentScope: ICanaryScope;
-    };
+    [scopeName: string]: ICanaryScopePair;
   };
 }
+
+export type ICanaryScopesByName = ICanaryExecutionRequest['scopes'];
+
+export interface ICanaryScopePair {
+  controlScope: ICanaryScope;
+  experimentScope: ICanaryScope;
+};
 
 export interface ICanaryScope {
   scope: string;

--- a/src/kayenta/layout/table/index.ts
+++ b/src/kayenta/layout/table/index.ts
@@ -1,3 +1,5 @@
 export * from './table';
 export * from './tableColumn';
 export * from './tableHeader';
+export * from './nativeTable';
+export * from './nativeTableHeader';

--- a/src/kayenta/layout/table/nativeTable.tsx
+++ b/src/kayenta/layout/table/nativeTable.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+
+import { ITableColumn } from './tableColumn';
+import { NativeTableHeader } from './nativeTableHeader';
+
+export interface INativeTableProps<T> {
+  rows: T[];
+  columns: ITableColumn<T>[];
+  rowKey: (row: T) => string;
+  tableBodyClassName?: string;
+  headerClassName?: string;
+  rowClassName?: (row: T) => string;
+  onRowClick?: (row: T) => void;
+  customRow?: (row: T) => JSX.Element;
+  className?: string;
+}
+
+export function NativeTable<T>({ rows, columns, rowKey, tableBodyClassName, rowClassName, onRowClick, customRow, className, headerClassName }: INativeTableProps<T>) {
+  const TableRow = ({ row }: { row: T }) => (
+    <tr
+      onClick={onRowClick ? () => onRowClick(row) : null}
+      className={classNames({ 'table-row': !rowClassName }, rowClassName && rowClassName(row))}
+    >
+      {
+        columns.map(({ label, hide, getContent }, i) => (
+          <td key={label || i}>
+            {!hide && getContent(row)}
+          </td>
+        ))
+      }
+    </tr>
+  );
+
+  return (
+    <table className={className}>
+      <NativeTableHeader columns={columns} className={classNames('table-header', headerClassName)}/>
+      <tbody className={tableBodyClassName}>
+        {
+          rows.map(r => (
+            customRow && customRow(r)
+              ? <td key={rowKey(r)}>{customRow(r)}</td>
+              : <TableRow key={rowKey(r)} row={r}/>
+          ))
+        }
+      </tbody>
+    </table>
+  );
+}
+

--- a/src/kayenta/layout/table/nativeTableHeader.tsx
+++ b/src/kayenta/layout/table/nativeTableHeader.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+
+import { ITableColumn } from './tableColumn';
+
+export interface INativeTableHeaderProps {
+  columns: ITableColumn<any>[];
+  className: string;
+}
+
+export const NativeTableHeader = ({ columns, className }: INativeTableHeaderProps) => {
+  return (
+    <thead className={className}>
+      <tr>
+        {columns.map(({ label, labelClassName, hide }, i) => (
+          <th key={label || i} className="native-table-header">
+            {!hide && (
+              <h6 className={classNames('heading-6', 'uppercase', 'color-text-primary', labelClassName)}>
+                {label}
+              </h6>
+            )}
+          </th>
+        ))}
+      </tr>
+    </thead>
+  );
+};

--- a/src/kayenta/layout/table/tableColumn.ts
+++ b/src/kayenta/layout/table/tableColumn.ts
@@ -2,6 +2,6 @@ export interface ITableColumn<T> {
   label?: string;
   labelClassName?: string;
   hide?: boolean;
-  width: number;
+  width?: number;
   getContent: (data: T) => JSX.Element;
 }

--- a/src/kayenta/report/list/configLink.tsx
+++ b/src/kayenta/report/list/configLink.tsx
@@ -21,8 +21,9 @@ export const ConfigLink = ({ configId, configName }: IConfigLinkOwnProps & IConf
       stateParams={{
         id: configId,
       }}
-      linkText={configName}
-    />
+    >
+      {configName}
+    </Link>
   );
 };
 

--- a/src/kayenta/report/list/executionList.less
+++ b/src/kayenta/report/list/executionList.less
@@ -1,6 +1,7 @@
+.execution-list-container {
+  overflow-y: auto;
+}
+
 .execution-list-table {
-  .list-group {
-    overflow-y: auto;
-    margin-bottom: 0;
-  }
+  margin-bottom: 0;
 }

--- a/src/kayenta/report/list/link.tsx
+++ b/src/kayenta/report/list/link.tsx
@@ -4,10 +4,10 @@ import { ReactInjector } from '@spinnaker/core';
 interface ILinkProps {
   targetState: string;
   stateParams: {[key: string]: any};
-  linkText: string;
+  children?: React.ReactNode;
 }
 
-export const Link = ({ targetState, stateParams, linkText }: ILinkProps) => {
+export const Link = ({ targetState, stateParams, children }: ILinkProps) => {
   const handleClick = () =>
     ReactInjector.$state.go(targetState, stateParams);
 
@@ -16,7 +16,7 @@ export const Link = ({ targetState, stateParams, linkText }: ILinkProps) => {
       className="clickable"
       onClick={handleClick}
     >
-      {linkText}
+      {children}
     </a>
   );
 };

--- a/src/kayenta/report/list/pipelineLink.tsx
+++ b/src/kayenta/report/list/pipelineLink.tsx
@@ -14,7 +14,8 @@ export const PipelineLink = ({ parentPipelineExecutionId, application }: IParent
         application,
         executionId: parentPipelineExecutionId,
       }}
-      linkText="Pipeline"
-    />
+    >
+      Pipeline
+    </Link>
   );
 };

--- a/src/kayenta/report/list/reportLink.tsx
+++ b/src/kayenta/report/list/reportLink.tsx
@@ -8,13 +8,14 @@ interface IReportLinkOwnProps {
   configName: string;
   executionId: string;
   application: string;
+  children?: React.ReactNode;
 }
 
 interface IReportLinkStateProps {
   configId: string;
 }
 
-export const ReportLink = ({ configId, executionId }: IReportLinkOwnProps & IReportLinkStateProps) => {
+export const ReportLink = ({ configId, executionId, children }: IReportLinkOwnProps & IReportLinkStateProps) => {
   return (
     <Link
       targetState="^.reportDetail"
@@ -22,8 +23,9 @@ export const ReportLink = ({ configId, executionId }: IReportLinkOwnProps & IRep
         configId,
         runId: executionId,
       }}
-      linkText="Report"
-    />
+    >
+      {children}
+    </Link>
   );
 };
 

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -15,12 +15,17 @@ import { PipelineLink } from './pipelineLink';
 
 import './executionList.less';
 
+
+// Both this and the atlas-specific logic in `getScopeLocations` shouldn't really
+// be in this file, and probably shouldn't even be referenced directly.
+// Ideally this and any other metric store customizations should happen in a registry
+// of store-specific transformation functions or similar.
 const isAtlasScope = (scope: string, metrics: ICanaryMetricConfig[]) => (
   metrics.some(({ query, scopeName }) => scopeName === scope && query.type === 'atlas')
 );
 
 const getScopeLocations = (scopes: ICanaryScopesByName, metrics: ICanaryMetricConfig[]) => (
-  Object.keys(scopes).reduce<Set<string>>((acc, scopeName) => {
+  Object.keys(scopes).reduce((acc, scopeName) => {
     const { controlScope, experimentScope } = scopes[scopeName];
     const isAtlas = isAtlasScope(scopeName, metrics);
 
@@ -38,7 +43,7 @@ const getScopeLocations = (scopes: ICanaryScopesByName, metrics: ICanaryMetricCo
     }
 
     return acc;
-  }, new Set())
+  }, new Set<string>())
 );
 
 const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
@@ -92,12 +97,12 @@ const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
   {
     label: 'Scopes',
     getContent: ({ canaryExecutionRequest: { scopes } }) => {
-      const baselineScopeNames = Object.keys(scopes).reduce<Set<string>>((acc, scope) =>
+      const baselineScopeNames = Object.keys(scopes).reduce((acc, scope) =>
         acc.add(scopes[scope].controlScope.scope)
-      , new Set())
-      const canaryScopeNames = Object.keys(scopes).reduce<Set<string>>((acc, scope) =>
+      , new Set<string>())
+      const canaryScopeNames = Object.keys(scopes).reduce((acc, scope) =>
         acc.add(scopes[scope].experimentScope.scope)
-      , new Set())
+      , new Set<string>())
 
       const areScopesIdentical = isEqual(baselineScopeNames, canaryScopeNames);
 

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -48,7 +48,7 @@ const getScopeLocations = (scopes: ICanaryScopesByName, metrics: ICanaryMetricCo
 
 const columns: ITableColumn<ICanaryExecutionStatusResult>[] = [
   {
-    label: 'Score / Report',
+    label: 'Summary',
     getContent: execution => (
       <>
         <ReportLink


### PR DESCRIPTION
We've gotten a lot of feedback on the report list, including:

- It's pretty unhelpful in terms of differentiating one run from another when the same config is used across multiple use cases.
- The `Pipeline` link is frustrating because it shows up when there's no pipeline, and then links to a broken page.
- It's difficult to navigate around because the `Report` link itself is all the way to the right and not particularly noticeable.

This is an attempt to solve some of those issues without doing a full rethink of the report list, which ought to happen at some point but will take a larger time investment.

A brief summary:

- The date, score, report link and a new relative date are all grouped together on the far left.
- The pipeline link is hidden when there's no parent pipeline.
- To differentiate between runs, there's now a de-duped summary of the locations and scopes for the report that also tolerates one of the Atlas specific quirks we've run into (`location` is not accurate when the dataset is configured to `global`).

Here's what it looks like with a single scope:
<img width="1369" alt="screen shot 2018-08-31 at 11 33 57 am" src="https://user-images.githubusercontent.com/1850998/44930100-18afef80-ad12-11e8-962a-40ac897f4e74.png">

And here's what it looks like with multiple scopes (if there are multiple scopes within canary / baseline, it will stack them vertically inside their group):
<img width="1365" alt="screen shot 2018-08-31 at 11 37 44 am" src="https://user-images.githubusercontent.com/1850998/44930189-5d3b8b00-ad12-11e8-94da-d3d5ae8061cd.png">

