### PR TITLE
fix(newrelic):  Add UI to edit select query

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -128,6 +128,7 @@ export const updateStackdriverMetricResourceField = createAction<{
   value: IStackdriverCanaryMetricSetQueryConfig[keyof IStackdriverCanaryMetricSetQueryConfig];
 }>(Actions.UPDATE_STACKDRIVER_METRIC_QUERY_FIELD);
 export const updateDatadogMetricName = createAction<{ metricName: string }>(Actions.UPDATE_DATADOG_METRIC_NAME);
+export const updateNewRelicSelect = createAction<{ select: string }>(Actions.UPDATE_NEWRELIC_SELECT);
 export const loadExecutionsRequest = createAction(Actions.LOAD_EXECUTIONS_REQUEST);
 export const loadExecutionsFailure = createAction<{ error: Error }>(Actions.LOAD_EXECUTIONS_FAILURE);
 export const loadExecutionsSuccess = createAction<{ executions: ICanaryExecutionStatusResult[] }>(

--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -46,6 +46,7 @@ export const SET_CONFIG_JSON_MODAL_TAB_STATE = 'set_config_json_modal_tab_state'
 export const UPDATE_ATLAS_QUERY = 'update_atlas_query';
 export const UPDATE_DATADOG_METRIC_TYPE = 'update_datadog_metric_type';
 export const UPDATE_DATADOG_METRIC_NAME = 'update_datadog_metric_name';
+export const UPDATE_NEWRELIC_SELECT = 'update_newrelic_select';
 export const COPY_SELECTED_CONFIG = 'copy_selected_config';
 export const CREATE_NEW_CONFIG = 'create_new_config';
 export const EDIT_GROUP_BEGIN = 'edit_group_name_begin';

--- a/src/kayenta/metricStore/newrelic/domain/INewRelicMetricDescriptor.ts
+++ b/src/kayenta/metricStore/newrelic/domain/INewRelicMetricDescriptor.ts
@@ -1,0 +1,5 @@
+import { IMetricsServiceMetadata } from 'kayenta/domain/IMetricsServiceMetadata';
+
+export interface INewRelicMetricDescriptor extends IMetricsServiceMetadata {
+  name: string;
+}

--- a/src/kayenta/metricStore/newrelic/index.ts
+++ b/src/kayenta/metricStore/newrelic/index.ts
@@ -1,8 +1,8 @@
 import metricStoreConfigStore from '../metricStoreConfig.service';
-import { queryFinder } from './metricConfigurer';
+import NewRelicMetricConfigurer, { queryFinder } from './metricConfigurer';
 
 metricStoreConfigStore.register({
   name: 'newrelic',
-  metricConfigurer: null,
+  metricConfigurer: NewRelicMetricConfigurer,
   queryFinder,
 });

--- a/src/kayenta/metricStore/newrelic/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/newrelic/metricConfigurer.tsx
@@ -1,18 +1,61 @@
-/*
-// These will be used when we build out the Canary Config UI, so keeping them
-// here for now.
-
 import * as React from 'react';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
-import { Option } from 'react-select';
 import FormRow from 'kayenta/layout/formRow';
-import RadioChoice from 'kayenta/layout/radioChoice';
+import { DisableableInput, DISABLE_EDIT_CONFIG } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import * as Creators from 'kayenta/actions/creators';
-*/
 import { get } from 'lodash';
 import { ICanaryMetricConfig } from 'kayenta/domain';
 
-export const queryFinder = (metric: ICanaryMetricConfig) => get(metric, 'query.metricName', '');
+interface INewRelicMetricConfigurerStateProps {
+  editingMetric: ICanaryMetricConfig;
+}
 
+interface INewRelicMetricConfigurerDispatchProps {
+  changeSelect: (event: any) => void;
+}
+
+type INewRelicConfigurerProps = INewRelicMetricConfigurerStateProps & INewRelicMetricConfigurerDispatchProps;
+
+export const queryFinder = (metric: ICanaryMetricConfig) => get(metric, 'query.select', '');
+
+/*
+ * Component for configuring a New Relic metric
+ */
+function NewRelicMetricConfigurer({ changeSelect, editingMetric }: NewRelicMetricConfigurerProps) {
+  return (
+    <>
+      <FormRow label="NRQL Select">
+        <DisableableInput
+          type="text"
+          value={queryFinder(editingMetric)}
+          onChange={changeSelect}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        />
+        <span className="body-small color-text-caption" style={{ marginTop: '5px' }}>
+          Enter the NRQL query only up to, but not including, the WHERE clause
+        </span>
+      </FormRow>
+    </>
+  );
+}
+
+function mapStateToProps(state: ICanaryState): INewRelicMetricConfigurerStateProps {
+  return {
+    editingMetric: state.selectedConfig.editingMetric,
+  };
+}
+
+function mapDispatchToProps(dispatch: (action: Action & any) => void): INewRelicMetricConfigurerDispatchProps {
+  return {
+    changeSelect: (event: any) => {
+      dispatch(Creators.updateNewRelicSelect({ select: event.target.value }));
+    },
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(NewRelicMetricConfigurer);

--- a/src/kayenta/reducers/data.ts
+++ b/src/kayenta/reducers/data.ts
@@ -128,6 +128,9 @@ const metricsServiceMetadata = combineReducers<IMetricsServiceMetadataState>({
         // no longer apply to the filter.
         return action.payload.metricType ? state : [];
       },
+      [Actions.UPDATE_NEWRELIC_SELECT]: (state: IMetricsServiceMetadata, action: Action & any) => {
+        return action.payload.select ? state : [];
+      },
       [Actions.UPDATE_GRAPHITE_METRIC_NAME]: (state: IMetricsServiceMetadata, action: Action & any) => {
         return action.payload.metricName ? state : [];
       },

--- a/src/kayenta/reducers/selectedConfig.ts
+++ b/src/kayenta/reducers/selectedConfig.ts
@@ -169,6 +169,10 @@ const editingMetric = handleActions(
       ...state,
       query: { ...state.query, metricName: action.payload.metricName },
     }),
+    [Actions.UPDATE_NEWRELIC_SELECT]: (state: ICanaryMetricConfig, action: Action & any) => ({
+      ...state,
+      query: { ...state.query, select: action.payload.select },
+    }),
     [Actions.SELECT_TEMPLATE]: (state: ICanaryMetricConfig, action: Action & any) => ({
       ...state,
       query: { ...state.query, customFilterTemplate: action.payload.name },


### PR DESCRIPTION
This adds the simplest of UI to let users edit the New Relic select query in the canary config without having to edit the JSON directly.