### PR TITLE
feat(stage): Add support for predefined locations, atlas scope fields

### DIFF
--- a/src/kayenta/domain/IKayentaAccount.ts
+++ b/src/kayenta/domain/IKayentaAccount.ts
@@ -3,6 +3,8 @@ export interface IKayentaAccount {
   type: string;
   supportedTypes: KayentaAccountType[];
   metricsStoreType?: string;
+  locations?: string[];
+  recommendedLocations?: string[];
 }
 
 export enum KayentaAccountType {

--- a/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
@@ -180,6 +180,8 @@ export class KayentaStageController implements IComponentController {
       case KayentaAnalysisType.RealTimeAutomatic:
         delete this.stage.canaryConfig.scopes[0].startTimeIso;
         delete this.stage.canaryConfig.scopes[0].endTimeIso;
+        delete this.stage.canaryConfig.scopes[0].controlLocation;
+        delete this.stage.canaryConfig.scopes[0].experimentLocation;
         this.initializeRealTimeAutomaticAnalysisType();
         break;
       case KayentaAnalysisType.Retrospective:

--- a/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
@@ -31,6 +31,12 @@ export class KayentaStageController implements IComponentController {
     detailsLoading: false,
     lifetimeHoursUpdatedToDuration: false,
     lifetime: { hours: '', minutes: '' },
+    showAdvancedSettings: false,
+    useAtlasGlobalDataset: false,
+    showAllLocations: {
+      control: false,
+      experiment: false,
+    },
   };
   public canaryConfigSummaries: ICanaryConfigSummary[] = [];
   public selectedCanaryConfigDetails: ICanaryConfig;
@@ -57,11 +63,12 @@ export class KayentaStageController implements IComponentController {
   private initialize = async (): Promise<void> => {
     await this.loadBackingData();
 
+    const firstStorageAccount = first(this.kayentaAccounts.get(KayentaAccountType.ObjectStore));
+    const firstMetricsAccount = first(this.kayentaAccounts.get(KayentaAccountType.MetricsStore));
+
     this.stage.canaryConfig = {
-      storageAccountName:
-        first(this.kayentaAccounts.get(KayentaAccountType.ConfigurationStore)) || CanarySettings.storageAccountName,
-      metricsAccountName:
-        first(this.kayentaAccounts.get(KayentaAccountType.MetricsStore)) || CanarySettings.metricsAccountName,
+      storageAccountName: (firstStorageAccount && firstStorageAccount.name) || CanarySettings.storageAccountName,
+      metricsAccountName: (firstMetricsAccount && firstMetricsAccount.name) || CanarySettings.metricsAccountName,
       ...this.stage.canaryConfig,
       scoreThresholds: {
         marginal: null,
@@ -90,6 +97,8 @@ export class KayentaStageController implements IComponentController {
 
     this.populateScopeNameChoices();
     this.setMetricStore();
+    this.setLocations();
+    this.setShowAdvancedSettings();
     this.setClusterList();
     this.deleteConfigAccountsIfMissing();
     this.updateLifetimeFromHoursToDuration();
@@ -137,7 +146,6 @@ export class KayentaStageController implements IComponentController {
     this.selectedCanaryConfigDetails = await this.loadCanaryConfigDetails();
     this.populateScopeNameChoices();
     this.setMetricStore();
-    this.overrideScoreThresholds();
   };
 
   public isExpression = (val: number | string): boolean => {
@@ -160,6 +168,14 @@ export class KayentaStageController implements IComponentController {
         delete this.stage.canaryConfig.scopes[0].startTimeIso;
         delete this.stage.canaryConfig.scopes[0].endTimeIso;
         delete this.stage.deployments;
+
+        if (this.metricStore === 'atlas') {
+          this.stage.canaryConfig.scopes.forEach((scope) => {
+            if (scope.extendedScopeParams) {
+              delete scope.extendedScopeParams.dataset;
+            }
+          });
+        }
         break;
       case KayentaAnalysisType.RealTimeAutomatic:
         delete this.stage.canaryConfig.scopes[0].startTimeIso;
@@ -170,6 +186,14 @@ export class KayentaStageController implements IComponentController {
         delete this.stage.canaryConfig.beginCanaryAnalysisAfterMins;
         delete this.stage.canaryConfig.lifetimeDuration;
         delete this.stage.deployments;
+
+        if (this.metricStore === 'atlas') {
+          this.stage.canaryConfig.scopes.forEach((scope) => {
+            if (scope.extendedScopeParams) {
+              delete scope.extendedScopeParams.dataset;
+            }
+          });
+        }
         break;
     }
     // Called from React.
@@ -191,6 +215,7 @@ export class KayentaStageController implements IComponentController {
     };
     this.accounts = await this.loadAccounts();
     this.setClusterList();
+    this.setMetricStore();
   };
 
   private loadCanaryConfigDetails = async (): Promise<ICanaryConfig> => {
@@ -212,34 +237,104 @@ export class KayentaStageController implements IComponentController {
 
   private setMetricStore = (): void => {
     this.metricStore = get(this.selectedCanaryConfigDetails, 'metrics[0].query.type');
+
+    if (this.metricStore === 'atlas') {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
+        scope.extendedScopeParams = { ...(scope.extendedScopeParams || {}) };
+        // TODO: support query types
+        scope.extendedScopeParams.type = 'cluster';
+      });
+
+      if (this.stage.analysisType === KayentaAnalysisType.RealTimeAutomatic) {
+        this.state.useAtlasGlobalDataset = (this.stage.canaryConfig.scopes[0].extendedScopeParams || {}).dataset === 'global';
+        this.stage.canaryConfig.scopes.forEach((scope) => {
+          scope.extendedScopeParams.dataset = this.state.useAtlasGlobalDataset ? 'global' : 'regional';
+        });
+      }
+
+      this.$scope.$applyAsync();
+    }
   };
 
-  // Should only be called when selecting a canary config.
-  // Expected stage behavior:
-  // On stage load, use the stage's score thresholds rather than the canary config's
-  // thresholds.
-  // When selecting a canary config, set the stage's thresholds equal
-  // to the canary config's thresholds unless they are undefined.
-  // In that case, fall back on the stage's thresholds.
-  private overrideScoreThresholds = (): void => {
-    if (!this.selectedCanaryConfigDetails) {
+  private setLocations = (): void => {
+    const { recommendedLocations, locations, hasChoices} = this.getLocationChoices();
+
+    if (!hasChoices) {
       return;
     }
 
-    if (!this.stage.canaryConfig.scoreThresholds) {
-      this.stage.canaryConfig.scoreThresholds = { marginal: null, pass: null };
+    this.state.showAllLocations.control = this.state.showAllLocations.experiment = (
+      recommendedLocations.length === 0 && locations.length > 0
+    );
+
+    this.stage.canaryConfig.scopes.forEach((scope) => {
+      if (!recommendedLocations.includes(scope.controlLocation) && !locations.includes(scope.controlLocation)) {
+        delete scope.controlLocation;
+      } else if (!recommendedLocations.includes(scope.controlLocation)) {
+        this.state.showAllLocations.control = true;
+      }
+
+      if (!recommendedLocations.includes(scope.experimentLocation) && !locations.includes(scope.experimentLocation)) {
+        delete scope.experimentLocation;
+      } else if (!recommendedLocations.includes(scope.experimentLocation)) {
+        this.state.showAllLocations.experiment = true;
+      }
+    });
+  };
+
+  private setShowAdvancedSettings = (): void => {
+    this.state.showAdvancedSettings = (
+      this.kayentaAccounts.get(KayentaAccountType.MetricsStore).length > 1 ||
+      this.kayentaAccounts.get(KayentaAccountType.ObjectStore).length > 1 ||
+      this.scopeNames.length > 1
+    );
+  }
+
+  public getLocationChoices = (): {
+    combinedLocations: { control: string[], experiment: string[] },
+    recommendedLocations: string[],
+    locations: string[],
+    hasChoices: boolean
+  } => {
+    const accounts = this.kayentaAccounts.get(KayentaAccountType.MetricsStore);
+    const selectedAccount = accounts && accounts.find(({ name }) => name === this.stage.canaryConfig.metricsAccountName);
+    if (!selectedAccount) {
+      return { combinedLocations: { control: [], experiment: [] }, recommendedLocations: [], locations: [], hasChoices: false };
     }
 
-    this.stage.canaryConfig.scoreThresholds.marginal = get(
-      this.selectedCanaryConfigDetails,
-      'classifier.scoreThresholds.marginal',
-      this.stage.canaryConfig.scoreThresholds.marginal || '',
-    ).toString();
-    this.stage.canaryConfig.scoreThresholds.pass = get(
-      this.selectedCanaryConfigDetails,
-      'classifier.scoreThresholds.pass',
-      this.stage.canaryConfig.scoreThresholds.pass || '',
-    ).toString();
+    const hasChoices = selectedAccount.locations.length > 0 || selectedAccount.recommendedLocations.length > 0;
+    const allLocations = selectedAccount.recommendedLocations.concat(selectedAccount.locations);
+    const control = uniq(this.state.showAllLocations.control ?
+      allLocations :
+      (selectedAccount.recommendedLocations.length > 0 ? selectedAccount.recommendedLocations : selectedAccount.locations));
+    const experiment = uniq(this.state.showAllLocations.experiment ?
+      allLocations :
+      (selectedAccount.recommendedLocations.length > 0 ? selectedAccount.recommendedLocations : selectedAccount.locations));
+
+    return {
+      combinedLocations: {
+        control,
+        experiment,
+      },
+      recommendedLocations: selectedAccount.recommendedLocations,
+      locations: selectedAccount.locations,
+      hasChoices,
+    };
+  };
+
+  public toggleAllLocations = (type: 'control' | 'experiment'): void => {
+    this.state.showAllLocations[type] = !this.state.showAllLocations[type];
+
+    const locationChoices = this.getLocationChoices();
+
+    this.stage.canaryConfig.scopes.forEach((scope) => {
+      if (!locationChoices.combinedLocations.control.includes(scope.controlLocation)) {
+        delete scope.controlLocation;
+      }
+      if (!locationChoices.combinedLocations.experiment.includes(scope.experimentLocation)) {
+        delete scope.experimentLocation;
+      }
+    });
   };
 
   private populateScopeNameChoices = (): void => {
@@ -249,6 +344,7 @@ export class KayentaStageController implements IComponentController {
 
     const scopeNames = uniq(map(this.selectedCanaryConfigDetails.metrics, metric => metric.scopeName || 'default'));
     this.scopeNames = !isEmpty(scopeNames) ? scopeNames : ['default'];
+    this.setShowAdvancedSettings();
 
     if (!isEmpty(this.stage.canaryConfig.scopes) && !scopeNames.includes(this.stage.canaryConfig.scopes[0].scopeName)) {
       delete this.stage.canaryConfig.scopes[0].scopeName;
@@ -501,6 +597,7 @@ export class KayentaStageController implements IComponentController {
       cleanup(control, 'control');
       cleanup(experiment, 'experiment');
       this.stage.deployments.serverGroupPairs = [{ control, experiment }];
+      this.$scope.$applyAsync();
     } catch (e) {
       this.$log.warn('Error creating server group pair for Kayenta stage: ', e);
     }
@@ -580,4 +677,35 @@ export class KayentaStageController implements IComponentController {
         server group in the <b>Baseline Version</b> cluster defined in this stage.`;
     }
   }
+
+  public handleAtlasDatasetChange = (event: Event): void => {
+    const { checked } = event.target as HTMLInputElement;
+    this.$scope.$applyAsync(() => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
+        scope.extendedScopeParams = { ...(scope.extendedScopeParams || {}) };
+        scope.extendedScopeParams.dataset = checked ? 'global' : 'regional';
+        // TODO: support query type
+        scope.extendedScopeParams.type = 'cluster';
+      });
+    });
+  };
+
+  public handleExtendedScopeParamsChange = (): void => {
+    if (this.metricStore !== 'atlas') {
+      return;
+    }
+
+    this.stage.canaryConfig.scopes.forEach((scope) => {
+      scope.extendedScopeParams = { ...(scope.extendedScopeParams || {}) };
+      // TODO: support query type
+      scope.extendedScopeParams.type = 'cluster';
+    });
+
+    if (this.stage.analysisType === KayentaAnalysisType.RealTimeAutomatic) {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
+        scope.extendedScopeParams.dataset = this.state.useAtlasGlobalDataset ? 'global' : 'regional';
+      });
+    }
+    this.$scope.$applyAsync();
+  };
 }

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -208,11 +208,33 @@
 
       <stage-config-field label="Baseline Location"
                           help-key="pipeline.config.canary.baselineLocation">
+        <select
+          required
+          class="form-control input-sm"
+          ng-if="kayentaCanaryStageCtrl.getLocationChoices().hasChoices"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].controlLocation"
+          ng-options="location for location in kayentaCanaryStageCtrl.getLocationChoices().combinedLocations.control">
+        </select>
         <input
           class="form-control input-sm"
+          ng-if="!kayentaCanaryStageCtrl.getLocationChoices().hasChoices"
           ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].controlLocation"
           required
           type="text"/>
+        <div class="pull-right" ng-if="kayentaCanaryStageCtrl.getLocationChoices().hasChoices">
+          <button
+            ng-click="kayentaCanaryStageCtrl.toggleAllLocations('control')"
+            ng-if="!kayentaCanaryStageCtrl.state.showAllLocations.control && kayentaCanaryStageCtrl.getLocationChoices().locations.length > 0"
+            class="link">
+            Show all locations
+          </button>
+          <button
+            ng-click="kayentaCanaryStageCtrl.toggleAllLocations('control')"
+            ng-if="kayentaCanaryStageCtrl.state.showAllLocations.control && kayentaCanaryStageCtrl.getLocationChoices().recommendedLocations.length > 0"
+            class="link">
+            Only show recommended locations
+          </button>
+        </div>
       </stage-config-field>
 
       <stage-config-field label="Canary"
@@ -226,11 +248,33 @@
 
       <stage-config-field label="Canary Location"
                           help-key="pipeline.config.canary.canaryLocation">
+        <select
+          required
+          class="form-control input-sm"
+          ng-if="kayentaCanaryStageCtrl.getLocationChoices().hasChoices"
+          ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].experimentLocation"
+          ng-options="location for location in kayentaCanaryStageCtrl.getLocationChoices().combinedLocations.experiment">
+        </select>
         <input
           class="form-control input-sm"
+          ng-if="!kayentaCanaryStageCtrl.getLocationChoices().hasChoices"
           ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].experimentLocation"
           required
           type="text"/>
+        <div class="pull-right" ng-if="kayentaCanaryStageCtrl.getLocationChoices().hasChoices">
+          <button
+            ng-click="kayentaCanaryStageCtrl.toggleAllLocations('experiment')"
+            ng-if="!kayentaCanaryStageCtrl.state.showAllLocations.experiment && kayentaCanaryStageCtrl.getLocationChoices().locations.length > 0"
+            class="link">
+            Show all locations
+          </button>
+          <button
+            ng-click="kayentaCanaryStageCtrl.toggleAllLocations('experiment')"
+            ng-if="kayentaCanaryStageCtrl.state.showAllLocations.experiment && kayentaCanaryStageCtrl.getLocationChoices().recommendedLocations.length > 0"
+            class="link">
+            Only show recommended locations
+          </button>
+        </div>
       </stage-config-field>
     </for-analysis-type>
 
@@ -288,6 +332,16 @@
 
   <kayenta-stage-config-section title="Metric Scope">
 
+    <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTimeAutomatic">
+      <stage-config-field label="Dataset" ng-if="kayentaCanaryStageCtrl.metricStore === 'atlas'">
+        <input
+          type="checkbox"
+          ng-model="kayentaCanaryStageCtrl.state.useAtlasGlobalDataset"
+          ng-click="kayentaCanaryStageCtrl.handleAtlasDatasetChange($event)" />
+        Use Global Atlas Dataset
+      </stage-config-field>
+    </for-analysis-type>
+
     <stage-config-field label="Resource Type" ng-if="kayentaCanaryStageCtrl.metricStore === 'prometheus'">
       <select
         class="form-control input-sm"
@@ -307,7 +361,8 @@
     <stage-config-field label="Extended Params"
                         help-key="pipeline.config.canary.extendedScopeParams">
       <map-editor
-        hidden-keys="['resourceType']"
+        hidden-keys="['resourceType', 'dataset', 'type']"
+        on-change="kayentaCanaryStageCtrl.handleExtendedScopeParamsChange()"
         model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].extendedScopeParams">
       </map-editor>
     </stage-config-field>
@@ -328,10 +383,11 @@
                            unhealthy-score="kayentaCanaryStageCtrl.stage.canaryConfig.scoreThresholds.marginal"></kayenta-canary-scores>
   </kayenta-stage-config-section>
 
-  <kayenta-stage-config-section title="Advanced Settings">
+  <kayenta-stage-config-section title="Advanced Settings" ng-if="kayentaCanaryStageCtrl.state.showAdvancedSettings">
 
     <stage-config-field label="Metrics Account"
-                        help-key="pipeline.config.metricsAccount">
+                        help-key="pipeline.config.metricsAccount"
+                        ng-if="kayentaCanaryStageCtrl.kayentaAccounts.get('METRICS_STORE').length > 1">
       <select
         class="form-control input-sm"
         ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.metricsAccountName"
@@ -340,7 +396,8 @@
       </select>
     </stage-config-field>
     <stage-config-field label="Storage Account"
-                        help-key="pipeline.config.storageAccount">
+                        help-key="pipeline.config.storageAccount"
+                        ng-if="kayentaCanaryStageCtrl.kayentaAccounts.get('OBJECT_STORE').length > 1">
       <select
         class="form-control input-sm"
         ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.storageAccountName"
@@ -349,7 +406,7 @@
       </select>
     </stage-config-field>
 
-    <stage-config-field label="Scope Name">
+    <stage-config-field label="Scope Name" ng-if="kayentaCanaryStageCtrl.scopeNames.length > 1">
       <ui-select required
                  ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].scopeName"
                  class="visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -361,7 +361,7 @@
     <stage-config-field label="Extended Params"
                         help-key="pipeline.config.canary.extendedScopeParams">
       <map-editor
-        hidden-keys="['resourceType', 'dataset', 'type']"
+        hidden-keys="['resourceType', 'dataset', 'type', 'environment']"
         on-change="kayentaCanaryStageCtrl.handleExtendedScopeParamsChange()"
         model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].extendedScopeParams">
       </map-editor>


### PR DESCRIPTION
Metric accounts now support two additional fields: `recommendedLocations` and `locations`, which can suggest location values to pick from for that account. This updates the stage config UI to handle three cases:
- There's no `recommendedLocations` or `locations`, we do what we were doing before (text field).
- There's _only_ `recommendedLocations` or only `locations`, we show a dropdown for the list with options.
- There's both `recommendedLocations` and `locations`, we show the dropdown with just `recommendedLocations` but give an option to toggle for all `recommendedLocations` + `locations`.

There's subtleties beyond this, like opening up an existing stage with a location that's not supported anymore, but in general that's the idea. I decided to stay away from having some option to use freeform text in addition to location choices simultaneously because it feels safer to stay restrictive for now and open it up more if we discover interesting use cases.

A few other things of note:

- There were some issues with finding and choosing object stores and metric stores in general, which are fixed.
- If there is only one metric store, object store, or scope respectively, we'll hide the selector for that option.
If there's only one of _all_ of the above, we won't show the 'advanced settings' section at all.
- We're now supporting some atlas-specific options and fields in `extendedScopeParams`. One is specifying the scope type as `cluster`, which we'd like to expand to `query` shortly. Another is whether to set the `dataset` to `regional` or `global` on automatic infrastructure deploys, which helps us infer which atlas data source to use on the backend.