### PR TITLE
feat(report/graph): clean up chart code-debt & update svg style

### DIFF
--- a/src/kayenta/report/detail/graph/semiotic/boxplot.less
+++ b/src/kayenta/report/detail/graph/semiotic/boxplot.less
@@ -38,5 +38,8 @@
         opacity: 0.3;
       }
     }
+    g.pieces {
+      shape-rendering: geometricprecision;
+    }
   }
 }

--- a/src/kayenta/report/detail/graph/semiotic/differenceArea.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/differenceArea.tsx
@@ -29,7 +29,7 @@ interface IInterimDataSet {
 }
 
 interface IDifferenceAreaProps extends ISemioticChartProps {
-  millisBaselineSet: number[];
+  millisSetBaseline: number[];
 }
 
 /*
@@ -40,13 +40,14 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
   private margin: IMargin = {
     left: 60,
     right: 20,
+    top: 8,
   };
 
   private chartHeight = 40; // chart height not including axes height
   private headerHeight = 17;
 
   private getChartData = () => {
-    const { metricSetPair, millisBaselineSet } = this.props;
+    const { metricSetPair } = this.props;
     const {
       values: { experiment, control },
       scopes,
@@ -66,9 +67,7 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
           canary: e,
           baseline: c,
         };
-      })
-      // filter based on the timestamps of the line chart
-      .filter((ds: IInterimDataSet) => millisBaselineSet.includes(ds.timestamp));
+      });
 
     const baselineReferenceDataPoints: IDataPoint[] = intDataSet.map((ds: IInterimDataSet) => ({
       timestampMillis: ds.timestamp,
@@ -96,9 +95,9 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
     };
   };
 
-  private getSecondaryAxis = (millisOffset: number, millisBaselineSet: number[]) => {
+  private getSecondaryAxis = (millisOffset: number, millisSetBaseline: number[]) => {
     const { parentWidth } = this.props;
-    const millisSetCanary = millisBaselineSet.map((ms: number) => ms + millisOffset);
+    const millisSetCanary = millisSetBaseline.map((ms: number) => ms + millisOffset);
 
     return (
       <SecondaryTSXAxis
@@ -120,7 +119,7 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
   };
 
   public render() {
-    const { metricSetPair, parentWidth, millisBaselineSet } = this.props;
+    const { metricSetPair, parentWidth, millisSetBaseline } = this.props;
 
     /*
      * Generate the data needed for the graph components
@@ -137,7 +136,7 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
     const computedConfig = {
       lines: chartData,
       size: [parentWidth, this.chartHeight + xAxisTotalHeight],
-      margin: { ...this.margin, top: 0, bottom: xAxisTotalHeight },
+      margin: { ...this.margin, bottom: xAxisTotalHeight },
       lineType: {
         type: 'area',
         interpolator: curveStepAfter,
@@ -165,13 +164,13 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
         },
         {
           orient: 'bottom',
-          tickValues: utils.calculateDateTimeTicks(millisBaselineSet),
+          tickValues: utils.calculateDateTimeTicks(millisSetBaseline),
           tickFormat: (d: number) => <CustomAxisTickLabel millis={d} />,
           label: shouldUseSecondaryXAxis ? 'Baseline' : undefined,
           className: shouldUseSecondaryXAxis ? 'baseline-dual-axis' : '',
         },
       ],
-      xExtent: [millisBaselineSet[0], millisBaselineSet[millisBaselineSet.length - 1]],
+      xExtent: [millisSetBaseline[0], millisSetBaseline[millisSetBaseline.length - 1]],
     };
 
     return (
@@ -180,7 +179,7 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
           Canary Value Differences from Baseline
         </div>
         <XYFrame {...computedConfig} />
-        {shouldUseSecondaryXAxis ? this.getSecondaryAxis(millisOffset, millisBaselineSet) : null}
+        {shouldUseSecondaryXAxis ? this.getSecondaryAxis(millisOffset, millisSetBaseline) : null}
       </div>
     );
   }

--- a/src/kayenta/report/detail/graph/semiotic/semioticGraph.less
+++ b/src/kayenta/report/detail/graph/semiotic/semioticGraph.less
@@ -3,6 +3,7 @@
 .semiotic-graph {
   margin-bottom: 8px;
   .visualization-layer {
+    shape-rendering: crispedges;
     .background-graphics {
       .axis-tick-lines {
         stroke: @grid-color;

--- a/src/kayenta/report/detail/graph/semiotic/timeSeries.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/timeSeries.tsx
@@ -6,7 +6,6 @@ import { SETTINGS } from '@spinnaker/core';
 const { defaultTimeZone } = SETTINGS;
 import { curveStepAfter } from 'd3-shape';
 import * as classNames from 'classnames';
-// import { chain } from 'lodash';
 
 import { IMetricSetPair } from 'kayenta/domain/IMetricSetPair';
 import * as utils from './utils';
@@ -180,9 +179,8 @@ export default class TimeSeries extends React.Component<ISemioticChartProps, ITi
       ? dataSets[0].coordinatesUnfiltered
       : dataSets[0].coordinatesUnfiltered.filter((c: IDataPoint) => {
           return (
-            !userBrushExtent ||
-            (c.timestampMillisNormalizedMinimap >= userBrushExtent[0].valueOf() &&
-              c.timestampMillisNormalizedMinimap <= userBrushExtent[1].valueOf())
+            c.timestampMillisNormalizedMinimap >= userBrushExtent[0].valueOf() &&
+            c.timestampMillisNormalizedMinimap <= userBrushExtent[1].valueOf()
           );
         })
     ).map((c: IDataPoint) => c.timestampMillisNormalizedMain);

--- a/src/kayenta/report/detail/graph/semiotic/utils.ts
+++ b/src/kayenta/report/detail/graph/semiotic/utils.ts
@@ -51,7 +51,7 @@ export const calculateDateTimeTicks = (millisSet: number[]) => {
   const minMillisShifted = minMillis + offsetMillis;
   const maxMillisShifted = maxMillis + offsetMillis;
   const scale = scaleUtc().domain([new Date(minMillisShifted), new Date(maxMillisShifted)]);
-  const ticks = scale.ticks(6).map((d: Date) => new Date(d.valueOf() - offsetMillis));
+  const ticks = scale.ticks(6).map((d: Date) => d.valueOf() - offsetMillis);
   return ticks;
 };
 


### PR DESCRIPTION
1. Changes on timeSeries.tsx:
- Rename a bunch of variables on timeSeries.tsx.
- Minimap xExtent bug is fixed in semiotic and we don't need a few interim objects as a workaround.
2. Change on differenceArea.tsx:
- Add top margin for the delta icon.
3. Others:
- Update css attribute for the svg line graphs. The lines should look more crisp now. 