### PR TITLE
feat(stage): Add score to execution labels

### DIFF
--- a/src/kayenta/stages/kayentaStage/CanaryExecutionLabel.tsx
+++ b/src/kayenta/stages/kayentaStage/CanaryExecutionLabel.tsx
@@ -1,0 +1,27 @@
+import { get } from 'lodash';
+import * as React from 'react';
+
+import { IExecutionStageSummary, IExecutionStage } from '@spinnaker/core';
+
+import { CanaryScore } from 'kayenta/components/canaryScore';
+
+export interface ICanaryExecutionLabelProps {
+  stage: IExecutionStageSummary;
+}
+
+export const CanaryExecutionLabel = ({ stage }: ICanaryExecutionLabelProps) => {
+  const { overallScore, overallResult } = get<IExecutionStage['context']>(stage, 'masterStage.context', {});
+  const score = (
+    <CanaryScore
+      inverse={true}
+      score={overallScore}
+      result={overallResult === 'success' ? overallResult : null}
+      health={overallResult === 'success' ? null : 'unhealthy'}
+    />
+  );
+  return (
+    <span className="stage-label">
+      <span>{stage.name}</span> ({score})
+    </span>
+  );
+};

--- a/src/kayenta/stages/kayentaStage/kayentaStage.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.ts
@@ -9,6 +9,7 @@ import { IKayentaStage, KayentaAnalysisType } from 'kayenta/domain';
 import { CANARY_SCORES_CONFIG_COMPONENT } from 'kayenta/components/canaryScores.component';
 import { KayentaStageTransformer, KAYENTA_STAGE_TRANSFORMER } from './kayentaStage.transformer';
 import { KayentaStageController } from './kayentaStage.controller';
+import { CanaryExecutionLabel } from './CanaryExecutionLabel';
 import { KAYENTA_STAGE_EXECUTION_DETAILS_CONTROLLER } from './kayentaStageExecutionDetails.controller';
 import { KAYENTA_STAGE_CONFIG_SECTION } from './kayentaStageConfigSection.component';
 import { KAYENTA_ANALYSIS_TYPE_COMPONENT } from './analysisType.component';
@@ -91,6 +92,7 @@ module(KAYENTA_CANARY_STAGE, [
       controller: 'KayentaCanaryStageCtrl',
       controllerAs: 'kayentaCanaryStageCtrl',
       executionDetailsUrl: require('./kayentaStageExecutionDetails.html'),
+      executionLabelComponent: CanaryExecutionLabel,
       validators: [
         { type: 'requiredField', fieldName: 'canaryConfig.canaryConfigId', fieldLabel: 'Config Name' },
         { type: 'requiredField', fieldName: 'canaryConfig.metricsAccountName', fieldLabel: 'Metrics Account' },


### PR DESCRIPTION
The older canary stage does a kind of nice thing where it adds the overall score/result to the execution labels and tooltips. This mostly does a 1:1 port of that into Kayenta:

<img width="285" alt="screen shot 2019-02-23 at 9 04 53 pm" src="https://user-images.githubusercontent.com/1850998/53295391-2faa3880-37af-11e9-942c-d4cd1371d9b5.png">
