### PR TITLE
feat(stage): add legacy siteLocal field for email notifications

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -11,6 +11,7 @@ var reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
 var defaultMetricStore = process.env.METRIC_STORE || 'atlas';
 var canaryStagesEnabled = process.env.CANARY_STAGES_ENABLED === 'true';
 var manualCanaryAnalysisEnabled = process.env.MANUAL_CANARY_ANALYSIS_ENABLED === 'true';
+var legacySiteLocalFieldsEnabled = process.env.LEGACY_SITE_LOCAL_FIELDS_ENABLED === 'true';
 var canaryStageName = process.env.CANARY_STAGE_NAME;
 var canaryStageDescription = process.env.CANARY_STAGE_DESCRIPTION;
 var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
@@ -91,6 +92,7 @@ window.spinnakerSettings = {
     metricStore: defaultMetricStore,
     stagesEnabled: canaryStagesEnabled,
     manualAnalysisEnabled: manualCanaryAnalysisEnabled,
+    legacySiteLocalFieldsEnabled: legacySiteLocalFieldsEnabled,
     stageName: canaryStageName,
     stageDescription: canaryStageDescription,
     atlasWebComponentsUrl: atlasWebComponentsUrl,

--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -57,6 +57,8 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.canary.lifetime': `
     <p>The total time for which data will be collected and analyzed during this stage.</p>
   `,
+  'pipeline.config.canary.legacySiteLocalRecipients':
+    '<p>Email addresses to be notified when a canary report completes, separated by commas.</p>',
   'pipeline.config.metricsAccount':
     "<p>The account to be used to access the metric store defined in this stage's canary config.</p>",
   'pipeline.config.storageAccount':

--- a/src/kayenta/canary.settings.ts
+++ b/src/kayenta/canary.settings.ts
@@ -17,6 +17,7 @@ export interface ICanarySettings {
   atlasGraphBaseUrl: string;
   templatesEnabled: boolean;
   manualAnalysisEnabled: boolean;
+  legacySiteLocalFieldsEnabled: boolean; // legacy fields for backwards-compat with old systems, no long term support planned
 }
 
 export const CanarySettings: ICanarySettings = SETTINGS.canary || { featureDisabled: true };

--- a/src/kayenta/domain/IKayentaStageConfig.ts
+++ b/src/kayenta/domain/IKayentaStageConfig.ts
@@ -19,6 +19,7 @@ export interface IKayentaStageCanaryConfig {
     pass: string;
     marginal: string;
   };
+  siteLocal?: { notificationEmail?: string[] | string };
   storageAccountName: string;
 }
 

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -424,6 +424,16 @@
 
   <kayenta-stage-config-section title="Advanced Settings" ng-if="kayentaCanaryStageCtrl.state.showAdvancedSettings">
 
+    <stage-config-field label="Notification Emails" help-key="pipeline.config.canary.legacySiteLocalRecipients" ng-if="kayentaCanaryStageCtrl.state.showLegacySiteLocalRecipients">
+      <textarea
+        class="form-control input-sm"
+        ng-model="kayentaCanaryStageCtrl.state.legacySiteLocalRecipients"
+        ng-change="kayentaCanaryStageCtrl.handleLegacySiteLocalRecipientsChange()"
+        placeholder="Email addresses separated by commas"
+      >
+      </textarea>
+    </stage-config-field>
+
     <stage-config-field label="Metrics Account"
                         help-key="pipeline.config.metricsAccount"
                         ng-if="kayentaCanaryStageCtrl.kayentaAccounts.get('METRICS_STORE').length > 1">


### PR DESCRIPTION
At Netflix, we use an internal system to send emails when canary reports complete. In order to facilitate that for the time being, this adds a feature-flagged UI for populating kayenta's `siteLocal` field with a list of emails to notify. We're already scoping out a mechanism to do this notification generically in OSS-land (and subsequently move to that model internally), but until then most of the new fields are called `legacyXYZ` to call out that they are not likely to be around for long.