### PR TITLE
feat: add validation to metrics form #345

### DIFF
--- a/src/kayenta/edit/editMetricValidation.spec.ts
+++ b/src/kayenta/edit/editMetricValidation.spec.ts
@@ -1,0 +1,87 @@
+import {
+  ICanaryMetricValidationErrors,
+  validateMetric,
+  validateMetricName,
+  validateMetricScopeName
+} from './editMetricValidation';
+import { ICanaryMetricConfig } from '../domain';
+
+describe('Canary metric validation', () => {
+  let errors: ICanaryMetricValidationErrors;
+  let editingMetric: ICanaryMetricConfig;
+  let metricList: ICanaryMetricConfig[];
+
+  beforeEach(() => {
+    errors = createErrors();
+    editingMetric = createEditingMetric('A', 'a');
+    metricList = createMetricList();
+  });
+
+  describe('validateMetricName', () => {
+    it('Does not update errors when metric name is valid', () => {
+      editingMetric.name = 'D';
+      expect(validateMetricName(errors, editingMetric, metricList).name).toBeNull();
+    });
+    it('Updates errors appropriately when metric name is empty', () => {
+      editingMetric.name = '';
+      expect(validateMetricName(errors, editingMetric, metricList).name).toEqual({
+        message: 'Name is required'
+      });
+    });
+    it('Updates errors appropriately when metric name is not unique', () => {
+      editingMetric.name = 'B';
+      expect(validateMetricName(errors, editingMetric, metricList).name).toEqual({
+        message: "Metric 'B' already exists"
+      });
+    });
+  });
+
+  describe('validateMetricScopeName', () => {
+    it('Does not update errors when metric scope name is valid', () => {
+      expect(validateMetricScopeName(errors, editingMetric).scopeName).toBeNull();
+    });
+    it('Updates errors appropriately when metric scope name is empty', () => {
+      editingMetric.scopeName = '';
+      expect(validateMetricScopeName(errors, editingMetric).scopeName).toEqual({
+        message: 'Scope name is required'
+      });
+    });
+  });
+
+  describe('validateMetric', () => {
+    it('Does not update errors when all fields are valid', () => {
+      expect(validateMetric(editingMetric, metricList)).toEqual(errors);
+    });
+    it('Reduces validation of all fields into one object', () => {
+      editingMetric.name = '';
+      editingMetric.scopeName = '';
+      expect(validateMetric(editingMetric, metricList)).toEqual({
+        name: { message: 'Name is required' },
+        scopeName: { message: 'Scope name is required' }
+      });
+    });
+  });
+});
+
+function createErrors(): ICanaryMetricValidationErrors {
+  return {
+    name: null,
+    scopeName: null
+  };
+}
+
+function createEditingMetric(name: string, id: string): ICanaryMetricConfig {
+  return {
+    name,
+    id,
+    scopeName: 'default'
+  } as ICanaryMetricConfig;
+}
+
+function createMetricList(): ICanaryMetricConfig[] {
+  return [
+    createEditingMetric('A', 'a'),
+    createEditingMetric('B', 'b'),
+    createEditingMetric('C', 'c')
+  ];
+}

