### PR TITLE
fix(configs): use a white BG for config metrics to work w/ native stickiness

### DIFF
--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -39,7 +39,7 @@
   }
 
   .config-detail {
-    padding: 1rem;
+    padding: 0 1rem 1rem;
     margin-bottom: 40px;
     overflow-y: auto;
     .config-detail-header {
@@ -48,6 +48,10 @@
       .heading-1 {
         margin: 3px 0 0 0;
       }
+    }
+
+    .contents .native-table-header {
+      padding-top: 10px;
     }
   }
 
@@ -140,6 +144,12 @@
   .header-transparent {
     .native-table-header {
       background-color: transparent;
+    }
+  }
+
+  .header-white {
+    .native-table-header {
+      background-color: white;
     }
   }
 

--- a/src/kayenta/edit/groupTabs.tsx
+++ b/src/kayenta/edit/groupTabs.tsx
@@ -55,7 +55,7 @@ function GroupTabs({
   };
   return (
     <section className="group-tabs">
-      <Tabs>
+      <Tabs style={{ marginBottom: '0' }}>
         <GroupTab group="" />
         {groupList.map(group => (
           <GroupTab key={group} group={group} editable={true} />

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -84,7 +84,7 @@ function MetricList({
 
   return (
     <>
-      <NativeTable columns={columns} rows={metrics} rowKey={metric => metric.id} className="header-transparent" />
+      <NativeTable columns={columns} rows={metrics} rowKey={metric => metric.id} className="header-white" />
       {!metrics.length && selectedGroup ? (
         <p>
           This group is empty! The group will be not be present the next time the config is loaded unless it is saved

--- a/src/kayenta/layout/tabs.tsx
+++ b/src/kayenta/layout/tabs.tsx
@@ -4,10 +4,15 @@ import * as classNames from 'classnames';
 export interface ITabsProps {
   children: any;
   className?: string;
+  style?: React.CSSProperties;
 }
 
-export function Tabs({ children, className }: ITabsProps) {
-  return <ul className={classNames('tabs-basic', 'list-unstyled', className)}>{children}</ul>;
+export function Tabs({ children, className, style }: ITabsProps) {
+  return (
+    <ul className={classNames('tabs-basic', 'list-unstyled', className)} style={style}>
+      {children}
+    </ul>
+  );
 }
 
 export interface ITabProps {


### PR DESCRIPTION
when this got refactored in #371 the BG on the individual `<th>` nodes ended up transparent, which doesn't work correctly with the native sticky positioning we're using now (Chrome can't handle sticky positioning on `<thead>`s yet).

fyi @csanden 