### PR TITLE
feat(stage): Add support for Amazon in Real Time Automatic mode

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -186,7 +186,7 @@
     </kayenta-stage-config-section>
   </for-analysis-type>
 
-  <kayenta-stage-config-section title="Baseline + Canary Server Groups">
+  <kayenta-stage-config-section title="Baseline + Canary Pair">
     <section-header ng-if="kayentaCanaryStageCtrl.stage.analysisType === 'realTime'">
       <span
         uib-tooltip="Click to populate with expressions for resolving control
@@ -273,7 +273,7 @@
               <tr ng-if="!kayentaCanaryStageCtrl.stage.deployments.serverGroupPairs.length">
                 <td colspan="4">
                   <button class="btn btn-block btn-sm add-new" ng-click="kayentaCanaryStageCtrl.addPair()">
-                    <span class="glyphicon glyphicon-plus-sign"></span> Create baseline / canary pair
+                    <span class="glyphicon glyphicon-plus-sign"></span> Add Baseline + Canary Pair
                   </button>
                 </td>
               </tr>


### PR DESCRIPTION
This just wires up the React code path for clone server group modals, which enables Amazon to do work with Real Time Automatic mode without much extra effort. Hasn't been heavily tested so may end up requiring some patches later on if we discover things in production.

Also opens up support for Titus, but I think there's some stuff in `@spinnaker/titus` that needs fixing to fully support that.