### PR TITLE
feat: add Delay Before Cleanup field to stage UI (#3502)

### DIFF
--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -46,6 +46,8 @@ const helpContents: { [key: string]: string } = {
         <p>Also used to provide variable bindings for use in the expansion of custom filter templates within the canary config.</p>`,
   'pipeline.config.canary.lookback':
     '<p>With an analysis type of <strong>Growing</strong>, the entire duration of the canary will be considered during the analysis.</p><p>When choosing <strong>Sliding</strong>, the canary will use the most recent number of specified minutes for its analysis report (<b>useful for long running canaries that span multiple days</b>).</p>',
+  'pipeline.config.canary.delayBeforeCleanup':
+    '<p>The total time after canary analysis ends before canary cluster cleanup begins. Allows for manual inspection of instances.</p>',
   'pipeline.config.canary.marginalScore': `
     <p>A canary stage can include multiple canary runs.</p>
     <p>If a given canary run score is less than or equal to the marginal threshold, the canary stage will fail immediately.</p>

--- a/src/kayenta/domain/IKayentaStageConfig.ts
+++ b/src/kayenta/domain/IKayentaStageConfig.ts
@@ -12,7 +12,7 @@ export interface IKayentaStageCanaryConfig {
   scopes: IKayentaStageCanaryConfigScope[];
   combinedCanaryResultStrategy: string;
   lifetimeHours?: string;
-  lifetimeDuration?: string;
+  lifetimeDuration?: string; // String to be converted to Java.time.Duration in Orca (https://github.com/spinnaker/orca/blob/master/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt#L32)
   lookbackMins?: string;
   metricsAccountName: string;
   scoreThresholds: {
@@ -42,17 +42,12 @@ export interface IKayentaStageDeployments {
     cluster: string;
   };
   serverGroupPairs: IKayentaServerGroupPair[];
-  delayBeforeCleanup: number;
+  delayBeforeCleanup: string; // String to be converted to Java.time.Duration in Orca (https://github.com/spinnaker/orca/blob/master/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/Deployments.kt#L33)
 }
 
 export interface IKayentaServerGroupPair {
   control: any;
   experiment: any;
-}
-
-export interface IKayentaStageLifetime {
-  hours?: number;
-  minutes?: number;
 }
 
 export enum KayentaAnalysisType {

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -44,18 +44,21 @@
                           help-key="pipeline.config.canary.lifetime"
                           ng-class="kayentaCanaryStageCtrl.getLifetimeClassnames()"
                           style="padding-left: 0; padding-right: 0;">
-        <input type="text"
+        <input type="number"
+               min="0"
+               ng-class="kayentaCanaryStageCtrl.getLifetimeInputClassnames()"
                ng-model="kayentaCanaryStageCtrl.state.lifetime.hours"
-               ng-required="kayentaCanaryStageCtrl.isLifetimeRequired()"
                class="form-control input-sm"
                style="display: inline-block; width: 11%"
                ng-change="kayentaCanaryStageCtrl.onLifetimeChange()" />
         <span class="form-control-static">
         hours
         </span>
-          <input type="text"
+          <input type="number"
+                 min="0"
+                 max="59"
+                 ng-class="kayentaCanaryStageCtrl.getLifetimeInputClassnames()"
                  ng-model="kayentaCanaryStageCtrl.state.lifetime.minutes"
-                 ng-required="kayentaCanaryStageCtrl.isLifetimeRequired()"
                  class="form-control input-sm"
                  style="display: inline-block; width: 11%; margin-left: 12px;"
                  ng-change="kayentaCanaryStageCtrl.onLifetimeChange()" />
@@ -114,6 +117,7 @@
         class="form-control input-sm"
         ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].step"
         type="number"
+        min="0"
         style="width: 33%; display: inline-block"/>
       <span class="form-control-static"> seconds</span>
     </stage-config-field>
@@ -153,6 +157,33 @@
       </div>
     </stage-config-field>
   </kayenta-stage-config-section>
+
+  <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTimeAutomatic">
+    <stage-config-field label="Delay Before Cleanup"
+                        field-columns="8"
+                        help-key="pipeline.config.canary.delayBeforeCleanup"
+                        style="padding-left: 0; padding-right: 0;">
+      <input type="number"
+             min="0"
+             ng-model="kayentaCanaryStageCtrl.state.delayBeforeCleanup.hours"
+             class="form-control input-sm"
+             style="display: inline-block; width: 11%;"
+             ng-change="kayentaCanaryStageCtrl.onDelayBeforeCleanupChange()" />
+      <span class="form-control-static">
+          hours
+      </span>
+      <input type="number"
+             min="0"
+             max="59"
+             ng-model="kayentaCanaryStageCtrl.state.delayBeforeCleanup.minutes"
+             class="form-control input-sm"
+             style="display: inline-block; width: 11%; margin-left: 12px"
+             ng-change="kayentaCanaryStageCtrl.onDelayBeforeCleanupChange()" />
+      <span class="form-control-static">
+          minutes
+      </span>
+    </stage-config-field>
+  </for-analysis-type>
 
   <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTimeAutomatic">
     <kayenta-stage-config-section title="Baseline Version">

--- a/src/kayenta/utils/duration.spec.ts
+++ b/src/kayenta/utils/duration.spec.ts
@@ -1,0 +1,69 @@
+import {
+  defaultDurationObject,
+  defaultDurationString,
+  getDurationString,
+  parseDurationString,
+  IDuration,
+} from './duration';
+
+type DurationTest = {
+  str: string;
+  obj: IDuration;
+};
+
+describe('Duration utils', () => {
+  let validDurationStringsToObjects: DurationTest[];
+  let invalidDurationStrings: any[];
+  let invalidDurationObjects: any[];
+
+  beforeEach(() => {
+    validDurationStringsToObjects = [
+      {
+        str: 'PT1H0M',
+        obj: { hours: 1, minutes: 0 },
+      },
+      {
+        str: 'PT0H10M',
+        obj: { hours: 0, minutes: 10 },
+      },
+      {
+        str: 'PT0H0M',
+        obj: { hours: 0, minutes: 0 },
+      },
+      {
+        str: 'PT20H6M',
+        obj: { hours: 20, minutes: 6 },
+      },
+    ];
+
+    invalidDurationStrings = ['invalid', { k: 'not_a_string' }, null];
+
+    invalidDurationObjects = [null, 'not_an_object', { hours: 'not_an_int', minutes: -1 }];
+  });
+
+  describe('parseDurationString', () => {
+    it('converts duration string to object', () => {
+      validDurationStringsToObjects.forEach(({ str, obj }) => {
+        expect(parseDurationString(str)).toEqual(obj);
+      });
+    });
+    it('handles invalid input', () => {
+      invalidDurationStrings.forEach(durationString => {
+        expect(parseDurationString(durationString)).toEqual(defaultDurationObject);
+      });
+    });
+  });
+
+  describe('getDurationString', () => {
+    it('converts duration object to string', () => {
+      validDurationStringsToObjects.forEach(({ str, obj }) => {
+        expect(getDurationString(obj)).toEqual(str);
+      });
+    });
+    it('handles invalid input', () => {
+      invalidDurationObjects.forEach(durationObject => {
+        expect(getDurationString(durationObject)).toEqual(defaultDurationString);
+      });
+    });
+  });
+});

--- a/src/kayenta/utils/duration.ts
+++ b/src/kayenta/utils/duration.ts
@@ -1,0 +1,48 @@
+import { isEmpty, isInteger, isString } from 'lodash';
+
+export interface IDuration {
+  hours: number;
+  minutes: number;
+}
+
+export const defaultDurationObject = {
+  hours: 0,
+  minutes: 0,
+};
+
+export const defaultDurationString = 'PT0H0M';
+
+export function parseDurationString(duration: string): IDuration {
+  const defaultDurationObjectCopy = { ...defaultDurationObject };
+  if (!isString(duration)) {
+    return defaultDurationObjectCopy;
+  }
+  const durationComponents = duration.match(/PT(\d+)H(?:(\d+)M)?/i);
+  if (isEmpty(durationComponents)) {
+    return defaultDurationObjectCopy;
+  }
+  let hours = parseInt(durationComponents[1], 10);
+  if (!isInteger(hours) || hours < 0) {
+    hours = 0;
+  }
+  let minutes = parseInt(durationComponents[2], 10);
+  if (!isInteger(minutes) || minutes < 0) {
+    minutes = 0;
+  }
+  return { hours, minutes };
+}
+// Returns string parsable by Java.time.Duration.parse
+// https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence
+export function getDurationString(duration: IDuration): string {
+  if (!duration) {
+    return defaultDurationString;
+  }
+  let { hours, minutes } = duration;
+  if (!isInteger(hours) || hours < 0) {
+    hours = 0;
+  }
+  if (!isInteger(minutes) || minutes < 0) {
+    minutes = 0;
+  }
+  return `PT${hours}H${minutes}M`;
+}


### PR DESCRIPTION
Closes [#3502](https://github.com/spinnaker/spinnaker/issues/3502):

- Adds "Delay Before Cleanup" field to Realtime (Automatic) Canary Analysis stage UI
- Move `Duration` parsing logic out of controller to be shared by `lifetimeDuration` and `delayBeforeCleanup` fields since both are stored on state as hours/minutes but saved to the stage as duration strings
- Change "Lifetime Duration" field to type number to match "Delay Before Cleanup" field, add min=0 to hours and min=0/max=59 to minutes
- Set "Step" min to 0

![delaybeforecleanupui](https://user-images.githubusercontent.com/15936279/47441907-3b450e80-d77f-11e8-85e5-1b1e32264190.png)
