### PR TITLE
feat(report/graph): Add a section for surfacing the report explanation/classification reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/spinnaker/deck-kayenta.png?branch=master)](https://travis-ci.org/spinnaker/deck-kayenta)
 
+## PR Process
+
+In order to commit to this repo, please fork the repository and submit Pull Requests from a fork rather than a branch. It requires additional permissions to push branches.
+
 ## Development
 
 Make sure that [node](http://nodejs.org/download/) and [yarn](https://yarnpkg.com/en/docs/install)
@@ -12,6 +16,7 @@ To develop this module, run it as a [Deck](https://github.com/spinnaker/deck) de
 ### yarn
 
 In the root of this repository and the main Deck repository, run
+
 ```bash
 yarn
 ```

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -5,6 +5,7 @@ import ReportScores from './reportScores';
 import MetricResults from './metricResults';
 
 import './detail.less';
+import ReportExplanation from './reportExplanation';
 
 /*
 * Layout for report detail view.
@@ -37,6 +38,7 @@ export default class DetailView extends React.Component<any, IDetailViewState> {
         </div>
         <div className="vertical flex-1">
           {isExpanded && <ReportHeader />}
+          <ReportExplanation />
           <ReportScores />
           <MetricResults />
         </div>

--- a/src/kayenta/report/detail/reportExplanation.less
+++ b/src/kayenta/report/detail/reportExplanation.less
@@ -1,0 +1,12 @@
+.report-explanation {
+  background-color: var(--color-warning);
+
+  height: 30px;
+  margin-bottom: 5px;
+  margin-left: 15px;
+  padding-top: 4px;
+
+  font-weight: bold;
+  font-size: 14px;
+  text-align: center;
+}

--- a/src/kayenta/report/detail/reportExplanation.tsx
+++ b/src/kayenta/report/detail/reportExplanation.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import { ICanaryState } from 'kayenta/reducers';
+import { ICanaryExecutionStatusResult } from 'kayenta/domain/ICanaryExecutionStatusResult';
+
+import './reportExplanation.less';
+
+interface IReportMetadata {
+  run: ICanaryExecutionStatusResult;
+}
+
+const getReason = (run: ICanaryExecutionStatusResult): string => {
+  if (run && run.result && run.result.judgeResult && run.result.judgeResult.score) {
+    return run.result.judgeResult.score.classificationReason;
+  }
+  return null;
+};
+
+const ReportExplanation = ({ run }: IReportMetadata) => {
+  const classificationReason = getReason(run);
+
+  if (classificationReason) {
+    return (
+      <section>
+        <div className="report-explanation">{classificationReason}</div>
+      </section>
+    );
+  }
+  return null;
+};
+
+const mapStateToProps = (state: ICanaryState) => ({
+  run: state.selectedRun.run,
+});
+
+export default connect(mapStateToProps)(ReportExplanation);


### PR DESCRIPTION
This change will surface the classification reason (if available) to help users understand why their canary may have failed outside of pure scoring.

![Screen Shot 2020-05-04 at 6 04 11 PM](https://user-images.githubusercontent.com/7786883/81034958-b9db3b80-8e4d-11ea-87ce-184d287ea563.png)
![Screen Shot 2020-05-04 at 6 04 04 PM](https://user-images.githubusercontent.com/7786883/81034959-ba73d200-8e4d-11ea-9447-aee32bc52621.png)

This does not change the appearance of success cases:

![Screen Shot 2020-05-04 at 6 04 21 PM](https://user-images.githubusercontent.com/7786883/81035002-eb540700-8e4d-11ea-82e8-97d55e327781.png)
