### PR TITLE
fix(report, config): don't blow up when navigating to top level config/report states

### DIFF
--- a/src/kayenta/navigation/canary.states.ts
+++ b/src/kayenta/navigation/canary.states.ts
@@ -59,7 +59,6 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
       const config: INestedState = {
         name: 'canaryConfig',
         url: '/config',
-        abstract: true,
         views: {
           canary: {
             component: CanaryConfigEdit,
@@ -67,6 +66,7 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
           },
         },
         children: [configDefault, configDetail],
+        redirectTo: transition => transition.to().name + '.configDefault',
       };
 
       const reportDetail: INestedState = {
@@ -101,7 +101,6 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
       const report: INestedState = {
         name: 'report',
         url: '/report',
-        abstract: true,
         views: {
           canary: {
             component: Report,
@@ -109,6 +108,7 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
           },
         },
         children: [reportDetail, reportDefault],
+        redirectTo: transition => transition.to().name + '.reportDefault',
       };
 
       const canaryRoot: INestedState = {


### PR DESCRIPTION
Turns out we've been implicitly relying on bypassing `UISref`'s transition logic, and [now that core no longer does that for us](https://github.com/spinnaker/deck/pull/7064) navigating to the top level report and config states from the nav is broken.

The actual culprits were 1. listing the top level states as abstract 2. not redirecting to the appropriate default state explicitly.