### PR TITLE
chore: bump to 0.0.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "lib/lib.js",
   "typings": "lib/kayenta/index.d.ts",
   "name": "@spinnaker/kayenta",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump package version to 0.0.65 so [PromQL queries](https://github.com/spinnaker/deck-kayenta/commit/27ed19c57a6a2ed934f97e9c9810e47dee5919b4) can be included with 1.11.x.