### PR TITLE
feat(datadog): Support metric types and tags

### DIFF
--- a/src/kayenta/domain/ICanaryConfig.ts
+++ b/src/kayenta/domain/ICanaryConfig.ts
@@ -33,6 +33,8 @@ export interface ICanaryMetricSetQueryConfig {
   serviceType: string;
   customInlineTemplate?: string;
   customFilterTemplate?: string;
+  metricType?: string;
+  tags?: [string];
 }
 
 export interface IGroupWeights {


### PR DESCRIPTION
feat(datadog): Support metric types and tags

This pull requests adds minimum Deck UI compatibility with a proposed Kayenta patch: https://github.com/spinnaker/kayenta/pull/608

It is compatible with existing configurations and only adds two optional fields. These fields are leveraged by DatadogCanaryMetricSetQueryConfigs.

Note: I don't like that we are filing the `ICanaryConfig` interface with metric provider specific properties such as Datadog's `metricType` and Prometheus's `customInlineTemplate`, but I think we can continue until we modularize some of these interfaces.

---

We have deployed this change on Airbnb's implementation of deck-kayenta for one week and have found no problems. 