### PR TITLE
feat(configs): hide scopeName field in metric config

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -100,7 +100,6 @@ export const updatePrometheusMetricQueryField = createAction<{
 export const updateStackdriverGroupBy = createAction<IUpdateListPayload>(Actions.UPDATE_STACKDRIVER_GROUP_BY_FIELDS);
 export const deleteTemplate = createAction<{ name: string }>(Actions.DELETE_TEMPLATE);
 export const selectTemplate = createAction<{ name: string }>(Actions.SELECT_TEMPLATE);
-export const updateMetricScopeName = createAction<{ scopeName: string }>(Actions.UPDATE_METRIC_SCOPE_NAME);
 export const changeMetricGroup = createAction<{ id: string }>(Actions.CHANGE_METRIC_GROUP);
 export const loadMetricsServiceMetadataRequest = createAction<{ filter: string; metricsAccountName: string }>(
   Actions.LOAD_METRICS_SERVICE_METADATA_REQUEST,

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -31,7 +31,6 @@ interface IEditMetricModalDispatchProps {
   updateCriticality: (event: any) => void;
   confirm: () => void;
   cancel: () => void;
-  updateScopeName: (event: any) => void;
 }
 
 interface IEditMetricModalStateProps {
@@ -95,7 +94,6 @@ function EditMetricModal({
   updateDirection,
   updateNanStrategy,
   updateCriticality,
-  updateScopeName,
   useInlineTemplateEditor,
   disableEdit,
   validationErrors,
@@ -211,14 +209,6 @@ function EditMetricModal({
               action={updateNanStrategy}
             />
           </FormRow>
-          <FormRow label="Scope Name" error={get(validationErrors, 'scopeName.message', null)}>
-            <DisableableInput
-              type="text"
-              value={metric.scopeName}
-              onChange={updateScopeName}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
-            />
-          </FormRow>
           <EffectSizeSummary effectSizes={effectSize} />
           <MetricConfigurerDelegator />
           {templatesEnabled && !useInlineTemplateEditor && <FilterTemplateSelector />}
@@ -268,7 +258,6 @@ function mapDispatchToProps(dispatch: any): IEditMetricModalDispatchProps {
     updateCriticality: ({ target }: React.ChangeEvent<HTMLInputElement>) => {
       dispatch(Creators.updateMetricCriticality({ id: target.dataset.id, critical: Boolean(target.checked) }));
     },
-    updateScopeName: (event: any) => dispatch(Creators.updateMetricScopeName({ scopeName: event.target.value })),
   };
 }
 

--- a/src/kayenta/edit/editMetricValidation.spec.ts
+++ b/src/kayenta/edit/editMetricValidation.spec.ts
@@ -1,9 +1,4 @@
-import {
-  ICanaryMetricValidationErrors,
-  validateMetric,
-  validateMetricName,
-  validateMetricScopeName,
-} from './editMetricValidation';
+import { ICanaryMetricValidationErrors, validateMetric, validateMetricName } from './editMetricValidation';
 import { ICanaryMetricConfig } from '../domain';
 
 describe('Canary metric validation', () => {
@@ -36,28 +31,14 @@ describe('Canary metric validation', () => {
     });
   });
 
-  describe('validateMetricScopeName', () => {
-    it('Does not update errors when metric scope name is valid', () => {
-      expect(validateMetricScopeName(errors, editingMetric).scopeName).toBeNull();
-    });
-    it('Updates errors appropriately when metric scope name is empty', () => {
-      editingMetric.scopeName = '';
-      expect(validateMetricScopeName(errors, editingMetric).scopeName).toEqual({
-        message: 'Scope name is required',
-      });
-    });
-  });
-
   describe('validateMetric', () => {
     it('Does not update errors when all fields are valid', () => {
       expect(validateMetric(editingMetric, metricList)).toEqual(errors);
     });
     it('Reduces validation of all fields into one object', () => {
       editingMetric.name = '';
-      editingMetric.scopeName = '';
       expect(validateMetric(editingMetric, metricList)).toEqual({
         name: { message: 'Name is required' },
-        scopeName: { message: 'Scope name is required' },
       });
     });
   });
@@ -66,7 +47,6 @@ describe('Canary metric validation', () => {
 function createErrors(): ICanaryMetricValidationErrors {
   return {
     name: null,
-    scopeName: null,
   };
 }
 

--- a/src/kayenta/edit/editMetricValidation.ts
+++ b/src/kayenta/edit/editMetricValidation.ts
@@ -35,31 +35,15 @@ export function validateMetricName(
   return nextErrors;
 }
 
-export function validateMetricScopeName(
-  errors: ICanaryMetricValidationErrors,
-  editingMetric: ICanaryMetricConfig,
-): ICanaryMetricValidationErrors {
-  const nextErrors = { ...errors };
-
-  const editingMetricScopeName = get(editingMetric, 'scopeName', '');
-
-  if (!editingMetricScopeName) {
-    nextErrors.scopeName = { message: 'Scope name is required' };
-  }
-
-  return nextErrors;
-}
-
 export function validateMetric(
   editingMetric: ICanaryMetricConfig,
   metricList: ICanaryMetricConfig[],
 ): ICanaryMetricValidationErrors {
   const errors: ICanaryMetricValidationErrors = {
     name: null,
-    scopeName: null,
   };
 
-  return [validateMetricName, validateMetricScopeName].reduce(
+  return [validateMetricName].reduce(
     (reducedErrors, validator) => validator(reducedErrors, editingMetric, metricList),
     errors,
   );

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -135,7 +135,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
               serviceType: event.target.dataset.metricStore,
             },
             groups: group ? [group] : [],
-            scopeName: 'default',
+            scopeName: 'default', // scopeName always defaults to `default` and is not configurable from the UI
             isNew: true,
           },
         }),


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4877

Per discussion on this [PR](https://github.com/spinnaker/deck-kayenta/pull/457), we should default the scope name to default and hide the field in the UI.