### PR TITLE
feat(config): less confusing UX when viewing a read only config

### DIFF
--- a/src/kayenta/canary.less
+++ b/src/kayenta/canary.less
@@ -49,6 +49,15 @@
       }
     }
 
+    .config-detail-edit-warning {
+      padding: 12px;
+      margin-bottom: 12px;
+      i.fa {
+        color: var(--color-notice);
+        font-size: 32px;
+      }
+    }
+
     .contents .native-table-header {
       padding-top: 10px;
     }

--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -1,33 +1,79 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { UISref } from '@uirouter/react';
 
 import { ICanaryState } from 'kayenta/reducers';
-import { ICanaryConfig } from 'kayenta/domain/ICanaryConfig';
-import ConfigDetailActionButtons from './configDetailActionButtons';
+import { ICanaryConfig } from 'kayenta/domain';
 import { mapStateToConfig } from 'kayenta/service/canaryConfig.service';
 import FormattedDate from 'kayenta/layout/formattedDate';
 
+import ConfigDetailActionButtons from './configDetailActionButtons';
+
 interface IConfigDetailStateProps {
   selectedConfig: ICanaryConfig;
+  editingDisabled: boolean;
 }
+
+const getOwnerAppLinks = (owners: string[]) => {
+  if (owners.length === 1) {
+    return (
+      <UISref to="." params={{ application: owners[0] }}>
+        <a>{owners[0]}</a>
+      </UISref>
+    );
+  } else {
+    // totally gross to read, but a somewhat-straightforward way of creating
+    // a 'one, two, or three' sentence from this array of app names with some JSX in between
+    const lastIndex = owners.length - 1;
+    return owners.map((owner, index) => (
+      <React.Fragment key={owner}>
+        {index === lastIndex ? 'or ' : ''}
+        <UISref to="." params={{ application: owner }}>
+          <a>{owner}</a>
+        </UISref>
+        {index < lastIndex && owners.length === 2 ? ' ' : ''}
+        {index < lastIndex && owners.length > 2 ? ', ' : ''}
+      </React.Fragment>
+    ));
+  }
+};
+
+const EditingDisabledWarning = ({ owners }: { owners: string[] }) => {
+  return (
+    <div className="horizontal middle well-compact alert alert-warning config-detail-edit-warning">
+      <i className="fa fa-exclamation-triangle sp-margin-m-right" />
+      <span>
+        <b>
+          Editing is disabled because this config is owned by{' '}
+          {owners.length > 1 ? `${owners.length} other applications` : 'another application'}.
+        </b>{' '}
+        To edit, view in {getOwnerAppLinks(owners)}
+      </span>
+    </div>
+  );
+};
 
 /*
  * Config detail header layout.
  */
