### PR TITLE
feat(kayenta): Add svg name to dataSource

### DIFF
--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -80,7 +80,7 @@ module(CANARY_DATA_SOURCE, []).run([
       lazy: true,
       autoActivate: true,
       defaultData: [],
-      iconSvg: 'spMenuCanaryConfig'
+      iconName: 'spMenuCanaryConfig'
     });
 
     const loadCanaryExecutions = (application: Application) => {
@@ -122,7 +122,7 @@ module(CANARY_DATA_SOURCE, []).run([
       lazy: true,
       autoActivate: true,
       defaultData: [],
-      iconSvg: 'spMenuCanaryReport'
+      iconName: 'spMenuCanaryReport'
     });
   },
 ]);

--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -80,6 +80,7 @@ module(CANARY_DATA_SOURCE, []).run([
       lazy: true,
       autoActivate: true,
       defaultData: [],
+      iconSvg: 'spMenuCanaryConfig'
     });
 
     const loadCanaryExecutions = (application: Application) => {
@@ -121,6 +122,7 @@ module(CANARY_DATA_SOURCE, []).run([
       lazy: true,
       autoActivate: true,
       defaultData: [],
+      iconSvg: 'spMenuCanaryReport'
     });
   },
 ]);


### PR DESCRIPTION
Depends on https://github.com/spinnaker/deck/pull/8120 merge and then bumping @spinnaker/core. 

> Given the svg icon loader (#8056) and the upcoming Nav restructure, it is a good time to migrate the nav bar icons to svgs.

> In order to do this, the ApplicationDataSource type now has an iconSvg attribute. Once this change propagates to all data sources in deck and deck-kayenta, a follow-up PR will update the NavIcon component to utilize dataSource.iconSvg instead of the current dataSource.icon, which points to the font awesome icon.