### PR TITLE
fix(prometheus): handle multiple accounts in metric type search

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -111,7 +111,7 @@ export const loadMetricsServiceMetadataSuccess = createAction<{ data: IMetricsSe
 export const loadMetricsServiceMetadataFailure = createAction<{ error: Error }>(
   Actions.LOAD_METRICS_SERVICE_METADATA_FAILURE,
 );
-export const updatePrometheusMetricDescriptorFilter = createAction<{ filter: string }>(
+export const updatePrometheusMetricDescriptorFilter = createAction<{ filter: string; metricsAccountName: string }>(
   Actions.UPDATE_PROMETHEUS_METRIC_DESCRIPTOR_FILTER,
 );
 export const updateGraphiteMetricDescriptorFilter = createAction<{ filter: string }>(

--- a/src/kayenta/metricStore/prometheus/metricTypeSelector.less
+++ b/src/kayenta/metricStore/prometheus/metricTypeSelector.less
@@ -1,0 +1,5 @@
+.prometheus-metric-type-selector-account-hint {
+  display: flex;
+  align-items: center;
+  height: 30px;
+}

--- a/src/kayenta/metricStore/prometheus/metricTypeSelector.spec.tsx
+++ b/src/kayenta/metricStore/prometheus/metricTypeSelector.spec.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { noop } from '@spinnaker/core';
+
+import { DisableableReactSelect } from 'kayenta/layout/disableable';
+import { IPrometheusMetricTypeSelectorProps, PrometheusMetricTypeSelector } from './metricTypeSelector';
+
+describe('<PrometheusMetricTypeSelector />', () => {
+  let wrapper: any;
+  const defaultProps: IPrometheusMetricTypeSelectorProps = {
+    accountOptions: [
+      {
+        label: 'my-first-prometheus-account',
+        value: 'my-first-prometheus-account',
+      },
+      {
+        label: 'my-second-prometheus-account',
+        value: 'my-second-prometheus-account',
+      },
+    ],
+    load: noop,
+    loading: false,
+    metricOptions: [],
+    onChange: noop,
+    value: '',
+  };
+
+  it('renders a typeahead select to search for metrics', () => {
+    wrapper = shallow(<PrometheusMetricTypeSelector {...defaultProps} />);
+    expect(wrapper.find(DisableableReactSelect).length).toEqual(1);
+    expect(wrapper.find(DisableableReactSelect).props().placeholder).toEqual(
+      'Enter at least three characters to search.',
+    );
+  });
+
+  it('displays which account will populate the search when >1 account is configured, defaulting to the first account alphabetically', () => {
+    wrapper = shallow(<PrometheusMetricTypeSelector {...defaultProps} />);
+    expect(
+      wrapper
+        .find('.prometheus-metric-type-selector-account-hint span')
+        .at(0)
+        .text(),
+    ).toEqual('Metric search is currently populating from my-first-prometheus-account.');
+  });
+
+  it('allows the user to switch which account populates the search when >1 account is configured', () => {
+    wrapper = shallow(<PrometheusMetricTypeSelector {...defaultProps} />);
+    expect(wrapper.find('.btn').text()).toEqual('Switch Account');
+    wrapper.find('.btn').simulate('click');
+    expect(wrapper.state('showAccountDropdown')).toEqual(true);
+    expect(wrapper.find(DisableableReactSelect).length).toEqual(2);
+  });
+
+  it('does not display account selection hint when there is only one account configured', () => {
+    wrapper = shallow(
+      <PrometheusMetricTypeSelector
+        {...defaultProps}
+        accountOptions={[{ label: 'my-only-prometheus-account', value: 'my-only-prometheus-account' }]}
+      />,
+    );
+    expect(wrapper.find('.prometheus-metric-type-selector-account-hint').length).toEqual(0);
+    expect(wrapper.find('.btn').length).toEqual(0);
+  });
+});

--- a/src/kayenta/metricStore/prometheus/metricTypeSelector.tsx
+++ b/src/kayenta/metricStore/prometheus/metricTypeSelector.tsx
@@ -2,60 +2,132 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { Option } from 'react-select';
+import { createSelector } from 'reselect';
+import { get, chain } from 'lodash';
+
+import { KayentaAccountType } from 'kayenta/domain';
 import { ICanaryState } from 'kayenta/reducers';
 import { IPrometheusMetricDescriptor } from './domain/IPrometheusMetricDescriptor';
 import { AsyncRequestState } from 'kayenta/reducers/asyncRequest';
 import * as Creators from 'kayenta/actions/creators';
 import { DISABLE_EDIT_CONFIG, DisableableReactSelect } from 'kayenta/layout/disableable';
 
+import './metricTypeSelector.less';
+
 interface IPrometheusMetricTypeSelectorDispatchProps {
-  load: (filter: string) => void;
+  load: (filter: string, metricsAccountName: string) => void;
 }
 
 interface IPrometheusMetricTypeSelectorStateProps {
-  options: Option[];
+  accountOptions: Array<Option<string>>;
   loading: boolean;
+  metricOptions: Array<Option<string>>;
 }
 
 interface IPrometheusMetricTypeSelectorOwnProps {
+  onChange: (option: Option<string>) => void;
   value: string;
-  onChange: (option: Option) => void;
 }
 
-const PrometheusMetricTypeSelector = ({
-  loading,
-  load,
-  options,
-  value,
-  onChange,
-}: IPrometheusMetricTypeSelectorDispatchProps &
+interface IPrometheusMetricTypeSelectorState {
+  selectedAccount: string;
+  showAccountDropdown: boolean;
+}
+
+export type IPrometheusMetricTypeSelectorProps = IPrometheusMetricTypeSelectorDispatchProps &
   IPrometheusMetricTypeSelectorStateProps &
-  IPrometheusMetricTypeSelectorOwnProps) => {
-  if (value && options.every(o => o.value !== value)) {
-    options = options.concat({ label: value, value });
+  IPrometheusMetricTypeSelectorOwnProps;
+
+export class PrometheusMetricTypeSelector extends React.Component<
+  IPrometheusMetricTypeSelectorProps,
+  IPrometheusMetricTypeSelectorState
+> {
+  public constructor(props: IPrometheusMetricTypeSelectorProps) {
+    super(props);
+    this.state = {
+      showAccountDropdown: false,
+      selectedAccount: get(props, ['accountOptions', 0, 'value']),
+    };
   }
 
-  return (
-    <DisableableReactSelect
-      isLoading={loading}
-      options={options}
-      onChange={onChange}
-      value={value}
-      placeholder={'Enter at least three characters to search.'}
-      onInputChange={input => {
-        load(input);
-        return input;
-      }}
-      disabledStateKeys={[DISABLE_EDIT_CONFIG]}
-    />
-  );
-};
+  public render() {
+    const { accountOptions, load, loading, metricOptions, onChange, value } = this.props;
+
+    const metricOptionsWithSelected =
+      value && metricOptions.every(o => o.value !== value)
+        ? metricOptions.concat({ label: value, value })
+        : metricOptions;
+
+    return (
+      <>
+        <DisableableReactSelect
+          isLoading={loading}
+          options={metricOptionsWithSelected}
+          onChange={onChange}
+          value={value}
+          placeholder={'Enter at least three characters to search.'}
+          onInputChange={input => {
+            load(input, this.state.selectedAccount);
+            return input;
+          }}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        />
+        {accountOptions.length > 1 && (
+          <div className="prometheus-metric-type-selector-account-hint">
+            <span>Metric search is currently populating from {this.state.selectedAccount}.</span>
+            <span className="btn btn-link" onClick={this.showAccountDropdown}>
+              {!this.state.showAccountDropdown && 'Switch Account'}
+            </span>
+          </div>
+        )}
+        {this.state.showAccountDropdown && (
+          <DisableableReactSelect
+            clearable={false}
+            options={accountOptions}
+            onChange={this.selectAccount}
+            value={this.state.selectedAccount}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+          />
+        )}
+      </>
+    );
+  }
+
+  private showAccountDropdown = (): void => {
+    this.setState({
+      showAccountDropdown: true,
+    });
+  };
+
+  private selectAccount = (option: Option<string>): void => {
+    this.setState({
+      selectedAccount: option.value,
+      showAccountDropdown: false,
+    });
+  };
+}
+
+const accountOptionsSelector = createSelector(
+  (state: ICanaryState) => state.data.kayentaAccounts.data,
+  (accounts): Array<Option<string>> => {
+    return chain(accounts)
+      .filter(a => a.supportedTypes.includes(KayentaAccountType.MetricsStore) && a.type === 'prometheus')
+      .sortBy(a => a.name)
+      .map(a => ({ label: a.name, value: a.name }))
+      .value();
+  },
+);
+
+const metricOptionsSelector = createSelector(
+  (state: ICanaryState) => state.data.metricsServiceMetadata.data,
+  (descriptors: IPrometheusMetricDescriptor[]): Array<Option<string>> =>
+    descriptors.map(d => ({ label: d.name, value: d.name })),
+);
 
 const mapStateToProps = (state: ICanaryState, ownProps: IPrometheusMetricTypeSelectorOwnProps) => {
-  const descriptors = state.data.metricsServiceMetadata.data as IPrometheusMetricDescriptor[];
-  const options: Option[] = descriptors.map(d => ({ label: d.name, value: d.name }));
   return {
-    options,
+    accountOptions: accountOptionsSelector(state),
+    metricOptions: metricOptionsSelector(state),
     loading: state.data.metricsServiceMetadata.load === AsyncRequestState.Requesting,
     ...ownProps,
   };
@@ -63,8 +135,8 @@ const mapStateToProps = (state: ICanaryState, ownProps: IPrometheusMetricTypeSel
 
 const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>) => {
   return {
-    load: (filter: string) => {
-      dispatch(Creators.updatePrometheusMetricDescriptorFilter({ filter }));
+    load: (filter: string, metricsAccountName: string) => {
+      dispatch(Creators.updatePrometheusMetricDescriptorFilter({ filter, metricsAccountName }));
     },
   };
 };

--- a/src/kayenta/middleware/epics.ts
+++ b/src/kayenta/middleware/epics.ts
@@ -94,25 +94,15 @@ const loadMetricSetPairEpic = (action$: Observable<Action & any>, store: Middlew
       .catch((error: Error) => Observable.of(Creators.loadMetricSetPairFailure({ error })));
   });
 
-const updatePrometheusMetricDescriptionFilterEpic = (
-  action$: Observable<Action & any>,
-  store: MiddlewareAPI<ICanaryState>,
-) =>
+const updatePrometheusMetricDescriptionFilterEpic = (action$: Observable<Action & any>) =>
   action$
     .filter(typeMatches(Actions.UPDATE_PROMETHEUS_METRIC_DESCRIPTOR_FILTER))
     .filter(action => action.payload.filter && action.payload.filter.length > 2)
     .debounceTime(200 /* milliseconds */)
     .map(action => {
-      const [metricsAccountName] = store
-        .getState()
-        .data.kayentaAccounts.data.filter(
-          account => account.supportedTypes.includes(KayentaAccountType.MetricsStore) && account.type === 'prometheus',
-        )
-        .map(account => account.name);
-
       return Creators.loadMetricsServiceMetadataRequest({
         filter: action.payload.filter,
-        metricsAccountName,
+        metricsAccountName: action.payload.metricsAccountName,
       });
     });
 


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4672#issuecomment-514746344
Relates to spinnaker/kayenta#598

- Unblocks users with multiple configured Prometheus accounts from searching for Prometheus metrics against different accounts when configuring a metric. Metric search will query against the alphabetically first account by default. Users can select a different account to search against, but the selected account will not be persisted with the configured metric since we want to keep the metric config account-agnostic.
- Does not change functionality for users with only one Prometheus account.

![29cf9382-dceb-4a87-b502-6c17faf7303e](https://user-images.githubusercontent.com/15936279/61891292-55ab4480-aed7-11e9-8a6d-235d748d6ae8.gif)
