### PR TITLE
feat(report): add per-metric deviation percentage

### DIFF
--- a/src/kayenta/report/detail/metricResultDeviation.tsx
+++ b/src/kayenta/report/detail/metricResultDeviation.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+interface IMetricResultDeviationProps {
+  className?: string;
+  ratio: number;
+}
+
+const formatDeviationAsPercentage = (ratio: number) => {
+  if (typeof ratio !== 'number') {
+    return 'N/A';
+  } else if (ratio === 1) {
+    return '0%';
+  } else if (ratio < 1) {
+    return ((ratio - 1) * 100).toFixed(1) + '%';
+  } else {
+    return '+' + ((ratio - 1) * 100).toFixed(1) + '%';
+  }
+};
+
+export default ({ ratio, className }: IMetricResultDeviationProps) =>
+  ratio && (
+    <span className={className} style={{ color: 'var(--color-text-caption' }}>
+      {formatDeviationAsPercentage(ratio)}
+    </span>
+  );

--- a/src/kayenta/report/detail/metricResultsColumns.tsx
+++ b/src/kayenta/report/detail/metricResultsColumns.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import MetricResultClassification from './metricResultClassification';
 import { ITableColumn } from 'kayenta/layout/table';
 import { IMetricResultsTableRow } from './metricResultsList';
+import MetricResultClassification from './metricResultClassification';
+import MetricResultDeviation from './metricResultDeviation';
 
 export const metricResultsColumns: ITableColumn<IMetricResultsTableRow>[] = [
   {
@@ -10,11 +11,13 @@ export const metricResultsColumns: ITableColumn<IMetricResultsTableRow>[] = [
     width: 5,
   },
   {
+    label: 'deviation',
+    getContent: ({ results }) => <MetricResultDeviation ratio={results[0].resultMetadata.ratio} />,
+    width: 1,
+  },
+  {
     label: 'result',
-    labelClassName: 'pull-right',
-    getContent: ({ results }) => (
-      <MetricResultClassification className="pull-right" classification={results[0].classification} />
-    ),
+    getContent: ({ results }) => <MetricResultClassification classification={results[0].classification} />,
     width: 1,
   },
 ];

--- a/src/kayenta/report/detail/multipleResultsTable.tsx
+++ b/src/kayenta/report/detail/multipleResultsTable.tsx
@@ -5,10 +5,12 @@ import * as classNames from 'classnames';
 
 import { ICanaryAnalysisResult } from 'kayenta/domain/ICanaryJudgeResult';
 import { ITableColumn, Table } from 'kayenta/layout/table';
-import MetricResultClassification from './metricResultClassification';
 import { ICanaryState } from 'kayenta/reducers';
 import { selectedMetricResultIdSelector } from 'kayenta/selectors';
 import * as Creators from 'kayenta/actions/creators';
+
+import MetricResultClassification from './metricResultClassification';
+import MetricResultDeviation from './metricResultDeviation';
 
 interface IMultipleResultsTableOwnProps {
   results: ICanaryAnalysisResult[];
@@ -34,16 +36,20 @@ const MultipleResultsTable = ({
 
   let columns: ITableColumn<ICanaryAnalysisResult>[] = tagKeys.map(key => ({
     label: key,
-    width: 1,
+    width: 5,
     getContent: (result: ICanaryAnalysisResult) => <span>{result.tags[key]}</span>,
   }));
 
-  columns = columns.concat({
-    width: 1,
-    getContent: (result: ICanaryAnalysisResult) => (
-      <MetricResultClassification className="pull-right" classification={result.classification} />
-    ),
-  });
+  columns = columns.concat([
+    {
+      width: 1,
+      getContent: ({ resultMetadata }) => <MetricResultDeviation ratio={resultMetadata.ratio} />,
+    },
+    {
+      width: 1,
+      getContent: ({ classification }) => <MetricResultClassification classification={classification} />,
+    },
+  ]);
 
   return (
     <Table


### PR DESCRIPTION
<img width="472" alt="screen shot 2018-11-29 at 12 43 13 pm" src="https://user-images.githubusercontent.com/1850998/49250788-a31cf380-f3d4-11e8-8efb-9961d76faeba.png">

Right now I'm pulling this out of `resultMetadata` and just not showing if it doesn't exist — do we expect to have this for every judge? Can always tweak when/how it shows up in the future.

fyi @skandragon @csanden 