### PR TITLE
fix(layout): correct firefox scrolling in flex container and spacing at bottom

### DIFF
--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -40,7 +40,7 @@
 
   .config-detail {
     padding: 1rem;
-    padding-bottom: 40px;
+    margin-bottom: 40px;
     overflow-y: auto;
     .config-detail-header {
       padding-right: 15px;
@@ -141,5 +141,10 @@
     .native-table-header {
       background-color: transparent;
     }
+  }
+
+  // Allow children of flex-1 with overflow of scroll or auto to scroll correctly in firefox
+  .flex-1 {
+    min-height: 0;
   }
 }


### PR DESCRIPTION
Before:

1. Scrolling disabled in firefox
 
![screen shot 2018-10-30 at 12 13 57 pm](https://user-images.githubusercontent.com/34253460/47732945-98d4d180-dc3d-11e8-88bc-196e32fb660e.png)

2. Padding at bottom incorrect when screen is scrolled

![screen shot 2018-10-30 at 12 15 50 pm](https://user-images.githubusercontent.com/34253460/47732970-a5f1c080-dc3d-11e8-878e-12b2e507b8ab.png)

After:

Scrolling in FF and margin at bottom:

![screen shot 2018-10-30 at 12 10 59 pm](https://user-images.githubusercontent.com/34253460/47732977-aa1dde00-dc3d-11e8-9fcc-e4634de768a2.png)
