### PR TITLE
fix(kayenta-details): ux bandaid for details view

### DIFF
--- a/src/kayenta/components/canaryScore.component.less
+++ b/src/kayenta/components/canaryScore.component.less
@@ -53,24 +53,22 @@
 }
 
 .score-large .score.score-label {
-  height: 48px;
+  height: auto;
   line-height: 48px;
-  padding: 0 10px 0 10px;
-  font-size: 200%;
+  padding: 0 10px;
+  font-size: 28px;
+  font-weight: bold;
+  margin: 0;
   border-radius: 0;
-  margin: 0 0 5px 10px;
-  min-width: 48px;
   display: inline-block;
 }
 
 .score.score-report {
-  display: flex;
   align-items: center;
-  flex-direction: column;
-  padding: 15px;
-  font-size: 200%;
-  border-radius: 0;
-  min-width: 30px;
+  padding: 12px 12px 6px;
+  font-size: 28px;
+  font-weight: bold;
+  margin-bottom: 10px;
   height: 100%;
 }
 

--- a/src/kayenta/components/canaryScore.tsx
+++ b/src/kayenta/components/canaryScore.tsx
@@ -47,7 +47,6 @@ export class CanaryScore extends React.Component<ICanaryScoreProps, ICanaryScore
     const className = [
       this.props.inverse ? 'inverse' : '',
       'score',
-      'label',
       'score-label',
       'label-default',
       `label-${this.state.healthLabel}`,

--- a/src/kayenta/report/detail/detail.less
+++ b/src/kayenta/report/detail/detail.less
@@ -1,0 +1,14 @@
+.kayenta-overview-toggle {
+  align-self: flex-end;
+  line-height: 48px;
+  position: fixed;
+  margin-top: -70px;
+  cursor: pointer;
+  padding-right: 10px;
+
+  p {
+    display: inline-block;
+    text-transform: uppercase;
+    margin-right: 10px;
+  }
+}

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -36,7 +36,7 @@ export default class DetailView extends React.Component<any, IDetailViewStatePro
       <>
         <div className="kayenta-overview-toggle" onClick={this.toggleDetailHeader}>
           {isExpanded ? <p>hide details</p> : <p>show details</p>}
-          <span className={`glyphicon glyphicon-chevron-right `} style={chevronStyle} />
+          <span className="glyphicon glyphicon-chevron-right" style={chevronStyle} />
         </div>
         <div className="vertical flex-1">
           {isExpanded && <ReportHeader />}

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -4,13 +4,46 @@ import ReportHeader from './header';
 import ReportScores from './reportScores';
 import MetricResults from './metricResults';
 
+import './detail.less';
+
 /*
 * Layout for report detail view.
 * */
-export default () => (
-  <div className="vertical flex-1">
-    <ReportHeader />
-    <ReportScores />
-    <MetricResults />
-  </div>
-);
+
+export interface IDetailViewStateProps {
+  isExpanded: boolean;
+}
+
+export default class DetailView extends React.Component<any, IDetailViewStateProps> {
+  constructor(props: any) {
+    super(props);
+    this.state = { isExpanded: true };
+  }
+
+  private toggleDetailHeader = (): void => {
+    this.setState({ isExpanded: !this.state.isExpanded });
+  };
+
+  public render() {
+    const { isExpanded } = this.state;
+
+    const chevronStyle = {
+      transform: this.state.isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
+      transition: 'all ease 0.15s',
+    };
+
+    return (
+      <>
+        <div className="kayenta-overview-toggle" onClick={this.toggleDetailHeader}>
+          {isExpanded ? <p>hide details</p> : <p>show details</p>}
+          <span className={`glyphicon glyphicon-chevron-right `} style={chevronStyle} />
+        </div>
+        <div className="vertical flex-1">
+          {isExpanded && <ReportHeader />}
+          <ReportScores />
+          <MetricResults />
+        </div>
+      </>
+    );
+  }
+}

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -10,7 +10,7 @@ import './detail.less';
 * Layout for report detail view.
 * */
 
-export interface IDetailViewStateProps {
+export interface IDetailViewState {
   isExpanded: boolean;
 }
 

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -14,11 +14,8 @@ export interface IDetailViewState {
   isExpanded: boolean;
 }
 
-export default class DetailView extends React.Component<any, IDetailViewStateProps> {
-  constructor(props: any) {
-    super(props);
-    this.state = { isExpanded: true };
-  }
+export default class DetailView extends React.Component<any, IDetailViewState> {
+  public state: IDetailViewState = { isExpanded: true };
 
   private toggleDetailHeader = (): void => {
     this.setState({ isExpanded: !this.state.isExpanded });

--- a/src/kayenta/report/detail/header.less
+++ b/src/kayenta/report/detail/header.less
@@ -63,7 +63,8 @@
   }
 }
 
-// sloppy global class name so HoverablePopover > Overlay (react-bootstrap) picks it up.
-.kayenta-scope {
-  word-break: break-all;
+.popover {
+  .kayenta-scope {
+    word-break: break-all;
+  }
 }

--- a/src/kayenta/report/detail/header.less
+++ b/src/kayenta/report/detail/header.less
@@ -3,22 +3,45 @@
   align-items: center;
 
   h1 {
-    display: flex;
+    flex: 1 0 200px;
     align-items: center;
     margin: 0;
     padding: 0;
+    word-break: break-all;
   }
 
   .report-score-wrapper {
     padding: 5px 20px 0 0;
     margin-left: 15px;
     border-right: 1px solid var(--color-titanium);
+    text-align: center;
+    flex: 0 0 200px;
   }
 
   .report-metadata {
-    flex: 1;
+    flex: 0 1 auto;
+    display: flex;
+    overflow: hidden;
     padding-left: 20px;
     padding-top: 10px;
+    width: 100%;
+
+    .group {
+      flex: 1 1 200px;
+      margin-right: 20px;
+      overflow: hidden;
+
+      &.group-time {
+        flex: 0 0 150px;
+      }
+      &.group-threshold {
+        flex: 0 0 80px;
+      }
+      &.group-source {
+        flex: 0 0 64px;
+        margin-right: 0;
+      }
+    }
 
     ul {
       margin-bottom: 0;
@@ -31,4 +54,16 @@
       }
     }
   }
+
+  .kayenta-scope {
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+// sloppy global class name so HoverablePopover > Overlay (react-bootstrap) picks it up.
+.kayenta-scope {
+  word-break: break-all;
 }

--- a/src/kayenta/report/detail/header.tsx
+++ b/src/kayenta/report/detail/header.tsx
@@ -18,13 +18,13 @@ export interface IReportHeaderStateProps {
 
 const ReportHeader = ({ id, name, score }: IReportHeaderStateProps) => (
   <section className="horizontal report-header">
-    <h1 className="heading-1 color-text-primary">
-      <UISref to="^.^.canaryConfig.configDetail" params={{ id }}>
-        <a className="clickable color-text-primary"> {name}</a>
-      </UISref>
-    </h1>
     <div className="report-score-wrapper">
       <ReportScore score={score} showClassification={true} />
+      <h1 className="heading-2 color-text-primary">
+        <UISref to="^.^.canaryConfig.configDetail" params={{ id }}>
+          <a className="clickable color-text-primary"> {name}</a>
+        </UISref>
+      </h1>
     </div>
     <ReportMetadata />
   </section>

--- a/src/kayenta/report/detail/reportMetadata.tsx
+++ b/src/kayenta/report/detail/reportMetadata.tsx
@@ -5,6 +5,7 @@ import { ICanaryState } from 'kayenta/reducers';
 import { ICanaryExecutionStatusResult } from 'kayenta/domain/ICanaryExecutionStatusResult';
 import FormattedDate from 'kayenta/layout/formattedDate';
 import SourceLinks from './sourceLinks';
+import { HoverablePopover } from '@spinnaker/core';
 
 interface IReportMetadata {
   run: ICanaryExecutionStatusResult;
@@ -51,7 +52,7 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
       entries: [
         {
           label: 'scope',
-          getContent: () => <p>{controlScope}</p>,
+          getContent: () => <p className="kayenta-scope">{controlScope}</p>,
         },
         {
           label: 'location',
@@ -64,7 +65,7 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
       entries: [
         {
           label: 'scope',
-          getContent: () => <p>{experimentScope}</p>,
+          getContent: () => <p className="kayenta-scope">{experimentScope}</p>,
         },
         {
           label: 'location',
@@ -130,24 +131,26 @@ const ReportMetadata = ({ run }: IReportMetadata) => {
 
   return (
     <section className="report-metadata">
-      <div className="horizontal space-between bottom">
-        {metadataGroups.map((group, index) => (
-          <div key={group.label || index}>
-            <Label label={group.label || ''} extraClass="label-lg" />
-            <ul className="list-unstyled list-inline">
-              {group.entries.map(e => (
-                <li key={e.label || index}>
-                  <Label label={e.label} />
-                  {e.getContent()}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-        <div key="source">
-          <Label label="Source" extraClass="label-lgf" />
-          <SourceLinks />
+      {metadataGroups.map((group, index) => (
+        <div className={`group group-${group.label}`} key={group.label || index}>
+          <Label label={group.label || ''} extraClass="label-lg" />
+          <ul className="list-unstyled">
+            {group.entries.map(e => (
+              <li key={e.label || index}>
+                <Label label={e.label} />
+                {e.label == 'scope' ? (
+                  <HoverablePopover template={e.getContent()}>{e.getContent()}</HoverablePopover>
+                ) : (
+                  <>{e.getContent()}</>
+                )}
+              </li>
+            ))}
+          </ul>
         </div>
+      ))}
+      <div className="group group-source" key="source">
+        <Label label="Source" extraClass="label-lgf" />
+        <SourceLinks />
       </div>
     </section>
   );

--- a/src/kayenta/report/detail/reportMetadata.tsx
+++ b/src/kayenta/report/detail/reportMetadata.tsx
@@ -19,6 +19,7 @@ interface IMetadataGroup {
 interface IMetadataEntry {
   label: string;
   getContent: () => JSX.Element;
+  popover?: boolean;
 }
 
 const Label = ({ label, extraClass }: { label: string; extraClass?: string }) => (
@@ -52,6 +53,7 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
       entries: [
         {
           label: 'scope',
+          popover: true,
           getContent: () => <p className="kayenta-scope">{controlScope}</p>,
         },
         {
@@ -65,6 +67,7 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
       entries: [
         {
           label: 'scope',
+          popover: true,
           getContent: () => <p className="kayenta-scope">{experimentScope}</p>,
         },
         {
@@ -138,7 +141,7 @@ const ReportMetadata = ({ run }: IReportMetadata) => {
             {group.entries.map(e => (
               <li key={e.label || index}>
                 <Label label={e.label} />
-                {e.label == 'scope' ? (
+                {e.popover ? (
                   <HoverablePopover template={e.getContent()}>{e.getContent()}</HoverablePopover>
                 ) : (
                   <>{e.getContent()}</>

--- a/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
+++ b/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
@@ -28,7 +28,13 @@ export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICana
       getContent: run => {
         return (
           <>
-            <CanaryScore score={run.context.canaryScore} health={run.health} result={run.result} inverse={false} />
+            <CanaryScore
+              score={run.context.canaryScore}
+              health={run.health}
+              result={run.result}
+              inverse={false}
+              className="label"
+            />
             {get(run, ['context', 'warnings'], []).length > 0 && (
               <HoverablePopover template={<CanaryRunWarningMessages messages={run.context.warnings} />}>
                 <i className="fa fa-exclamation-triangle" style={{ paddingLeft: '8px' }} />


### PR DESCRIPTION
fixes the detail view header, and allows it to be collapsed for more vertical real estate.