--- a/src/kayenta/edit/editMetricValidation.ts
+++ b/src/kayenta/edit/editMetricValidation.ts
@@ -1,0 +1,54 @@
+import { get } from 'lodash';
+import { ICanaryMetricConfig } from '../domain';
+
+export interface ICanaryMetricValidationError {
+  message: string;
+}
+
+export interface ICanaryMetricValidationErrors {
+  name: ICanaryMetricValidationError;
+  scopeName: ICanaryMetricValidationError;
+}
+
+export function validateMetricName(errors: ICanaryMetricValidationErrors, editingMetric: ICanaryMetricConfig, metricList: ICanaryMetricConfig[]): ICanaryMetricValidationErrors {
+  const nextErrors = { ...errors };
+
+  const editingMetricName = get(editingMetric, 'name', '');
+  if (!editingMetricName) {
+    nextErrors.name = { message: 'Name is required' };
+    return nextErrors;
+  }
+
+  const isNameUnique = metricList.every(m =>
+    m.name !== editingMetricName || m.id === editingMetric.id
+  );
+  if (!isNameUnique) {
+    nextErrors.name = { message: `Metric '${editingMetricName}' already exists` }
+  }
+
+  return nextErrors;
+}
+
+export function validateMetricScopeName(errors: ICanaryMetricValidationErrors, editingMetric: ICanaryMetricConfig): ICanaryMetricValidationErrors {
+  const nextErrors = { ...errors };
+
+  const editingMetricScopeName = get(editingMetric, 'scopeName', '');
+
+  if (!editingMetricScopeName) {
+    nextErrors.scopeName = { message: 'Scope name is required' }
+  }
+
+  return nextErrors;
+}
+
+export function validateMetric(editingMetric: ICanaryMetricConfig, metricList: ICanaryMetricConfig[]): ICanaryMetricValidationErrors {
+  const errors: ICanaryMetricValidationErrors = {
+    name: null,
+    scopeName: null,
+  };
+
+  return [
+    validateMetricName,
+    validateMetricScopeName
+  ].reduce((reducedErrors, validator) => validator(reducedErrors, editingMetric, metricList), errors);
+}

--- a/src/kayenta/layout/formRow.tsx
+++ b/src/kayenta/layout/formRow.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import { ValidationMessage } from '@spinnaker/core';
 
 export default function FormRow(
-  { label, children, checkbox }: { label?: string | React.ReactFragment, children?: any, checkbox?: boolean }
+  { label, children, checkbox, error }: { label?: string | React.ReactFragment, children?: any, checkbox?: boolean, error?: string }
 ) {
   return (
     <div className="form-group row">
@@ -14,6 +15,7 @@ export default function FormRow(
         style={checkbox ? { marginTop: '0', marginBottom: '0' } : null}
       >
         {children}
+        {error && <ValidationMessage type="error" message={error} />}
       </div>
     </div>
   );

--- a/src/kayenta/selectors/index.ts
+++ b/src/kayenta/selectors/index.ts
@@ -2,8 +2,9 @@ import { createSelector } from 'reselect';
 import { get } from 'lodash';
 
 import { ICanaryState } from '../reducers/index';
-import { ICanaryConfig } from 'kayenta/domain/index';
+import { ICanaryConfig, ICanaryMetricConfig } from 'kayenta/domain/index';
 import { ICanaryExecutionStatusResult } from '../domain/ICanaryExecutionStatusResult';
+import { validateMetric } from '../edit/editMetricValidation';
 
 export const runSelector = (state: ICanaryState): ICanaryExecutionStatusResult => state.selectedRun.run;
 
@@ -62,3 +63,15 @@ export const resolveConfigIdFromExecutionId = (state: ICanaryState, executionId:
   const execution = executions.find(ex => ex.pipelineId === executionId);
   return execution.canaryConfigId;
 };
+
+export const editingMetricSelector =
+  (state: ICanaryState): ICanaryMetricConfig => state.selectedConfig.editingMetric;
+
+export const metricListSelector =
+  (state: ICanaryState): ICanaryMetricConfig[] => state.selectedConfig.metricList;
+
+export const editingMetricValidationErrorsSelector = createSelector(
+  editingMetricSelector,
+  metricListSelector,
+  validateMetric
+);


### PR DESCRIPTION
Resolves #345

Adds validation to the metrics form:
- Missing metric name ([Screenshot](https://screenshot.googleplex.com/bp3R1WdrctG))
- Duplicate metric name ([Screenshot](https://screenshot.googleplex.com/5QAcVzxLQMu))
- Missing metric scope name ([Screenshot](https://screenshot.googleplex.com/PkfXCAReGuj)) 

Per discussion with @danielpeach, I considered refactoring the metrics form to use Formik, but this would have required removing the form state from the Redux state, which each of the individually-connected metrics configuration components reads from and updates. Instead, I added a Formik-style errors object prop to `editMetricModal` with keys corresponding to each validated field. I added the logic for populating this to a selector so it can be derived from but not pollute the Redux state. I also added an error prop to `FormRow` to conditionally render an error component below invalid inputs.