### PR TITLE
fix(newrelic): Make New Relic canary graphs work

### DIFF
--- a/src/kayenta/metricStore/index.ts
+++ b/src/kayenta/metricStore/index.ts
@@ -4,3 +4,4 @@ import './prometheus';
 import './signalfx';
 import './stackdriver';
 import './graphite';
+import './newrelic';

--- a/src/kayenta/metricStore/newrelic/index.ts
+++ b/src/kayenta/metricStore/newrelic/index.ts
@@ -1,0 +1,8 @@
+import metricStoreConfigStore from '../metricStoreConfig.service';
+import { queryFinder } from './metricConfigurer';
+
+metricStoreConfigStore.register({
+  name: 'newrelic',
+  metricConfigurer: null,
+  queryFinder,
+});

--- a/src/kayenta/metricStore/newrelic/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/newrelic/metricConfigurer.tsx
@@ -1,0 +1,18 @@
+/*
+// These will be used when we build out the Canary Config UI, so keeping them
+// here for now.
+
+import * as React from 'react';
+import { Action } from 'redux';
+import { connect } from 'react-redux';
+import { Option } from 'react-select';
+import FormRow from 'kayenta/layout/formRow';
+import RadioChoice from 'kayenta/layout/radioChoice';
+import { ICanaryState } from 'kayenta/reducers';
+import * as Creators from 'kayenta/actions/creators';
+*/
+import { get } from 'lodash';
+import { ICanaryMetricConfig } from 'kayenta/domain';
+
+export const queryFinder = (metric: ICanaryMetricConfig) => get(metric, 'query.metricName', '');
+


### PR DESCRIPTION
This is a small patch to make sure the graph view for New Relic canaries
doesn't crash.  This will soon be extended to properly handle UI
configuration of New Relic canary configs, but wanted to get this in
first, since crashes are bad.

Ref:  https://github.com/spinnaker/spinnaker/issues/4389

Kudos to @imakewebthings for pointing out the underlying cause.