-function ConfigDetailHeader({ selectedConfig }: IConfigDetailStateProps) {
+function ConfigDetailHeader({ selectedConfig, editingDisabled }: IConfigDetailStateProps) {
   return (
-    <div className="horizontal config-detail-header">
-      <div className="flex-3">
-        <h1 className="heading-1 color-text-primary">{selectedConfig ? selectedConfig.name : ''}</h1>
+    <div className="vertical">
+      <div className="horizontal config-detail-header">
+        <div className="flex-3">
+          <h1 className="heading-1 color-text-primary">{selectedConfig ? selectedConfig.name : ''}</h1>
+        </div>
+        <div className="flex-1">
+          <h5 className="heading-5">
+            <strong>Edited:</strong>{' '}
+            <FormattedDate dateIso={selectedConfig ? selectedConfig.updatedTimestampIso : ''} />
+          </h5>
+        </div>
+        <div className="flex-2">
+          <ConfigDetailActionButtons />
+        </div>
       </div>
-      <div className="flex-1">
-        <h5 className="heading-5">
-          <strong>Edited:</strong> <FormattedDate dateIso={selectedConfig ? selectedConfig.updatedTimestampIso : ''} />
-        </h5>
-      </div>
-      <div className="flex-2">
-        <ConfigDetailActionButtons />
-      </div>
+      {selectedConfig && editingDisabled && <EditingDisabledWarning owners={selectedConfig.applications} />}
     </div>
   );
 }
@@ -35,6 +81,7 @@ function ConfigDetailHeader({ selectedConfig }: IConfigDetailStateProps) {
 function mapStateToProps(state: ICanaryState): IConfigDetailStateProps {
   return {
     selectedConfig: mapStateToConfig(state),
+    editingDisabled: state.app.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/configJsonModal.tsx
+++ b/src/kayenta/edit/configJsonModal.tsx
@@ -105,7 +105,7 @@ function ConfigJsonModal({
                 data-id={id}
                 data-serialized={configJson}
                 onClick={updateConfig}
-                disabled={!!deserializationError}
+                disabled={!!deserializationError || disabled}
               >
                 Update
               </button>

--- a/src/kayenta/edit/copyConfigButton.tsx
+++ b/src/kayenta/edit/copyConfigButton.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { UISref } from '@uirouter/react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
+
 import { ICanaryState } from '../reducers/index';
 
 interface ICopyConfigButtonStateProps {
@@ -23,7 +25,7 @@ function CopyConfigButton({ disabled }: ICopyConfigButtonStateProps) {
 
 function mapStateToProps(state: ICanaryState) {
   return {
-    disabled: state.selectedConfig.config && state.selectedConfig.config.isNew,
+    disabled: get(state.selectedConfig, 'config.isNew') || state.app.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -39,6 +39,7 @@ interface IEditMetricModalStateProps {
   groups: string[];
   isTemplateValid: boolean;
   useInlineTemplateEditor: boolean;
+  disableEdit: boolean;
   validationErrors: ICanaryMetricValidationErrors;
 }
 
@@ -96,6 +97,7 @@ function EditMetricModal({
   updateCriticality,
   updateScopeName,
   useInlineTemplateEditor,
+  disableEdit,
   validationErrors,
 }: IEditMetricModalDispatchProps & IEditMetricModalStateProps) {
   if (!metric) {
@@ -110,7 +112,7 @@ function EditMetricModal({
     'canary',
     'effectSize',
   ]);
-  const isConfirmDisabled = !isTemplateValid || values(validationErrors).some(e => !isNull(e));
+  const isConfirmDisabled = !isTemplateValid || disableEdit || values(validationErrors).some(e => !isNull(e));
 
   const metricGroup = metric.groups.length ? metric.groups[0] : groups[0];
   const templatesEnabled =
@@ -121,7 +123,7 @@ function EditMetricModal({
     <Modal bsSize="large" show={true} onHide={noop} className={classNames('kayenta-edit-metric-modal')}>
       <Styleguide>
         <Modal.Header>
-          <Modal.Title>Configure Metric</Modal.Title>
+          <Modal.Title>{disableEdit ? 'Metric Details' : 'Configure Metric'}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <FormRow label="Group">
@@ -276,6 +278,7 @@ function mapStateToProps(state: ICanaryState): IEditMetricModalStateProps {
     groups: state.selectedConfig.group.list.sort(),
     isTemplateValid: isTemplateValidSelector(state),
     useInlineTemplateEditor: useInlineTemplateEditorSelector(state),
+    disableEdit: state.app.disableConfigEdit,
     validationErrors: editingMetricValidationErrorsSelector(state),
   };
 }

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
 import { cloneDeep } from 'lodash';
-import { noop } from '@spinnaker/core';
 import { ICanaryMetricConfig } from 'kayenta/domain';
 import { ICanaryState } from 'kayenta/reducers';
 import * as Creators from 'kayenta/actions/creators';
@@ -61,20 +60,15 @@ function MetricList({
       getContent: metric => (
         <div className="horizontal pull-right metrics-action-buttons">
           <button className="link" data-id={metric.id} onClick={editMetric}>
-            Edit
+            {disableEdit ? 'View' : 'Edit'}
           </button>
-          <button className="link" data-id={metric.id} onClick={openChangeMetricGroupModal}>
+          <button className="link" data-id={metric.id} disabled={disableEdit} onClick={openChangeMetricGroupModal}>
             Move Group
           </button>
-          <button className="link" data-id={metric.id} onClick={() => copyMetric(metric)}>
+          <button className="link" data-id={metric.id} disabled={disableEdit} onClick={() => copyMetric(metric)}>
             Copy
           </button>
-          <button
-            className="link"
-            data-id={metric.id}
-            disabled={disableEdit}
-            onClick={disableEdit ? noop : removeMetric}
-          >
+          <button className="link" data-id={metric.id} disabled={disableEdit} onClick={removeMetric}>
             Delete
           </button>
         </div>

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -46,7 +46,7 @@ function NameAndDescription({
   );
 }
 
-function mapStateToProps(state: ICanaryState) {
+function mapStateToProps(state: ICanaryState): INameAndDescriptionStateProps {
   if (state.selectedConfig.config) {
     return {
       name: state.selectedConfig.config.name,
@@ -60,7 +60,7 @@ function mapStateToProps(state: ICanaryState) {
   }
 }
 
-function mapDispatchToProps(dispatch: (action: Action & any) => void) {
+function mapDispatchToProps(dispatch: (action: Action & any) => void): INameAndDescriptionDispatchProps {
   return {
     changeName: (event: React.ChangeEvent<HTMLInputElement>) => {
       dispatch(


### PR DESCRIPTION
Today when you view a config in an app that doesn't 'own' that config, we are _theoretically_ supposed to switch to a read only view. Turns out, we don't really do that and instead we really just disable the 'Delete' buttons on stuff with everything else left editable. For added fun, if you try to click 'copy' it opens up a copied config but doesn't let you edit it and therefore it's impossible to save. This has caused some confusion at Netflix, especially because there's no mention of _why_ editing is disabled.

My attempt to reduce confusion is pretty low effort (this doesn't come up too often):
- _Actually_ disable everything on the config page that has to do with write operations (copy, saving changes to metrics, updating the JSON manually, etc.)
- Add a new warning at the top of the page that explains why the config isn't editable, and lists out the apps that own the config. Each app in the list is a link to the config details view in the context of that app (so you can make edits if you truly want to)

Here's what the warning looks like with one, two, and more than two apps respectively:

<img width="1115" alt="Screen Shot 2019-05-08 at 3 52 44 PM" src="https://user-images.githubusercontent.com/1850998/57416647-d51d5780-71b5-11e9-90ca-0d720a28435a.png">

<img width="1153" alt="Screen Shot 2019-05-08 at 3 57 36 PM" src="https://user-images.githubusercontent.com/1850998/57416656-db133880-71b5-11e9-81ea-b9f822ac9115.png">

<img width="1126" alt="Screen Shot 2019-05-08 at 3 52 14 PM" src="https://user-images.githubusercontent.com/1850998/57416668-e7979100-71b5-11e9-808d-6abc72476eae.png">
