### PR TITLE
fix(datadog):  Add aggregator selector to Datadog

### DIFF
--- a/src/kayenta/metricStore/datadog/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/datadog/metricConfigurer.tsx
@@ -4,6 +4,7 @@ import { Action } from 'redux';
 import { connect } from 'react-redux';
 import { Option } from 'react-select';
 import FormRow from 'kayenta/layout/formRow';
+import RadioChoice from 'kayenta/layout/radioChoice';
 import { ICanaryState } from 'kayenta/reducers';
 import * as Creators from 'kayenta/actions/creators';
 import { ICanaryMetricConfig } from 'kayenta/domain';
@@ -14,24 +15,59 @@ interface IDatadogMetricConfigurerStateProps {
 }
 
 interface IDatadogMetricConfigurerDispatchProps {
-  changeMetricName: (name: string) => void;
+  changeMetricName: (agg: string, name: string) => void;
 }
 
 type DatadogMetricConfigurerProps = IDatadogMetricConfigurerStateProps & IDatadogMetricConfigurerDispatchProps;
 
-export const queryFinder = (metric: ICanaryMetricConfig) => get(metric, 'query.metricName', '');
+export const queryFinder = (metric: ICanaryMetricConfig) => get(metric, 'query.metricName', ':');
+
+export const nameFinder = (metric: ICanaryMetricConfig) => queryFinder(metric).split(':', 2)[1];
+export const aggFinder = (metric: ICanaryMetricConfig) => queryFinder(metric).split(':', 2)[0];
 
 /*
 * Component for configuring a Datadog metric.
 * */
 function DatadogMetricConfigurer({ changeMetricName, editingMetric }: DatadogMetricConfigurerProps) {
   return (
-    <FormRow label="Datadog Metric">
-      <DatadogMetricTypeSelector
-        value={queryFinder(editingMetric)}
-        onChange={(option: Option<string>) => changeMetricName(get(option, 'value'))}
-      />
-    </FormRow>
+    <>
+      <FormRow label="Datadog Metric">
+        <DatadogMetricTypeSelector
+          value={nameFinder(editingMetric)}
+          onChange={(option: Option<string>) => changeMetricName(aggFinder(editingMetric), get(option, 'value'))}
+        />
+      </FormRow>
+      <FormRow label="Metric Aggregation">
+        <RadioChoice
+          value="avg"
+          label="Average"
+          name="aggregator"
+          current={aggFinder(editingMetric)}
+          action={() => changeMetricName('avg', nameFinder(editingMetric))}
+        />
+        <RadioChoice
+          value="sum"
+          label="Sum"
+          name="aggregator"
+          current={aggFinder(editingMetric)}
+          action={() => changeMetricName('sum', nameFinder(editingMetric))}
+        />
+        <RadioChoice
+          value="max"
+          label="Max"
+          name="aggregator"
+          current={aggFinder(editingMetric)}
+          action={() => changeMetricName('max', nameFinder(editingMetric))}
+        />
+        <RadioChoice
+          value="min"
+          label="Min"
+          name="aggregator"
+          current={aggFinder(editingMetric)}
+          action={() => changeMetricName('min', nameFinder(editingMetric))}
+        />
+      </FormRow>
+    </>
   );
 }
 
@@ -43,7 +79,8 @@ function mapStateToProps(state: ICanaryState): IDatadogMetricConfigurerStateProp
 
 function mapDispatchToProps(dispatch: (action: Action & any) => void): IDatadogMetricConfigurerDispatchProps {
   return {
-    changeMetricName: (metricName: string): void => {
+    changeMetricName: (agg: string, name: string): void => {
+      var metricName = agg + ':' + name;
       dispatch(Creators.updateDatadogMetricName({ metricName }));
     },
   };

--- a/src/kayenta/metricStore/datadog/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/datadog/metricConfigurer.tsx
@@ -80,7 +80,7 @@ function mapStateToProps(state: ICanaryState): IDatadogMetricConfigurerStateProp
 function mapDispatchToProps(dispatch: (action: Action & any) => void): IDatadogMetricConfigurerDispatchProps {
   return {
     changeMetricName: (agg: string, name: string): void => {
-      var metricName = agg + ':' + name;
+      const metricName = agg + ':' + name;
       dispatch(Creators.updateDatadogMetricName({ metricName }));
     },
   };


### PR DESCRIPTION
The typeahead/dropdown selector for Datadog metrics prevented the proper
prefixing of the aggregator function (avg, max, min, sum).  This adds
those as radio button options and assembles the metric name properly, so
the backend Kayenta implementation doesn't have to change.