### PR TITLE
feat: show templates in metric config editor

### DIFF
--- a/src/kayenta/edit/filterTemplateSelector.spec.tsx
+++ b/src/kayenta/edit/filterTemplateSelector.spec.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { createMockStore } from 'redux-test-utils';
+import { Provider } from 'react-redux';
+import Select from 'react-select';
+
+import { noop } from '@spinnaker/core';
+import { FilterTemplateSelector, IFilterTemplateSelectorProps } from './filterTemplateSelector';
+
+describe('<FilterTemplateSelector />', () => {
+  it('builds options from filter template map', () => {
+    const component = buildComponent({
+      template: 'my-filter-template',
+      templates: {
+        'my-filter-template': 'metadata.user_labels."app"="${scope}"',
+        'my-other-filter-template': 'metadata.user_labels."app"="${location}"',
+      },
+    });
+
+    expect(
+      component
+        .find(Select)
+        .first()
+        .props()
+        .options.map(o => o.value),
+    ).toEqual(['my-filter-template', 'my-other-filter-template']);
+  });
+
+  it('renders filter template', () => {
+    let component = buildComponent({
+      template: 'my-filter-template',
+      templates: {
+        'my-filter-template': 'metadata.user_labels."app"="${scope}"',
+        'my-other-filter-template': 'metadata.user_labels."app"="${location}"',
+      },
+    });
+
+    let pre = component.find('pre').first();
+    expect(pre.html()).toContain('${scope}');
+
+    component = buildComponent({
+      template: 'my-other-filter-template',
+      templates: {
+        'my-filter-template': 'metadata.user_labels."app"="${scope}"',
+        'my-other-filter-template': 'metadata.user_labels."app"="${location}"',
+      },
+    });
+    pre = component.find('pre').first();
+    expect(pre.html()).toContain('${location}');
+  });
+
+  it('does not render filter template if not present', () => {
+    ['my-third-filter-template', '', null].forEach(template => {
+      const component = buildComponent({
+        template,
+        templates: {
+          'my-filter-template': 'metadata.user_labels."app"="${scope}"',
+          'my-other-filter-template': 'metadata.user_labels."app"="${location}"',
+        },
+      });
+
+      expect(component.find('pre').length).toEqual(0);
+    });
+  });
+});
+
+const buildComponent = (props: Partial<IFilterTemplateSelectorProps>) =>
+  mount(
+    <Provider store={createMockStore()}>
+      <FilterTemplateSelector template={props.template} templates={props.templates} select={noop} />
+    </Provider>,
+  ).find(FilterTemplateSelector);

--- a/src/kayenta/edit/filterTemplateSelector.tsx
+++ b/src/kayenta/edit/filterTemplateSelector.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Option } from 'react-select';
+
+import FormRow from 'kayenta/layout/formRow';
+import { DisableableReactSelect, DISABLE_EDIT_CONFIG } from 'kayenta/layout/disableable';
+
+export interface IFilterTemplateSelectorProps {
+  templates: { [name: string]: string };
+  template: string;
+  select: (template: Option) => void;
+}
+
+export function FilterTemplateSelector({ template, templates, select }: IFilterTemplateSelectorProps) {
+  const options = Object.keys(templates).map(t => ({ value: t, label: t }));
+
+  return (
+    <>
+      <FormRow label="Filter Template">
+        <DisableableReactSelect
+          value={template}
+          options={options}
+          onChange={select}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        />
+      </FormRow>
+      <FormRow>{template && templates && templates[template] && <pre>{templates[template]}</pre>}</FormRow>
+    </>
+  );
+}

--- a/src/kayenta/edit/templates/templates.tsx
+++ b/src/kayenta/edit/templates/templates.tsx
@@ -21,7 +21,7 @@ interface ITemplatesDispatchProps {
   add: () => void;
 }
 
-interface ITemplate {
+export interface ITemplate {
   name: string;
   value: string;
 }

--- a/src/kayenta/reducers/selectedConfig.ts
+++ b/src/kayenta/reducers/selectedConfig.ts
@@ -348,14 +348,14 @@ export function editGroupConfirmReducer(
     return state;
   }
 
-  const metricUpdator = (c: ICanaryMetricConfig): ICanaryMetricConfig => ({
+  const metricUpdater = (c: ICanaryMetricConfig): ICanaryMetricConfig => ({
     ...c,
     groups: (c.groups || []).includes(payload.group)
       ? [payload.edit].concat((c.groups || []).filter(g => g !== payload.group))
       : c.groups,
   });
 
-  const weightsUpdator = (weights: IGroupWeights): IGroupWeights => {
+  const weightsUpdater = (weights: IGroupWeights): IGroupWeights => {
     const weight = weights[payload.group];
     weights = omit(weights, payload.group);
     return {
@@ -364,16 +364,16 @@ export function editGroupConfirmReducer(
     };
   };
 
-  const listUpdator = (groupList: string[]): string[] =>
+  const listUpdater = (groupList: string[]): string[] =>
     [payload.edit].concat((groupList || []).filter(g => g !== payload.group));
   return {
     ...state,
-    metricList: state.metricList.map(metricUpdator),
+    metricList: state.metricList.map(metricUpdater),
     group: {
       ...state.group,
       selected: payload.edit,
-      groupWeights: weightsUpdator(state.group.groupWeights),
-      list: listUpdator(state.group.list),
+      groupWeights: weightsUpdater(state.group.groupWeights),
+      list: listUpdater(state.group.list),
     },
   };
 }
@@ -396,14 +396,14 @@ export function changeMetricGroupConfirmReducer(
     return state;
   }
 
-  const metricUpdator = (m: ICanaryMetricConfig): ICanaryMetricConfig => ({
+  const metricUpdater = (m: ICanaryMetricConfig): ICanaryMetricConfig => ({
     ...m,
     groups: m.id === metricId ? [toGroup] : m.groups,
   });
 
   return {
     ...state,
-    metricList: state.metricList.map(metricUpdator),
+    metricList: state.metricList.map(metricUpdater),
   };
 }
 
@@ -450,6 +450,19 @@ const editingTemplateConfirmReducer = (state: ISelectedConfigState, action: Acti
     [editedName]: editedValue,
   };
 
+  const metricUpdater = (metric: ICanaryMetricConfig) => {
+    if (get(metric, 'query.customFilterTemplate') !== name) {
+      return metric;
+    }
+    return {
+      ...metric,
+      query: {
+        ...metric.query,
+        customFilterTemplate: editedName,
+      },
+    };
+  };
+
   return {
     ...state,
     editingTemplate: {
@@ -461,6 +474,7 @@ const editingTemplateConfirmReducer = (state: ISelectedConfigState, action: Acti
       ...state.config,
       templates,
     },
+    metricList: (state.metricList || []).map(metricUpdater),
   };
 };
 


### PR DESCRIPTION
![preview_template](https://user-images.githubusercontent.com/13868700/46981707-89834f00-d0a7-11e8-93a1-b41ca17e32b0.png)

Also fixes bug where an update to a filter template name isn't reflected in the metric configs.
