### PR TITLE
fix(stage): don't steal other stages when no intervalStageId exists

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
@@ -19,10 +19,14 @@ export class KayentaStageTransformer implements ITransformer {
       if (stage.type === KAYENTA_CANARY) {
         OrchestratedItemTransformer.defineProperties(stage);
 
-        const intervalStageId = stage.context.intervalStageId;
-        const syntheticCanaryStages = execution.stages.filter(
-          s => s.parentStageId === intervalStageId && [WAIT, RUN_CANARY].includes(s.type),
-        );
+        const intervalStageId: string = stage.context.intervalStageId;
+        const syntheticCanaryStages = intervalStageId
+          ? execution.stages.filter(
+              ({ parentStageId, type }) =>
+                parentStageId && parentStageId === intervalStageId && [WAIT, RUN_CANARY].includes(type),
+            )
+          : [];
+
         stagesToRenderAsTasks = stagesToRenderAsTasks.concat(syntheticCanaryStages);
 
         const runCanaryStages = syntheticCanaryStages.filter(s => s.type === RUN_CANARY);


### PR DESCRIPTION
Apparently when I write transformers I accidentally make them very greedy, as this is the second case of `KayentaStageTransformer` stealing other stages and using them as its own.

Turns out that early in the lifecycle of `kayentaCanary` stages they don't actually have an `intervalStageId`, which makes sense. Top level stages don't have `parentStageId`s, which also makes sense. The only thing that doesn't make sense is the conditional I wrote which took any stages whose `parentStageId` matched the value of `intervalStageId` (when both are sometimes `undefined`) and claimed them as belonging to the `kayentaCanary` stage.

Sometimes this bug resulted in weird missing stages, other times it blew up the pipeline graph code and led to an unrecoverable full page crash.

cc @gregorymfoster