### PR TITLE
fix(stage): improve start and end timestamp validation and help text

### DIFF
--- a/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
+++ b/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
@@ -82,7 +82,7 @@ export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICana
 }
 
 function CanaryRunTimestamps({ canaryRun, firstScopeName }: { canaryRun: IStage; firstScopeName: string }) {
-  const toolTipText = 'Copy timestamp to clipboard';
+  const toolTipText = 'Copy timestamp to clipboard as UTC instant in ISO-8601 format';
   return (
     <section className="small">
       <ul className="list-unstyled">

--- a/src/kayenta/stages/kayentaStage/kayentaStage.html
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.html
@@ -72,6 +72,7 @@
       <stage-config-field label="Start Time"
                           help-key="pipeline.config.canary.startTimeIso">
         <input
+          required
           class="form-control input-sm"
           ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].startTimeIso"
           type="text"/>
@@ -80,6 +81,7 @@
       <stage-config-field label="End Time"
                           help-key="pipeline.config.canary.endTimeIso">
         <input
+          required
           class="form-control input-sm"
           ng-model="kayentaCanaryStageCtrl.stage.canaryConfig.scopes[0].endTimeIso"
           type="text"/>

--- a/src/kayenta/stages/kayentaStage/kayentaStage.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.ts
@@ -20,6 +20,10 @@ const isExpression = (value: string) => isString(value) && value.includes('${');
 const emailPattern = /^(.+)@(.+).([A-Za-z]{2,6})/;
 const isValidEmail = (email: string) => isExpression(email) || email.match(emailPattern);
 
+const utcInstantPattern = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$/;
+const isValidUtcInstant = (timestamp: string) =>
+  isExpression(timestamp) || (isString(timestamp) && timestamp.match(utcInstantPattern));
+
 const requiredForAnalysisTypes = (
   analysisTypes: KayentaAnalysisType[] = [],
   fieldName: string,
@@ -204,6 +208,34 @@ module(KAYENTA_CANARY_STAGE, [
             const emails = Array.isArray(notificationEmail) ? notificationEmail : [notificationEmail];
             const invalidEmail = emails.find(email => !isValidEmail(email));
             return invalidEmail ? `Invalid <strong>Notification Email</strong> (${invalidEmail})` : null;
+          },
+        },
+        {
+          type: 'custom',
+          validate: (_pipeline: IPipeline, stage: IKayentaStage) => {
+            const startTime: string = get(stage, 'canaryConfig.scopes[0].startTimeIso');
+            if (
+              stage.analysisType == KayentaAnalysisType.Retrospective &&
+              !isEmpty(startTime) &&
+              !isValidUtcInstant(startTime)
+            ) {
+              return '<strong>Start Time</strong> must be formatted as a UTC instant using ISO-8601 instant format (e.g., 2018-07-12T20:28:29Z).';
+            }
+            return null;
+          },
+        },
+        {
+          type: 'custom',
+          validate: (_pipeline: IPipeline, stage: IKayentaStage) => {
+            const endTime: string = get(stage, 'canaryConfig.scopes[0].endTimeIso');
+            if (
+              stage.analysisType === KayentaAnalysisType.Retrospective &&
+              !isEmpty(endTime) &&
+              !isValidUtcInstant(endTime)
+            ) {
+              return '<strong>End Time</strong> must be formatted as a UTC instant using ISO-8601 instant format (e.g., 2018-07-12T20:28:29Z).';
+            }
+            return null;
           },
         },
       ],


### PR DESCRIPTION
Closes https://github.com/spinnaker/deck-kayenta/issues/453

- In the canary stage execution details, there is a tooltip that displays a formatted start and end time, which matches the formatting of the Last Updated column. However, the timestamp that is actually copied to the clipboard is formatted as an ISO-8601 instant, which is what the start and end time inputs of the Retrospective Analysis field expects. Clarify the formatting in the tooltip text.
- Also, validate that the Retrospective Analysis start and end times are indeed formatted as ISO-8601 instants using a scary regex from the internet.