### PR TITLE
fix(configs): make the config list click target humanely sized

### DIFF
--- a/src/kayenta/edit/configList.less
+++ b/src/kayenta/edit/configList.less
@@ -1,0 +1,7 @@
+.config-list > .tabs-vertical > li {
+  padding: 0;
+
+  & > a {
+    padding: 18px 12px;
+  }
+}

--- a/src/kayenta/edit/configList.tsx
+++ b/src/kayenta/edit/configList.tsx
@@ -9,6 +9,8 @@ import CreateConfigButton from './createConfigButton';
 import FormattedDate from 'kayenta/layout/formattedDate';
 import { OwnedBy } from './ownedBy';
 
+import './configList.less';
+
 interface IConfigListStateProps {
   configs: ICanaryConfigSummary[];
   selectedConfigId: string;
@@ -21,18 +23,20 @@ interface IConfigListStateProps {
 function ConfigList({ configs, selectedConfigId, application }: IConfigListStateProps) {
   return (
     <section className="config-list">
-      <ul className="tabs-vertical list-unstyled" style={{ wordBreak: 'break-all' }}>
+      <ul className="tabs-vertical list-unstyled " style={{ wordBreak: 'break-all' }}>
         {configs.map(config => (
-          <UISref key={config.id} to=".configDetail" params={{ id: config.id, new: false, copy: false }}>
-            <li className={config.id === selectedConfigId ? 'selected' : ''}>
-              <span className="heading-4 color-text-primary">{config.name}</span>
-              <div className="body-small color-text-caption caption" style={{ marginTop: '5px', marginBottom: '0' }}>
-                Edited: <FormattedDate dateIso={config.updatedTimestampIso} />
-                <br />
-                <OwnedBy owningApplications={config.applications} currentApplication={application} />
-              </div>
-            </li>
-          </UISref>
+          <li key={config.id} className={config.id === selectedConfigId ? 'selected' : ''}>
+            <UISref to=".configDetail" params={{ id: config.id, new: false, copy: false }}>
+              <a>
+                <div className="heading-4 color-text-primary">{config.name}</div>
+                <div className="body-small color-text-caption caption" style={{ marginTop: '5px', marginBottom: '0' }}>
+                  Edited: <FormattedDate dateIso={config.updatedTimestampIso} />
+                  <br />
+                  <OwnedBy owningApplications={config.applications} currentApplication={application} />
+                </div>
+              </a>
+            </UISref>
+          </li>
         ))}
       </ul>
       <CreateConfigButton />

--- a/src/kayenta/edit/configList.tsx
+++ b/src/kayenta/edit/configList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { sortBy } from 'lodash';
-import { UISref, UISrefActive } from '@uirouter/react';
+import { UISref } from '@uirouter/react';
 
 import { ICanaryState } from 'kayenta/reducers';
 import { ICanaryConfigSummary } from 'kayenta/domain/ICanaryConfigSummary';
@@ -23,18 +23,16 @@ function ConfigList({ configs, selectedConfigId, application }: IConfigListState
     <section className="config-list">
       <ul className="tabs-vertical list-unstyled" style={{ wordBreak: 'break-all' }}>
         {configs.map(config => (
-          <li key={config.id} className={config.id === selectedConfigId ? 'selected' : ''}>
-            <UISrefActive class="active">
-              <UISref to=".configDetail" params={{ id: config.id, new: false, copy: false }}>
-                <a className="heading-4">{config.name}</a>
-              </UISref>
-            </UISrefActive>
-            <div className="body-small color-text-caption caption" style={{ marginTop: '5px', marginBottom: '0' }}>
-              Edited: <FormattedDate dateIso={config.updatedTimestampIso} />
-              <br />
-              <OwnedBy owningApplications={config.applications} currentApplication={application} />
-            </div>
-          </li>
+          <UISref key={config.id} to=".configDetail" params={{ id: config.id, new: false, copy: false }}>
+            <li className={config.id === selectedConfigId ? 'selected' : ''}>
+              <span className="heading-4 color-text-primary">{config.name}</span>
+              <div className="body-small color-text-caption caption" style={{ marginTop: '5px', marginBottom: '0' }}>
+                Edited: <FormattedDate dateIso={config.updatedTimestampIso} />
+                <br />
+                <OwnedBy owningApplications={config.applications} currentApplication={application} />
+              </div>
+            </li>
+          </UISref>
         ))}
       </ul>
       <CreateConfigButton />


### PR DESCRIPTION
In the list of canary configs the nice, big sidebar items have a hover state _and_ a pointer cursor, but the actual `<UISref>` has been on this teeny tiny little link you have to know to click despite our affordances lying to you:

<img width="330" alt="screen shot 2019-02-27 at 8 24 42 am" src="https://user-images.githubusercontent.com/1850998/53505793-73c86200-3a69-11e9-96c3-7a066b2b1a6e.png">

This moves the `<UISref>` up to cover the entire `<li>` so the affordances match reality. I yanked out the `<a>` entirely, and the text now looks a little more like a normal sidebar item rather than a sub-link inside a bigger clickable thing:

<img width="250" alt="screen shot 2019-02-27 at 8 29 39 am" src="https://user-images.githubusercontent.com/1850998/53506014-f3563100-3a69-11e9-9a1a-a33c8c7bd612.png">

<img width="257" alt="screen shot 2019-02-27 at 8 29 54 am" src="https://user-images.githubusercontent.com/1850998/53506025-f8b37b80-3a69-11e9-91dc-5fb759f586ca.png">
