### PR TITLE
fix(executionSummary): don't npe on basically every execution

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
@@ -9,6 +9,10 @@ const stageTypesToAlwaysShow = [KAYENTA_CANARY, CREATE_SERVER_GROUP];
 export class KayentaStageTransformer implements ITransformer {
   public transform(_application: Application, execution: IExecution): void {
     const kayentaStage = execution.stages.find(({ type }) => type === KAYENTA_CANARY);
+    if (!kayentaStage) {
+      return;
+    }
+
     let stagesToRenderAsTasks: IExecutionStage[] = [];
 
     execution.stages.forEach(stage => {


### PR DESCRIPTION
I definitely realized that stage transformers are called for every execution even if they don't contain a specific stage type, this was simply a piece of very subtle performance art that involved breaking everyone's executions