### PR TITLE
feat(executionSummary): hide noisy deployment stages, make rendering less flakey

### DIFF
--- a/src/kayenta/stages/kayentaStage/stageTypes.ts
+++ b/src/kayenta/stages/kayentaStage/stageTypes.ts
@@ -1,4 +1,5 @@
 export const KAYENTA_CANARY = 'kayentaCanary';
 export const RUN_CANARY = 'runCanary';
 export const WAIT = 'wait';
+export const CREATE_SERVER_GROUP = 'createServerGroup';
 export const DEPLOY_CANARY_SERVER_GROUPS = 'deployCanaryServerGroups';


### PR DESCRIPTION
During an automatic deployment, the execution summary gets pretty cluttered with synthetic stages for all the various steps in a parallel baseline + canary deploy. As a side effect it can get pretty hard to find the stage with the actual scores. Our hypothesis is that if a step in the deployment is _successful_, there's not enough value in showing it to justify the noise.

I chose to hide all successful deployment steps _except_ the two `createServerGroup` stages, because they each contain a succinct summary of what was deployed and a link out to the server group. Those two stages will also now appear as `Deploy {baseline|canary} in {locations}`, which should make the steps pretty clear. In the deployment success case (including when the analysis step is failed due to a low score), we go from this:

<img width="468" alt="screen shot 2019-02-22 at 10 34 54 pm" src="https://user-images.githubusercontent.com/1850998/53282944-cd403200-36f3-11e9-9079-9add6c07cd0d.png">

To this:

<img width="473" alt="screen shot 2019-02-22 at 10 34 03 pm" src="https://user-images.githubusercontent.com/1850998/53282975-0e384680-36f4-11e9-832f-77f5e80f3e7f.png">

I also moved around the initialization code for the execution summary a bit, because it seems there was work happening too early in the process of setting up the controller. The result was code trying to operate on a different stage on the controller scope which blew up and caused rendering flakiness (something like every second or third render).