### PR TITLE
fix(stage): mark 'Scope Type' as required for non-automatic Atlas stages

### DIFF
--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -403,7 +403,10 @@
 
     <for-analysis-type stage="kayentaCanaryStageCtrl.stage" types="realTime, retrospective">
       <stage-config-field label="Scope Type" ng-if="kayentaCanaryStageCtrl.metricStore === 'atlas'">
-        <select class="form-control input-sm" ng-model="kayentaCanaryStageCtrl.state.atlasScopeType" ng-options="(type === 'cluster' ? 'Cluster' : 'Query') for type in ['cluster', 'query']"
+        <select
+          required
+          class="form-control input-sm" ng-model="kayentaCanaryStageCtrl.state.atlasScopeType"
+          ng-options="(type === 'cluster' ? 'Cluster' : 'Query') for type in ['cluster', 'query']"
           ng-change="kayentaCanaryStageCtrl.onAtlasScopeTypeChange()">
         </select>
       </stage-config-field>

--- a/src/kayenta/stages/kayentaStage/kayentaStage.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.ts
@@ -163,6 +163,28 @@ module(KAYENTA_CANARY_STAGE, [
         },
         {
           type: 'custom',
+          validate: (_pipeline: IPipeline, stage: IKayentaStage) => {
+            if (
+              !has(stage, 'canaryConfig.canaryConfigId') ||
+              stage.analysisType === KayentaAnalysisType.RealTimeAutomatic
+            ) {
+              return null;
+            }
+
+            return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then(configDetails => {
+              if (
+                get(configDetails, 'metrics[0].query.type') === 'atlas' &&
+                !get(stage, 'canaryConfig.scopes[0].extendedScopeParams.type')
+              ) {
+                return 'Scope Type is required';
+              } else {
+                return null;
+              }
+            });
+          },
+        },
+        {
+          type: 'custom',
           validate: allScopesMustBeConfigured,
         },
         {


### PR DESCRIPTION
The stage config's controller already defaults to a non-null value in all the cases i've been able to identify, but we ran into a snag internally where someone was migrating their old stages over to the `kayentaCanary`  stage and somehow the `type` field got dropped from the underlying JSON. They were unaware since we didn't show any sort of validation errors — this should theoretically fix that.