### PR TITLE
fix(style): Table should render correctly with large scopes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "angular-ui-sortable": "^0.17.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-polyfill": "^6.26.0",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "cachefactory": "^3.0.0",
     "chart.js": "^2.7.0",
     "class-autobind-decorator": "^2.2.1",

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -57,7 +57,7 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
   {
     label: 'Summary',
     getContent: execution => (
-      <>
+      <div>
         <ReportLink
           configName={execution.config ? execution.config.name : execution.result.config.name}
           executionId={execution.pipelineId}
@@ -67,13 +67,10 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
           {'  '}
           <FormattedDate dateIso={execution.startTimeIso} />
         </ReportLink>
-        {'  '}
         {execution.startTimeIso && (
-          <span className="color-text-caption body-small" style={{ marginLeft: '10px' }}>
-            {moment(execution.startTimeIso).fromNow()}
-          </span>
+          <div className="color-text-caption body-small">{moment(execution.startTimeIso).fromNow()}</div>
         )}
-      </>
+      </div>
     ),
   },
   {
@@ -114,9 +111,10 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
 
       const areScopesIdentical = isEqual(baselineScopeNames, canaryScopeNames);
 
+      const styles: React.CSSProperties = { maxWidth: '350px', wordBreak: 'break-all' };
       if (areScopesIdentical) {
         return (
-          <div className="vertical">
+          <div className="vertical" style={styles}>
             {[...canaryScopeNames].map(scope => (
               <span key={scope}>{scope}</span>
             ))}
@@ -124,7 +122,7 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
         );
       } else {
         return (
-          <div className="vertical">
+          <div className="vertical" style={styles}>
             <span className="heading-6 uppercase color-text-caption">Baseline</span>
             {[...baselineScopeNames].map(scope => (
               <span key={scope}>{scope}</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,10 +2137,10 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 boundary-cells@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Fix canary report table and upgrade to bootstrap 3.4.1

Canary report has garbled scores and information if the scope is too long. Temporarily fixed it to make it usable. Upgraded to bootstrap 3.4.1 since this is on the older version with a few XSS vulnerabilities. 
