### PR TITLE
feat(canary) - add support for displaying time offset canaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "lib/lib.js",
   "typings": "lib/kayenta/index.d.ts",
   "name": "@spinnaker/kayenta",
-  "version": "0.0.73",
+  "version": "0.0.75",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -22,6 +22,8 @@ const helpContents: { [key: string]: string } = {
   `,
   'pipeline.config.canary.delayBeforeAnalysis':
     '<p>The number of minutes until the first canary analysis measurement interval begins.</p>',
+  'pipeline.config.canary.baselineAnalysisOffset':
+    '<p>The offset in minutes of baseline data collection from the beginning of canary analysis. Useful for comparing metrics pre-canary for relative comparison. This field accepts SpEL</p>',
   'pipeline.config.canary.canaryInterval': `
         <p>The frequency at which a canary score is generated. The recommended interval is at least 30 minutes.</p>
         <p>If an interval is not specified, or the specified interval is larger than the overall time range, there will be one canary run over the full time range.</p>`,

--- a/src/kayenta/report/detail/graph/chartjs/chartConfigFactory.ts
+++ b/src/kayenta/report/detail/graph/chartjs/chartConfigFactory.ts
@@ -4,12 +4,16 @@ import * as moment from 'moment-timezone';
 import { SETTINGS } from '@spinnaker/core';
 import { IMetricSetPair, IMetricSetScope } from 'kayenta/domain/IMetricSetPair';
 import { GraphType } from '../metricSetPairGraph.service';
+import { ChartLegendItemCallback } from './graph';
 
 const { defaultTimeZone } = SETTINGS;
 
 // TODO(dpeach): remove this after https://github.com/chartjs/Chart.js/pull/4843
 // has been merged and released.
 moment.tz.setDefault(defaultTimeZone);
+
+const BASELINE_COLOR_HEX = '#983f00';
+const CANARY_COLOR_HEX = '#0175dc';
 
 const buildChartPoints = (values: number[], scope: IMetricSetScope): ChartPoint[] => {
   if (!values) {
@@ -31,31 +35,50 @@ const buildChartPoints = (values: number[], scope: IMetricSetScope): ChartPoint[
     .filter(point => !!point);
 };
 
-export const buildChartConfig = (metricSetPair: IMetricSetPair, type: GraphType): ChartConfiguration => {
+export const buildChartConfig = (
+  metricSetPair: IMetricSetPair,
+  type: GraphType,
+  legendCallback: ChartLegendItemCallback,
+): ChartConfiguration => {
   if (type !== GraphType.AmplitudeVsTime) {
     // only one type for now.
     return null;
   }
 
+  const controlData = buildChartPoints(metricSetPair.values.control, metricSetPair.scopes.control);
+  const experimentData = buildChartPoints(metricSetPair.values.experiment, metricSetPair.scopes.experiment);
+
+  //if the experiment and control have different start times add a second axis
+  if (controlData.length > 0 && experimentData.length > 0 && controlData[0].x !== experimentData[0].x) {
+    return buildDualAxisLineChartConfig(controlData, experimentData, legendCallback);
+  } else {
+    return buildDefaultLineChartConfig(controlData, experimentData);
+  }
+};
+
+export const buildDefaultLineChartConfig = (
+  controlData: ChartPoint[],
+  experimentData: ChartPoint[],
+): ChartConfiguration => {
   return {
     type: 'line',
     data: {
       datasets: [
         {
-          borderColor: '#983f00',
+          borderColor: BASELINE_COLOR_HEX,
           borderWidth: 1,
           pointRadius: 0,
           backgroundColor: 'transparent',
-          data: buildChartPoints(metricSetPair.values.control, metricSetPair.scopes.control),
+          data: controlData,
           label: 'Baseline',
           steppedLine: true,
         },
         {
-          borderColor: '#0175dc',
+          borderColor: CANARY_COLOR_HEX,
           borderWidth: 1,
           pointRadius: 0,
           backgroundColor: 'transparent',
-          data: buildChartPoints(metricSetPair.values.experiment, metricSetPair.scopes.experiment),
+          data: experimentData,
           label: 'Canary',
           steppedLine: true,
         },
@@ -77,6 +100,91 @@ export const buildChartConfig = (metricSetPair: IMetricSetPair, type: GraphType)
           {
             type: 'time',
             distribution: 'series',
+          } as any,
+        ], // bad typings.
+      },
+    },
+  };
+};
+
+export const buildDualAxisLineChartConfig = (
+  controlData: ChartPoint[],
+  experimentData: ChartPoint[],
+  legendCallback: ChartLegendItemCallback,
+): ChartConfiguration => {
+  return {
+    type: 'line',
+    data: {
+      datasets: [
+        {
+          borderColor: BASELINE_COLOR_HEX,
+          borderWidth: 1,
+          pointRadius: 0,
+          backgroundColor: 'transparent',
+          data: controlData,
+          label: 'Baseline',
+          xAxisID: 'baseline-axis',
+          steppedLine: true,
+        },
+        {
+          borderColor: CANARY_COLOR_HEX,
+          borderWidth: 1,
+          pointRadius: 0,
+          backgroundColor: 'transparent',
+          data: experimentData,
+          label: 'Canary',
+          xAxisID: 'canary-axis',
+          steppedLine: true,
+        },
+      ],
+    },
+    options: {
+      animation: {
+        duration: 0,
+      },
+      legend: {
+        position: 'bottom',
+        onClick: legendCallback,
+        labels: {
+          fontSize: 15,
+          padding: 5,
+        },
+      },
+      scales: {
+        xAxes: [
+          {
+            id: 'canary-axis',
+            label: 'Canary',
+            type: 'time',
+            distribution: 'series',
+            scaleLabel: {
+              display: true,
+              labelString: 'Canary',
+            },
+            time: {
+              min: experimentData[0].x,
+              max: experimentData[experimentData.length - 1].x,
+            },
+            ticks: {
+              fontColor: CANARY_COLOR_HEX,
+            },
+          } as any,
+          {
+            id: 'baseline-axis',
+            label: 'Baseline',
+            type: 'time',
+            distribution: 'series',
+            scaleLabel: {
+              display: true,
+              labelString: 'Baseline',
+            },
+            time: {
+              min: controlData[0].x,
+              max: controlData[controlData.length - 1].x,
+            },
+            ticks: {
+              fontColor: BASELINE_COLOR_HEX,
+            },
           } as any,
         ], // bad typings.
       },

--- a/src/kayenta/report/detail/graph/chartjs/graph.tsx
+++ b/src/kayenta/report/detail/graph/chartjs/graph.tsx
@@ -1,17 +1,34 @@
 import * as React from 'react';
-import { Chart } from 'chart.js';
+import { Chart, ChartLegendItem } from 'chart.js';
 
 import { IMetricSetPairGraphProps } from '../metricSetPairGraph.service';
 import { buildChartConfig } from './chartConfigFactory';
+
+export interface ChartLegendItemCallback {
+  (e: MouseEvent, legendItem: ChartLegendItem): void;
+}
 
 export default class ChartJSGraph extends React.Component<IMetricSetPairGraphProps> {
   private canvas: HTMLCanvasElement;
   public chart: Chart;
 
+  public legendOnClickHideAxis: ChartLegendItemCallback = (e: MouseEvent, legendItem: ChartLegendItem): void => {
+    const xAxes = this.chart.config.options.scales.xAxes;
+
+    xAxes.forEach(axis => {
+      if (axis.scaleLabel.labelString === legendItem.text) {
+        axis.display = !axis.display;
+      }
+    });
+
+    //call the default handler now
+    Chart.defaults.global.legend.onClick.call(this, e, legendItem);
+  };
+
   public componentDidMount(): void {
     const context = this.canvas.getContext('2d');
     const { metricSetPair, type } = this.props;
-    this.chart = new Chart.Chart(context, buildChartConfig(metricSetPair, type));
+    this.chart = new Chart.Chart(context, buildChartConfig(metricSetPair, type, this.legendOnClickHideAxis));
   }
 
   public render() {

--- a/src/kayenta/report/detail/reportMetadata.tsx
+++ b/src/kayenta/report/detail/reportMetadata.tsx
@@ -36,15 +36,19 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
 
   const {
     controlScope: {
-      // If the canary ran through Orca, it's not possible
-      // for start, end, and step to be different between control and experiment.
-      start,
-      end,
       step,
       location: controlLocation,
       scope: controlScope,
     },
-    experimentScope: { location: experimentLocation, scope: experimentScope },
+    experimentScope: {
+      // Since baseline starttime may be offset in canaries from Orca,
+      // Choose the experiment start and end to represent
+      // the canary start and end times
+      start: experimentStart,
+      end: experimentEnd,
+      location: experimentLocation,
+      scope: experimentScope,
+    },
   } = scopes[0];
 
   return [
@@ -83,7 +87,7 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
           label: 'start',
           getContent: () => (
             <p>
-              <FormattedDate dateIso={start} />
+              <FormattedDate dateIso={experimentStart} />
             </p>
           ),
         },
@@ -91,7 +95,7 @@ const buildScopeMetadataEntries = (run: ICanaryExecutionStatusResult): IMetadata
           label: 'end',
           getContent: () => (
             <p>
-              <FormattedDate dateIso={end} />
+              <FormattedDate dateIso={experimentEnd} />
             </p>
           ),
         },

--- a/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
+++ b/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
@@ -87,18 +87,18 @@ function CanaryRunTimestamps({ canaryRun, firstScopeName }: { canaryRun: IStage;
     <section className="small">
       <ul className="list-unstyled">
         <li>
-          <b>Start:</b> {timestamp(Date.parse(canaryRun.context.scopes[firstScopeName].controlScope.start))}
+          <b>Start:</b> {timestamp(Date.parse(canaryRun.context.scopes[firstScopeName].experimentScope.start))}
           <CopyToClipboard
             displayText={false}
-            text={canaryRun.context.scopes[firstScopeName].controlScope.start}
+            text={canaryRun.context.scopes[firstScopeName].experimentScope.start}
             toolTip={toolTipText}
           />
         </li>
         <li>
-          <b>End:</b> {timestamp(Date.parse(canaryRun.context.scopes[firstScopeName].controlScope.end))}
+          <b>End:</b> {timestamp(Date.parse(canaryRun.context.scopes[firstScopeName].experimentScope.end))}
           <CopyToClipboard
             displayText={false}
-            text={canaryRun.context.scopes[firstScopeName].controlScope.end}
+            text={canaryRun.context.scopes[firstScopeName].experimentScope.end}
             toolTip={toolTipText}
           />
         </li>

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -122,6 +122,18 @@
       <span class="form-control-static"> seconds</span>
     </stage-config-field>
 
+    <stage-config-field label="Baseline Offset"
+                        help-key="pipeline.config.canary.baselineAnalysisOffset"
+                        field-columns="3">
+      <input
+        class="form-control input-sm"
+        ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.baselineAnalysisOffsetInMins"
+        type="text"
+        min="0"
+        style="width: 33%; display: inline-block"/>
+      <span class="form-control-static"> minutes</span>
+    </stage-config-field>
+
     <stage-config-field label="Lookback Type"
                         help-key="pipeline.config.canary.lookback"
                         field-columns="3">

--- a/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStageExecutionDetails.html
@@ -85,6 +85,10 @@
           <div class="col-md-4 sm-label-right compact">Interval</div>
           <div class="col-md-6">{{stage.context.canaryConfig.canaryAnalysisIntervalMins}} minutes</div>
         </div>
+        <div class="row" ng-if="stage.context.canaryConfig.baselineAnalysisOffsetInMins">
+          <div class="col-md-4 sm-label-right compact">Baseline Offset</div>
+          <div class="col-md-6">{{stage.context.canaryConfig.baselineAnalysisOffsetInMins}} minutes</div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Associated Orca Pull: https://github.com/spinnaker/orca/pull/2836

We have added support for offsetting canaries baseline scope to enable comparison across two different windows in time. This allows for checking metrics against previous known values enabling canaries during rollouts, and checking the effect of a deployment on overall metrics without deploying a baseline scope.

Added functionality:
- add support for 2 x-axis
- add support for hiding an axis
- added displays of the offset value where relevent