### PR TITLE
chore(dependencies): bump marked version to patch security vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8515,9 +8515,9 @@ marching-simplex-table@^1.0.0:
     convex-hull "^1.0.3"
 
 marked@^0.3.3:
-  version "0.3.16"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.16.tgz#2f188b7dfcfa6540fe9940adaf0f3b791c9a5cba"
-  integrity sha512-diLiAxHidES67uJ1P5unXBUB4CyOFwodKrctuK0U4Ogw865N9Aw4dLmY0BK0tGKOy3xvkdMGgUXPD6W9z1Ne0Q==
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
+  integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
 mat4-decompose@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
Dependabot recommended we bump the version of `marked` to patch a security vulnerability in deck, figured I would take care of it here as well (Deck PR [here](https://github.com/spinnaker/deck/pull/5935)).