### PR TITLE
fix(stage): rename Server Group detail, allow multiple pairs

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
@@ -601,8 +601,8 @@ export class KayentaStageController implements IComponentController {
         serverGroup.freeFormDetails = `${serverGroup.freeFormDetails ? `${serverGroup.freeFormDetails}-` : ''}${type}`;
       };
 
-      cleanup(control, 'control');
-      cleanup(experiment, 'experiment');
+      cleanup(control, 'baseline');
+      cleanup(experiment, 'canary');
       this.stage.deployments.serverGroupPairs = [{ control, experiment }];
       this.$scope.$applyAsync();
     } catch (e) {


### PR DESCRIPTION
Per a conversation from a little while ago, this switches the detail for server group pairs from `control`/`experiment` to `baseline`/`canary`, which better matches the rest of the user-facing terminology. It also adds the option to provide multiple pairs in a single stage.