### PR TITLE
feat: select resource type in prometheus edit metric modal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
   "rules": {
     "eol-last": 1,
     "semi": 2,
-    "quotes": [1, "single", { "allowTemplateLiterals": true }],
+    "quotes": [1, "single", { "allowTemplateLiterals": true, "avoidEscape": true }],
     "comma-dangle": 0,
     "no-extra-boolean-cast": 1,
     "no-unused-vars": 1,
@@ -37,6 +37,7 @@
     "no-empty-pattern": 0
   },
   "parserOptions": {
+    "ecmaVersion": 8,
     "sourceType": "module"
   },
   "env": {

--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -17,6 +17,7 @@ import {
 } from 'kayenta/domain';
 import { IUpdateKeyValueListPayload } from '../layout/keyValueList';
 import { IStackdriverCanaryMetricSetQueryConfig } from '../metricStore/stackdriver/domain/IStackdriverCanaryMetricSetQueryConfig';
+import { IPrometheusCanaryMetricSetQueryConfig } from '../metricStore/prometheus/domain/IPrometheusCanaryMetricSetQueryConfig';
 
 export interface IKayentaAction<T> extends Action {
   payload: T;
@@ -91,6 +92,10 @@ export const editTemplateName = createAction<{ name: string }>(Actions.EDIT_TEMP
 export const editTemplateValue = createAction<{ value: string }>(Actions.EDIT_TEMPLATE_VALUE);
 export const updatePrometheusLabelBindings = createAction<IUpdateListPayload>(Actions.UPDATE_PROMETHEUS_LABEL_BINDINGS);
 export const updatePrometheusGroupBy = createAction<IUpdateListPayload>(Actions.UPDATE_PROMETHEUS_GROUP_BY_FIELDS);
+export const updatePrometheusMetricQueryField = createAction<{
+  field: keyof IPrometheusCanaryMetricSetQueryConfig;
+  value: IPrometheusCanaryMetricSetQueryConfig[keyof IPrometheusCanaryMetricSetQueryConfig];
+}>(Actions.UPDATE_PROMETHEUS_METRIC_QUERY_FIELD);
 export const updateStackdriverGroupBy = createAction<IUpdateListPayload>(Actions.UPDATE_STACKDRIVER_GROUP_BY_FIELDS);
 export const deleteTemplate = createAction<{ name: string }>(Actions.DELETE_TEMPLATE);
 export const selectTemplate = createAction<{ name: string }>(Actions.SELECT_TEMPLATE);
@@ -108,7 +113,6 @@ export const loadMetricsServiceMetadataFailure = createAction<{ error: Error }>(
 export const updatePrometheusMetricDescriptorFilter = createAction<{ filter: string }>(
   Actions.UPDATE_PROMETHEUS_METRIC_DESCRIPTOR_FILTER,
 );
-export const updatePrometheusMetricType = createAction<{ metricName: string }>(Actions.UPDATE_PROMETHEUS_METRIC_TYPE);
 export const updateStackdriverMetricDescriptorFilter = createAction<{ filter: string }>(
   Actions.UPDATE_STACKDRIVER_METRIC_DESCRIPTOR_FILTER,
 );

--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -33,6 +33,7 @@ export const CONFIG_JSON_MODAL_OPEN = 'config_json_modal_open';
 export const CONFIG_JSON_MODAL_CLOSE = 'config_json_modal_close';
 export const SET_CONFIG_JSON = 'set_config_json';
 export const UPDATE_PROMETHEUS_METRIC_TYPE = 'update_prometheus_metric_type';
+export const UPDATE_PROMETHEUS_METRIC_QUERY_FIELD = 'update_prometheus_metric_query_field';
 export const UPDATE_PROMETHEUS_LABEL_BINDINGS = 'update_prometheus_label_bindings';
 export const UPDATE_PROMETHEUS_GROUP_BY_FIELDS = 'update_prometheus_group_by_fields';
 export const UPDATE_STACKDRIVER_METRIC_TYPE = 'update_stackdriver_metric_type';

--- a/src/kayenta/manualAnalysis/ManualAnalysisModal.tsx
+++ b/src/kayenta/manualAnalysis/ManualAnalysisModal.tsx
@@ -139,15 +139,15 @@ export class ManualAnalysisModal extends React.Component<IManualAnalysisModalPro
     dismissModal: noop,
   };
 
-  public static show(props: IManualAnalysisModalProps): Promise<any> {
-    const modalProps = { dialogClassName: 'modal-lg' };
-    return ReactModal.show(ManualAnalysisModal, props, modalProps);
-  }
-
   public state: IManualAnalysisModalState = {
     showAllControlLocations: false,
     showAllExperimentLocations: false,
   };
+
+  public static show(props: IManualAnalysisModalProps): Promise<any> {
+    const modalProps = { dialogClassName: 'modal-lg' };
+    return ReactModal.show(ManualAnalysisModal, props, modalProps);
+  }
 
   constructor(props: IManualAnalysisModalProps) {
     super(props);

--- a/src/kayenta/metricStore/prometheus/domain/IPrometheusCanaryMetricSetQueryConfig.ts
+++ b/src/kayenta/metricStore/prometheus/domain/IPrometheusCanaryMetricSetQueryConfig.ts
@@ -1,6 +1,7 @@
 import { ICanaryMetricSetQueryConfig } from 'kayenta/domain';
 
 export interface IPrometheusCanaryMetricSetQueryConfig extends ICanaryMetricSetQueryConfig {
+  resourceType: string;
   metricName: string;
   labelBindings: string[];
   groupByFields: string[];

--- a/src/kayenta/metricStore/prometheus/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/prometheus/metricConfigurer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as Select from 'react-select';
+import { Option } from 'react-select';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
@@ -9,30 +9,50 @@ import { ICanaryMetricConfig } from 'kayenta/domain/ICanaryConfig';
 import { IUpdateListPayload, List } from 'kayenta/layout/list';
 import * as Creators from 'kayenta/actions/creators';
 import PrometheusMetricTypeSelector from './metricTypeSelector';
+import { DISABLE_EDIT_CONFIG, DisableableReactSelect } from 'kayenta/layout/disableable';
+import { IPrometheusCanaryMetricSetQueryConfig } from './domain/IPrometheusCanaryMetricSetQueryConfig';
 
 interface IPrometheusMetricConfigurerStateProps {
   editingMetric: ICanaryMetricConfig;
 }
 
 interface IPrometheusMetricConfigurerDispatchProps {
-  updateMetricType: (option: Select.Option) => void;
   updateLabelBindings: (payload: IUpdateListPayload) => void;
   updateGroupBy: (payload: IUpdateListPayload) => void;
+  updatePrometheusMetricQueryField<T extends keyof IPrometheusCanaryMetricSetQueryConfig>(
+    field: keyof IPrometheusCanaryMetricSetQueryConfig,
+    value: Option<IPrometheusCanaryMetricSetQueryConfig[T]>,
+  ): void;
 }
+
+const RESOURCE_TYPES = ['gce_instance', 'aws_ec2_instance'];
+
+const toReactSelectOptions = (values: string[]): Option<string>[] => values.map(value => ({ value, label: value }));
 
 /*
 * Component for configuring a Prometheus metric.
 * */
 function PrometheusMetricConfigurer({
   editingMetric,
-  updateMetricType,
   updateLabelBindings,
   updateGroupBy,
+  updatePrometheusMetricQueryField,
 }: IPrometheusMetricConfigurerStateProps & IPrometheusMetricConfigurerDispatchProps) {
   return (
     <section>
+      <FormRow label="Resource Type">
+        <DisableableReactSelect
+          value={get(editingMetric, 'query.resourceType')}
+          options={toReactSelectOptions(RESOURCE_TYPES)}
+          onChange={(option: Option<string>) => updatePrometheusMetricQueryField('resourceType', option)}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        />
+      </FormRow>
       <FormRow label="Metric Name">
-        <PrometheusMetricTypeSelector value={get(editingMetric, 'query.metricName', '')} onChange={updateMetricType} />
+        <PrometheusMetricTypeSelector
+          value={get(editingMetric, 'query.metricName', '')}
+          onChange={(option: Option<string>) => updatePrometheusMetricQueryField('metricName', option)}
+        />
       </FormRow>
       <FormRow label="Label Bindings">
         <List list={editingMetric.query.labelBindings || []} actionCreator={updateLabelBindings} />
@@ -52,15 +72,10 @@ function mapStateToProps(state: ICanaryState): IPrometheusMetricConfigurerStateP
 
 function mapDispatchToProps(dispatch: (action: Action & any) => void): IPrometheusMetricConfigurerDispatchProps {
   return {
-    updateMetricType: (option: Select.Option): void => {
-      dispatch(
-        Creators.updatePrometheusMetricType({
-          metricName: (option ? option.value : null) as string,
-        }),
-      );
-    },
     updateLabelBindings: payload => dispatch(Creators.updatePrometheusLabelBindings(payload)),
     updateGroupBy: payload => dispatch(Creators.updatePrometheusGroupBy(payload)),
+    updatePrometheusMetricQueryField: (field, option) =>
+      dispatch(Creators.updatePrometheusMetricQueryField({ field, value: option && option.value })),
   };
 }
 

--- a/src/kayenta/reducers/prometheusMetricConfig.spec.ts
+++ b/src/kayenta/reducers/prometheusMetricConfig.spec.ts
@@ -1,0 +1,32 @@
+import { prometheusMetricConfigReducer } from './prometheusMetricConfig';
+import * as Actions from 'kayenta/actions';
+
+describe('Reducer: prometheusMetricConfigReducer', () => {
+  describe('update query field', () => {
+    it('updates arbitrary query key/value pairs on a query', () => {
+      const nextState = prometheusMetricConfigReducer({ query: { resourceType: 'aws_ec2_instance' } } as any, {
+        type: Actions.UPDATE_PROMETHEUS_METRIC_QUERY_FIELD,
+        payload: { field: 'resourceType', value: 'gce_instance' },
+      });
+      expect(nextState.query.resourceType).toEqual('gce_instance');
+    });
+
+    it('creates key/value pair if not already extant on the query', () => {
+      const nextState = prometheusMetricConfigReducer({ query: {} } as any, {
+        type: Actions.UPDATE_PROMETHEUS_METRIC_QUERY_FIELD,
+        payload: { field: 'resourceType', value: 'gce_instance' },
+      });
+      expect(nextState.query.resourceType).toEqual('gce_instance');
+    });
+
+    it('deletes key/value pair if passed falsy value', () => {
+      [null, undefined, ''].forEach(falsyValue => {
+        const nextState = prometheusMetricConfigReducer({ query: { resourceType: 'aws_ec2_instance' } } as any, {
+          type: Actions.UPDATE_PROMETHEUS_METRIC_QUERY_FIELD,
+          payload: { field: 'resourceType', value: falsyValue },
+        });
+        expect(nextState.query.resourceType).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/kayenta/reducers/prometheusMetricConfig.ts
+++ b/src/kayenta/reducers/prometheusMetricConfig.ts
@@ -1,5 +1,6 @@
 import { Action } from 'redux';
 import { handleActions } from 'redux-actions';
+import { omit } from 'lodash';
 
 import * as Actions from 'kayenta/actions';
 import { IKayentaAction } from 'kayenta/actions/creators';
@@ -14,10 +15,23 @@ type IPrometheusMetricConfig = ICanaryMetricConfig<IPrometheusCanaryMetricSetQue
 
 export const prometheusMetricConfigReducer = handleActions<IPrometheusMetricConfig, Action & any>(
   {
-    [Actions.UPDATE_PROMETHEUS_METRIC_TYPE]: (state: ICanaryMetricConfig, action: Action & any) => ({
+    [Actions.UPDATE_PROMETHEUS_METRIC_TYPE]: (state: IPrometheusMetricConfig, action: Action & any) => ({
       ...state,
       query: { ...state.query, metricName: action.payload.metricName, type: 'prometheus' },
     }),
+    [Actions.UPDATE_PROMETHEUS_METRIC_QUERY_FIELD]: (state: IPrometheusMetricConfig, action: Action & any) => {
+      if (!action.payload.value) {
+        return {
+          ...state,
+          query: omit(state.query, action.payload.field),
+        };
+      }
+
+      return {
+        ...state,
+        query: { ...state.query, [action.payload.field]: action.payload.value },
+      };
+    },
     [Actions.UPDATE_PROMETHEUS_LABEL_BINDINGS]: (
       state: IPrometheusMetricConfig,
       action: IKayentaAction<IUpdateListPayload>,

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -342,22 +342,6 @@
       </stage-config-field>
     </for-analysis-type>
 
-    <stage-config-field label="Resource Type" ng-if="kayentaCanaryStageCtrl.metricStore === 'prometheus'">
-      <select
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].extendedScopeParams.resourceType"
-        ng-options="option for option in ['', 'gce_instance', 'aws_ec2_instance']">
-      </select>
-    </stage-config-field>
-
-    <stage-config-field label="Resource Type" ng-if="kayentaCanaryStageCtrl.metricStore === 'stackdriver'">
-      <select
-        class="form-control input-sm"
-        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].extendedScopeParams.resourceType"
-        ng-options="option for option in ['gce_instance', 'aws_ec2_instance', 'gae_app', 'k8s_container', 'k8s_pod', 'k8s_node', 'gke_container', 'https_lb_rule', 'global']">
-      </select>
-    </stage-config-field>
-
     <stage-config-field label="Extended Params"
                         help-key="pipeline.config.canary.extendedScopeParams">
       <map-editor


### PR DESCRIPTION
- removes resource type selector in stage config
- removes conflict between linter and formatter

![prometheus](https://user-images.githubusercontent.com/13868700/47180116-bc1e8900-d2ed-11e8-91c7-20bc7035ef5f.png)
