### PR TITLE
chore(deps): upgrade prettier, format files

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "luxon": "^1.11.3",
     "ngtemplate-loader": "^1.3.1",
     "node-libs-browser": "^2.0.0",
-    "prettier": "^1.14.3",
+    "prettier": "^2.0.5",
     "pretty-quick": "^1.7.0",
     "prop-types": "^15.6.1",
     "react-test-renderer": "16.8.6",

--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -92,7 +92,7 @@ module(CANARY_DATA_SOURCE, []).run([
       // TODO(dpeach): make the number of canary executions rendered configurable from the UI.
       const listExecutionsRequest = listCanaryExecutions(application.name, 20);
 
-      listExecutionsRequest.catch(error => {
+      listExecutionsRequest.catch((error) => {
         canaryStore.dispatch(Creators.loadExecutionsFailure({ error }));
       });
 

--- a/src/kayenta/canary.help.ts
+++ b/src/kayenta/canary.help.ts
@@ -116,4 +116,4 @@ const helpContents: { [key: string]: string } = {
   'stackdriver.perSeriesAligner': 'Use an algorithm to align individual time series.',
 };
 
-Object.keys(helpContents).forEach(key => HelpContentsRegistry.register(key, helpContents[key]));
+Object.keys(helpContents).forEach((key) => HelpContentsRegistry.register(key, helpContents[key]));

--- a/src/kayenta/canary.module.ts
+++ b/src/kayenta/canary.module.ts
@@ -11,7 +11,7 @@ import 'kayenta/report/detail/graph/semiotic';
 
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
-templates.keys().forEach(key => {
+templates.keys().forEach((key) => {
   templates(key);
 });
 

--- a/src/kayenta/components/loadStates.tsx
+++ b/src/kayenta/components/loadStates.tsx
@@ -9,9 +9,9 @@ export interface ILoadStatesProps {
 }
 
 /*
-* Builder for rendering load states. Defaults to standard spinner during
-* `Requesting` state.
-* */
+ * Builder for rendering load states. Defaults to standard spinner during
+ * `Requesting` state.
+ * */
 export default class LoadStatesBuilder {
   private requesting: JSX.Element;
   private fulfilled: JSX.Element;

--- a/src/kayenta/edit/changeMetricGroupModal.tsx
+++ b/src/kayenta/edit/changeMetricGroupModal.tsx
@@ -47,7 +47,7 @@ function ChangeMetricGroupModal({
             disabledStateKeys={[DISABLE_EDIT_CONFIG]}
           >
             <option value={''}>-- select group --</option>
-            {groups.map(g => (
+            {groups.map((g) => (
               <option key={g} value={g}>
                 {g}
               </option>
@@ -81,7 +81,7 @@ function mapStateToProps(
   // e.g., a [system, requests] -> [requests] move should be allowed, but
   // don't offer a [system] -> [system] move.
   return {
-    groups: state.selectedConfig.group.list.filter(g => metric.groups.length > 1 || !metric.groups.includes(g)),
+    groups: state.selectedConfig.group.list.filter((g) => metric.groups.length > 1 || !metric.groups.includes(g)),
     toGroup: state.selectedConfig.changeMetricGroup.toGroup,
   };
 }
@@ -103,7 +103,4 @@ function mapDispatchToProps(
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ChangeMetricGroupModal);
+export default connect(mapStateToProps, mapDispatchToProps)(ChangeMetricGroupModal);

--- a/src/kayenta/edit/configDetailLoader.tsx
+++ b/src/kayenta/edit/configDetailLoader.tsx
@@ -57,7 +57,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IConfigLo
   };
 }
 
-export default connect(
-  null,
-  mapDispatchToProps,
-)(ConfigDetailLoader);
+export default connect(null, mapDispatchToProps)(ConfigDetailLoader);

--- a/src/kayenta/edit/configJsonModal.tsx
+++ b/src/kayenta/edit/configJsonModal.tsx
@@ -75,14 +75,13 @@ function ConfigJsonModal({
             {tabState === ConfigJsonModalTabState.Edit && (
               <JsonEditor value={configJson} debounceChangePeriod={500} onChange={setConfigJson} readOnly={disabled} />
             )}
-            {tabState === ConfigJsonModalTabState.Diff &&
-              !deserializationError && (
-                <div className="modal-show-history">
-                  <div className="show-history">
-                    <DiffView diff={diff} />
-                  </div>
+            {tabState === ConfigJsonModalTabState.Diff && !deserializationError && (
+              <div className="modal-show-history">
+                <div className="show-history">
+                  <DiffView diff={diff} />
                 </div>
-              )}
+              </div>
+            )}
             {!!deserializationError && (
               <div className="horizontal row center">
                 <span className="error-message">Error: {deserializationError}</span>
@@ -136,7 +135,7 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IConfigJs
 function mapStateToProps(state: ICanaryState): IConfigJsonStateProps {
   const id: string = get(state, 'selectedConfig.config.id');
   const persistedConfig = JsonUtils.makeSortedStringFromObject(
-    omit(state.data.configs.find(c => c.id === id) || {}, 'id'),
+    omit(state.data.configs.find((c) => c.id === id) || {}, 'id'),
   );
 
   const configJson =
@@ -156,7 +155,4 @@ function mapStateToProps(state: ICanaryState): IConfigJsonStateProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ConfigJsonModal);
+export default connect(mapStateToProps, mapDispatchToProps)(ConfigJsonModal);

--- a/src/kayenta/edit/configList.tsx
+++ b/src/kayenta/edit/configList.tsx
@@ -24,7 +24,7 @@ function ConfigList({ configs, selectedConfigId, application }: IConfigListState
   return (
     <section className="config-list">
       <ul className="tabs-vertical list-unstyled " style={{ wordBreak: 'break-all' }}>
-        {configs.map(config => (
+        {configs.map((config) => (
           <li key={config.id} className={config.id === selectedConfigId ? 'selected' : ''}>
             <UISref to=".configDetail" params={{ id: config.id, new: false, copy: false }}>
               <a>

--- a/src/kayenta/edit/createConfigButton.tsx
+++ b/src/kayenta/edit/createConfigButton.tsx
@@ -9,8 +9,8 @@ interface ICreateConfigButtonStateProps {
 }
 
 /*
-* Button for creating a new canary config.
-*/
+ * Button for creating a new canary config.
+ */
 function CreateConfigButton({ disabled }: ICreateConfigButtonStateProps) {
   return (
     <UISref to=".configDetail" params={{ id: UUIDGenerator.generateUuid(), new: true }}>

--- a/src/kayenta/edit/deleteModal.tsx
+++ b/src/kayenta/edit/deleteModal.tsx
@@ -84,7 +84,4 @@ function mapStateToProps(state: ICanaryState): IDeleteModalStateProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DeleteConfigModal);
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteConfigModal);

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -110,7 +110,7 @@ function EditMetricModal({
     'canary',
     'effectSize',
   ]);
-  const isConfirmDisabled = !isTemplateValid || disableEdit || values(validationErrors).some(e => !isNull(e));
+  const isConfirmDisabled = !isTemplateValid || disableEdit || values(validationErrors).some((e) => !isNull(e));
 
   const metricGroup = metric.groups.length ? metric.groups[0] : groups[0];
   const templatesEnabled =
@@ -141,7 +141,7 @@ function EditMetricModal({
                 className="form-control input-sm"
                 disabledStateKeys={[DISABLE_EDIT_CONFIG]}
               >
-                {groups.map(g => (
+                {groups.map((g) => (
                   <option key={g} value={g}>
                     {g}
                   </option>
@@ -272,7 +272,4 @@ function mapStateToProps(state: ICanaryState): IEditMetricModalStateProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(EditMetricModal);
+export default connect(mapStateToProps, mapDispatchToProps)(EditMetricModal);

--- a/src/kayenta/edit/editMetricValidation.ts
+++ b/src/kayenta/edit/editMetricValidation.ts
@@ -27,7 +27,7 @@ export function validateMetricName(
     return nextErrors;
   }
 
-  const isNameUnique = metricList.every(m => m.name !== editingMetricName || m.id === editingMetric.id);
+  const isNameUnique = metricList.every((m) => m.name !== editingMetricName || m.id === editingMetric.id);
   if (!isNameUnique) {
     nextErrors.name = { message: `Metric '${editingMetricName}' already exists` };
   }

--- a/src/kayenta/edit/filterTemplateSelector.spec.tsx
+++ b/src/kayenta/edit/filterTemplateSelector.spec.tsx
@@ -39,10 +39,7 @@ describe('<FilterTemplateSelector />', () => {
   });
   it('builds options from filter template map', () => {
     const component = buildComponent(defaultProps);
-    const allProps: any = component
-      .find(Select)
-      .first()
-      .props();
+    const allProps: any = component.find(Select).first().props();
 
     expect(allProps.options.map((o: Option) => o.value)).toEqual([
       'my-filter-template',
@@ -90,12 +87,7 @@ describe('<FilterTemplateSelector />', () => {
         },
       },
     });
-    expect(
-      component
-        .find(ValidationMessage)
-        .first()
-        .props().message,
-    ).toEqual('Template name is required');
+    expect(component.find(ValidationMessage).first().props().message).toEqual('Template name is required');
   });
 
   it('renders input and textarea when editing template', () => {

--- a/src/kayenta/edit/filterTemplateSelector.tsx
+++ b/src/kayenta/edit/filterTemplateSelector.tsx
@@ -44,7 +44,7 @@ export type IFilterTemplateSelectorProps = IFilterTemplateSelectorStateProps & I
 
 export class FilterTemplateSelector extends React.Component<IFilterTemplateSelectorProps> {
   private getOptions = (): Option[] => {
-    const templateOptions = Object.keys(this.props.templates).map(t => ({
+    const templateOptions = Object.keys(this.props.templates).map((t) => ({
       value: t,
       label: t,
       requestingNew: false,
@@ -61,12 +61,12 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
       <span className="filter-template-option">
         <span>{option.label}</span>
         <span>
-          <button className="link" onMouseDown={e => this.props.deleteTemplate(e, option.value)}>
+          <button className="link" onMouseDown={(e) => this.props.deleteTemplate(e, option.value)}>
             Delete
           </button>
           <button
             className="link"
-            onMouseDown={e => this.props.editTemplateBegin(e, option.value, this.props.templates[option.value])}
+            onMouseDown={(e) => this.props.editTemplateBegin(e, option.value, this.props.templates[option.value])}
           >
             Edit
           </button>
@@ -130,7 +130,7 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
                 </button>
                 <button
                   className="link"
-                  disabled={[validation.errors.templateName, validation.errors.templateValue].some(e => e != null)}
+                  disabled={[validation.errors.templateName, validation.errors.templateValue].some((e) => e != null)}
                   onClick={editTemplateConfirm}
                 >
                   Save
@@ -139,12 +139,11 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
             </FormRow>
           </>
         )}
-        {!isEditing &&
-          selectedTemplateName && (
-            <FormRow>
-              <pre className="template-editor-value-formatted">{templates[selectedTemplateName]}</pre>
-            </FormRow>
-          )}
+        {!isEditing && selectedTemplateName && (
+          <FormRow>
+            <pre className="template-editor-value-formatted">{templates[selectedTemplateName]}</pre>
+          </FormRow>
+        )}
       </>
     );
   }
@@ -188,7 +187,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>): IFilterTemplateSe
   },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(FilterTemplateSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(FilterTemplateSelector);

--- a/src/kayenta/edit/filterTemplatesValidation.ts
+++ b/src/kayenta/edit/filterTemplatesValidation.ts
@@ -38,7 +38,7 @@ export function validateTemplateName(
 
   const isNameEdited = editingTemplate && editingTemplate.editedName !== editingTemplate.name;
   const savedTemplateNames = Object.keys(configTemplates || {});
-  const isNameDuplicate = isNameEdited && savedTemplateNames.some(name => editingTemplate.editedName === name);
+  const isNameDuplicate = isNameEdited && savedTemplateNames.some((name) => editingTemplate.editedName === name);
   if (isNameDuplicate) {
     validation.errors.templateName = {
       message: `Filter template named '${editingTemplate.editedName}' already exists`,
@@ -73,12 +73,12 @@ export function validateTemplateInUseWarning(
   const otherMetricsUsingTemplate =
     editingMetric != null &&
     filterTemplate != null &&
-    metricList.filter(m => m.name !== editingMetric.name && filterTemplate === get(m, 'query.customFilterTemplate'));
+    metricList.filter((m) => m.name !== editingMetric.name && filterTemplate === get(m, 'query.customFilterTemplate'));
 
   if (!isEmpty(otherMetricsUsingTemplate)) {
     validation.warnings.template = {
       message: `Warning: editing or deleting this template will affect the following metrics: ${otherMetricsUsingTemplate
-        .map(m => m.name)
+        .map((m) => m.name)
         .join(', ')}`,
     };
   }

--- a/src/kayenta/edit/groupName.tsx
+++ b/src/kayenta/edit/groupName.tsx
@@ -75,7 +75,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IGroupNam
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GroupName);
+export default connect(mapStateToProps, mapDispatchToProps)(GroupName);

--- a/src/kayenta/edit/groupTabs.tsx
+++ b/src/kayenta/edit/groupTabs.tsx
@@ -41,15 +41,13 @@ function GroupTabs({
     return (
       <Tab selected={selected}>
         <GroupName group={group} editing={selected && editing} onClick={selectGroup} defaultGroup={ALL} />
-        {selected &&
-          editable &&
-          !editing && (
-            <i
-              data-group={group}
-              onClick={disableConfigEdit ? noop : editGroupBegin}
-              className={classNames('fas', 'fa-pencil-alt', { disabled: disableConfigEdit })}
-            />
-          )}
+        {selected && editable && !editing && (
+          <i
+            data-group={group}
+            onClick={disableConfigEdit ? noop : editGroupBegin}
+            className={classNames('fas', 'fa-pencil-alt', { disabled: disableConfigEdit })}
+          />
+        )}
       </Tab>
     );
   };
@@ -57,7 +55,7 @@ function GroupTabs({
     <section className="group-tabs">
       <Tabs style={{ marginBottom: '0' }}>
         <GroupTab group="" />
-        {groupList.map(group => (
+        {groupList.map((group) => (
           <GroupTab key={group} group={group} editable={true} />
         ))}
         <DisableableButton className="passive float-right" onClick={addGroup} disabledStateKeys={[DISABLE_EDIT_CONFIG]}>
@@ -95,7 +93,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IGroupTab
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GroupTabs);
+export default connect(mapStateToProps, mapDispatchToProps)(GroupTabs);

--- a/src/kayenta/edit/groupWeight.tsx
+++ b/src/kayenta/edit/groupWeight.tsx
@@ -23,8 +23,8 @@ interface IGroupWeightDispatchProps {
 }
 
 /*
-* Component for configuring a group weight.
-* */
+ * Component for configuring a group weight.
+ * */
 function GroupWeight({
   group,
   config,
@@ -75,7 +75,4 @@ function mapDispatchToProps(
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GroupWeight);
+export default connect(mapStateToProps, mapDispatchToProps)(GroupWeight);

--- a/src/kayenta/edit/groupWeights.tsx
+++ b/src/kayenta/edit/groupWeights.tsx
@@ -11,14 +11,14 @@ interface IGroupWeightsStateProps {
 }
 
 /*
-* Component for rendering list of group weight configurers.
-*/
+ * Component for rendering list of group weight configurers.
+ */
 function GroupWeights({ groups }: IGroupWeightsStateProps) {
   const hasGroups = groups.length > 0;
   return (
     <section>
       {hasGroups ? (
-        groups.map(group => <GroupWeight key={group} group={group} />)
+        groups.map((group) => <GroupWeight key={group} group={group} />)
       ) : (
         <p key="no-groups">You have not configured any grouped metrics.</p>
       )}
@@ -29,7 +29,7 @@ function GroupWeights({ groups }: IGroupWeightsStateProps) {
 function mapStateToProps(state: ICanaryState): IGroupWeightsStateProps {
   const config = mapStateToConfig(state);
   const metrics = config ? config.metrics : [];
-  const groups = uniq(flatMap(metrics, metric => metric.groups || []));
+  const groups = uniq(flatMap(metrics, (metric) => metric.groups || []));
   return {
     groups,
   };

--- a/src/kayenta/edit/inlineTemplateEditor.spec.tsx
+++ b/src/kayenta/edit/inlineTemplateEditor.spec.tsx
@@ -23,12 +23,7 @@ describe('<InlineTemplateEditor />', () => {
       transformValueForSave: identity,
       editTemplateValue: noop,
     });
-    expect(
-      component
-        .find(DisableableTextarea)
-        .first()
-        .props().value,
-    ).toEqual('metadata.user_labels."app"="${scope}"');
+    expect(component.find(DisableableTextarea).first().props().value).toEqual('metadata.user_labels."app"="${scope}"');
   });
   it('renders an error for empty input', () => {
     let component = buildComponent({

--- a/src/kayenta/edit/inlineTemplateEditor.tsx
+++ b/src/kayenta/edit/inlineTemplateEditor.tsx
@@ -56,7 +56,4 @@ function mapDispatchToProps(dispatch: any): IInlineTemplateEditorDispatchProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(InlineTemplateEditor);
+export default connect(mapStateToProps, mapDispatchToProps)(InlineTemplateEditor);

--- a/src/kayenta/edit/judgeSelect.tsx
+++ b/src/kayenta/edit/judgeSelect.tsx
@@ -64,7 +64,7 @@ function JudgeSelect({
 
 function mapStateToProps(state: ICanaryState): IJudgeSelectStateProps {
   return {
-    judgeOptions: (state.data.judges || []).map(judge => ({ value: judge.name, label: judge.name })),
+    judgeOptions: (state.data.judges || []).map((judge) => ({ value: judge.name, label: judge.name })),
     selectedJudge: state.selectedConfig.judge.judgeConfig.name,
     renderState: state.selectedConfig.judge.renderState,
   };
@@ -78,7 +78,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IJudgeSel
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(JudgeSelect);
+export default connect(mapStateToProps, mapDispatchToProps)(JudgeSelect);

--- a/src/kayenta/edit/metricConfigurerDelegator.tsx
+++ b/src/kayenta/edit/metricConfigurerDelegator.tsx
@@ -9,8 +9,8 @@ interface IMetricConfigurerDelegatorStateProps {
 }
 
 /*
-* Should find and render the appropriate metric configurer for a given metric store.
-* */
+ * Should find and render the appropriate metric configurer for a given metric store.
+ * */
 function MetricConfigurerDelegator({ editingMetric }: IMetricConfigurerDelegatorStateProps) {
   const config = metricStoreConfigService.getDelegate(editingMetric.query.type);
   if (config && config.metricConfigurer) {

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -49,15 +49,15 @@ function MetricList({
   const columns: Array<ITableColumn<ICanaryMetricConfig>> = [
     {
       label: 'Metric Name',
-      getContent: metric => <span>{metric.name || '(new)'}</span>,
+      getContent: (metric) => <span>{metric.name || '(new)'}</span>,
     },
     {
       label: 'Groups',
-      getContent: metric => <span>{metric.groups.join(', ')}</span>,
+      getContent: (metric) => <span>{metric.groups.join(', ')}</span>,
       hide: () => !showGroups,
     },
     {
-      getContent: metric => (
+      getContent: (metric) => (
         <div className="horizontal pull-right metrics-action-buttons">
           <button className="link" data-id={metric.id} onClick={editMetric}>
             {disableEdit ? 'View' : 'Edit'}
@@ -78,7 +78,7 @@ function MetricList({
 
   return (
     <>
-      <NativeTable columns={columns} rows={metrics} rowKey={metric => metric.id} className="header-white" />
+      <NativeTable columns={columns} rows={metrics} rowKey={(metric) => metric.id} className="header-white" />
       {!metrics.length && selectedGroup ? (
         <p>
           This group is empty! The group will be not be present the next time the config is loaded unless it is saved
@@ -109,9 +109,9 @@ function mapStateToProps(state: ICanaryState): IMetricListStateProps {
     selectedGroup,
     groupList: state.selectedConfig.group.list,
     metrics: metricList.filter(filter),
-    showGroups: !selectedGroup || metricList.filter(filter).some(metric => metric.groups.length > 1),
+    showGroups: !selectedGroup || metricList.filter(filter).some((metric) => metric.groups.length > 1),
     changingGroupMetric: state.selectedConfig.metricList.find(
-      m => m.id === state.selectedConfig.changeMetricGroup.metric,
+      (m) => m.id === state.selectedConfig.changeMetricGroup.metric,
     ),
     metricStore: state.selectedConfig.selectedStore,
     disableEdit: state.app.disableConfigEdit,
@@ -158,7 +158,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IMetricLi
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MetricList);
+export default connect(mapStateToProps, mapDispatchToProps)(MetricList);

--- a/src/kayenta/edit/metricStoreSelector.tsx
+++ b/src/kayenta/edit/metricStoreSelector.tsx
@@ -34,7 +34,7 @@ const MetricStoreSelector = ({
         className="form-control input-sm"
         disabledStateKeys={[DISABLE_EDIT_CONFIG]}
       >
-        {stores.map(s => (
+        {stores.map((s) => (
           <option key={s} value={s}>
             {s}
           </option>
@@ -47,8 +47,8 @@ const MetricStoreSelector = ({
 const mapStateToProps = (state: ICanaryState): IMetricStoreSelectorStateProps => {
   return {
     stores: chain(state.data.kayentaAccounts.data)
-      .filter(account => account.supportedTypes.includes(KayentaAccountType.MetricsStore))
-      .map(account => account.metricsStoreType || account.type)
+      .filter((account) => account.supportedTypes.includes(KayentaAccountType.MetricsStore))
+      .map((account) => account.metricsStoreType || account.type)
       .uniq()
       .sort()
       .valueOf(),
@@ -62,7 +62,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>): IMetricStoreSelec
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MetricStoreSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(MetricStoreSelector);

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -79,7 +79,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): INameAndD
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(NameAndDescription);
+export default connect(mapStateToProps, mapDispatchToProps)(NameAndDescription);

--- a/src/kayenta/edit/openConfigJsonModalButton.tsx
+++ b/src/kayenta/edit/openConfigJsonModalButton.tsx
@@ -30,7 +30,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IOpenConf
   };
 }
 
-export default connect(
-  null,
-  mapDispatchToProps,
-)(OpenConfigJsonModalButton);
+export default connect(null, mapDispatchToProps)(OpenConfigJsonModalButton);

--- a/src/kayenta/edit/openDeleteModalButton.tsx
+++ b/src/kayenta/edit/openDeleteModalButton.tsx
@@ -46,7 +46,4 @@ function mapDispatchToProps(dispatch: any): IDeleteButtonDispatchProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DeleteConfigButton);
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteConfigButton);

--- a/src/kayenta/edit/saveConfigButton.tsx
+++ b/src/kayenta/edit/saveConfigButton.tsx
@@ -61,7 +61,4 @@ function mapDispatchToProps(dispatch: any): ISaveButtonDispatchProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SaveConfigButton);
+export default connect(mapStateToProps, mapDispatchToProps)(SaveConfigButton);

--- a/src/kayenta/edit/saveConfigError.tsx
+++ b/src/kayenta/edit/saveConfigError.tsx
@@ -56,7 +56,4 @@ function mapDispatchToProps(dispatch: any): ISaveErrorDispatchProps {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SaveConfigError);
+export default connect(mapStateToProps, mapDispatchToProps)(SaveConfigError);

--- a/src/kayenta/edit/validationErrors.tsx
+++ b/src/kayenta/edit/validationErrors.tsx
@@ -16,7 +16,7 @@ const ConfigValidationErrors = ({ errors }: IConfigValidationErrorsStateProps) =
     <section>
       <p>The following errors may prevent this config from working properly:</p>
       <ul>
-        {errors.map(e => (
+        {errors.map((e) => (
           <li key={e}>{e}</li>
         ))}
       </ul>
@@ -33,7 +33,7 @@ const ConfigValidationErrors = ({ errors }: IConfigValidationErrorsStateProps) =
 };
 
 const mapStateToProps = (state: ICanaryState): IConfigValidationErrorsStateProps => ({
-  errors: state.selectedConfig.validationErrors.map(e => e.message),
+  errors: state.selectedConfig.validationErrors.map((e) => e.message),
 });
 
 export default connect(mapStateToProps)(ConfigValidationErrors);

--- a/src/kayenta/layout/disableable.tsx
+++ b/src/kayenta/layout/disableable.tsx
@@ -22,7 +22,7 @@ interface IDisableableOwnProps {
 }
 
 const mapStateToProps = (state: ICanaryState, ownProps: IDisableableOwnProps) => ({
-  disabledBecauseOfState: (ownProps.disabledStateKeys || []).some(key => get<boolean>(state, key, false)),
+  disabledBecauseOfState: (ownProps.disabledStateKeys || []).some((key) => get<boolean>(state, key, false)),
 });
 
 // A component wrapped in `disableable` is disabled if one of the keys passed
@@ -41,13 +41,13 @@ type IDisableableButtonProps = React.DetailedHTMLProps<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
 >;
-export const DisableableButton = disableable<IDisableableButtonProps>(props => {
+export const DisableableButton = disableable<IDisableableButtonProps>((props) => {
   const { children, ...otherProps } = props;
   return <button {...otherProps}>{children}</button>;
 });
 
 type IDisableableInputProps = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
-export const DisableableInput = disableable<IDisableableInputProps>(props => {
+export const DisableableInput = disableable<IDisableableInputProps>((props) => {
   const { className, ...inputProps } = props;
   return (
     <input
@@ -60,18 +60,18 @@ export const DisableableInput = disableable<IDisableableInputProps>(props => {
   );
 });
 
-export const DisableableReactSelect = disableable<ReactSelectProps>(props => {
+export const DisableableReactSelect = disableable<ReactSelectProps>((props) => {
   const { children, ...selectProps } = props;
   return <Select {...selectProps}>{children}</Select>;
 });
 
-export const DisableableReactTypeahead = disableable<TypeaheadProps<any>>(props => {
+export const DisableableReactTypeahead = disableable<TypeaheadProps<any>>((props) => {
   const { children, ...selectProps } = props;
   return <Typeahead {...selectProps}>{children}</Typeahead>;
 });
 
 type IDisableableSelectProps = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
-export const DisableableSelect = disableable<IDisableableSelectProps>(props => {
+export const DisableableSelect = disableable<IDisableableSelectProps>((props) => {
   const { children, ...selectProps } = props;
   return <select {...selectProps}>{children}</select>;
 });
@@ -81,7 +81,7 @@ type IDisableableTextareaProps = React.DetailedHTMLProps<
   React.InputHTMLAttributes<HTMLTextAreaElement>,
   HTMLTextAreaElement
 > & { rows?: number };
-export const DisableableTextarea = disableable<IDisableableTextareaProps>(props => {
+export const DisableableTextarea = disableable<IDisableableTextareaProps>((props) => {
   const { className, ...textareaProps } = props;
   return <textarea className={classNames('form-control', 'input-sm', className)} {...textareaProps} />;
 });

--- a/src/kayenta/layout/formList.tsx
+++ b/src/kayenta/layout/formList.tsx
@@ -5,14 +5,14 @@ export interface IFormListProps {
 }
 
 /*
-* Mostly exists to centralize styles for form components.
-* */
+ * Mostly exists to centralize styles for form components.
+ * */
 export default function FormList({ children }: IFormListProps) {
   return (
     <ul className="list-group">
       {React.Children.map(
         children,
-        c =>
+        (c) =>
           c && (
             <li className="list-unstyled">
               <form role="form" className="form-horizontal container-fluid">

--- a/src/kayenta/layout/table/nativeTable.tsx
+++ b/src/kayenta/layout/table/nativeTable.tsx
@@ -42,9 +42,8 @@ export function NativeTable<T>({
     <table className={className}>
       <NativeTableHeader rows={rows} columns={columns} className={classNames('table-header', headerClassName)} />
       <tbody className={tableBodyClassName}>
-        {rows.map(
-          r =>
-            customRow && customRow(r) ? <td key={rowKey(r)}>{customRow(r)}</td> : <TableRow key={rowKey(r)} row={r} />,
+        {rows.map((r) =>
+          customRow && customRow(r) ? <td key={rowKey(r)}>{customRow(r)}</td> : <TableRow key={rowKey(r)} row={r} />,
         )}
       </tbody>
     </table>

--- a/src/kayenta/layout/table/table.tsx
+++ b/src/kayenta/layout/table/table.tsx
@@ -47,13 +47,8 @@ export function Table<T>({
     <div className={className}>
       <ul className={classNames(tableBodyClassName, 'list-group')}>
         <TableHeader columns={columns} className={classNames('table-header', 'sticky-header', headerClassName)} />
-        {rows.map(
-          r =>
-            customRow && customRow(r) ? (
-              <div key={rowKey(r)}>{customRow(r)}</div>
-            ) : (
-              <TableRow key={rowKey(r)} row={r} />
-            ),
+        {rows.map((r) =>
+          customRow && customRow(r) ? <div key={rowKey(r)}>{customRow(r)}</div> : <TableRow key={rowKey(r)} row={r} />,
         )}
       </ul>
     </div>

--- a/src/kayenta/manualAnalysis/ManualAnalysisModal.tsx
+++ b/src/kayenta/manualAnalysis/ManualAnalysisModal.tsx
@@ -230,7 +230,7 @@ export class ManualAnalysisModal extends React.Component<IManualAnalysisModalPro
         actions.setSubmitting(false);
         actions.setStatus({ succeeded: true });
       })
-      .catch(error => {
+      .catch((error) => {
         actions.setSubmitting(false);
         actions.setStatus({ succeeded: false, error });
       });
@@ -368,8 +368,8 @@ export class ManualAnalysisModal extends React.Component<IManualAnalysisModalPro
                             recommendedLocations={recommendedLocations}
                             locations={locations}
                             value={values.baselineLocation}
-                            onChange={location => setFieldValue('baselineLocation', location)}
-                            onShowAllChange={showAll => this.setState({ showAllControlLocations: showAll })}
+                            onChange={(location) => setFieldValue('baselineLocation', location)}
+                            onShowAllChange={(showAll) => this.setState({ showAllControlLocations: showAll })}
                             input={
                               <Field
                                 className="form-control input-sm"
@@ -399,8 +399,8 @@ export class ManualAnalysisModal extends React.Component<IManualAnalysisModalPro
                             recommendedLocations={recommendedLocations}
                             locations={locations}
                             value={values.canaryLocation}
-                            onChange={location => setFieldValue('canaryLocation', location)}
-                            onShowAllChange={showAll => this.setState({ showAllExperimentLocations: showAll })}
+                            onChange={(location) => setFieldValue('canaryLocation', location)}
+                            onShowAllChange={(showAll) => this.setState({ showAllExperimentLocations: showAll })}
                             input={
                               <Field
                                 className="form-control input-sm"
@@ -434,7 +434,7 @@ export class ManualAnalysisModal extends React.Component<IManualAnalysisModalPro
                         <div className="col-md-7">
                           <MapEditor
                             model={values.extendedScopeParams}
-                            onChange={model => setFieldValue('extendedScopeParams', model)}
+                            onChange={(model) => setFieldValue('extendedScopeParams', model)}
                             hiddenKeys={['resourceType']}
                           />
                         </div>
@@ -529,7 +529,7 @@ const LocationField = ({
   }
 
   const combinedLocations = combineLocations(showAll, recommendedLocations, locations);
-  const options = combinedLocations.map(location => ({ label: location, value: location }));
+  const options = combinedLocations.map((location) => ({ label: location, value: location }));
 
   return (
     <>
@@ -539,23 +539,22 @@ const LocationField = ({
         options={options}
         onChange={(item: { label: string; value: string }) => onChange((item && item.value) || '')}
       />
-      {recommendedLocations.length > 0 &&
-        locations.length > 0 && (
-          <div className="pull-right">
-            <button
-              type="button"
-              className="link"
-              onClick={() => {
-                onShowAllChange(!showAll);
-                if (!combineLocations(!showAll, recommendedLocations, locations).includes(value)) {
-                  onChange('');
-                }
-              }}
-            >
-              {showAll ? 'Only show recommended locations' : 'Show all locations'}
-            </button>
-          </div>
-        )}
+      {recommendedLocations.length > 0 && locations.length > 0 && (
+        <div className="pull-right">
+          <button
+            type="button"
+            className="link"
+            onClick={() => {
+              onShowAllChange(!showAll);
+              if (!combineLocations(!showAll, recommendedLocations, locations).includes(value)) {
+                onChange('');
+              }
+            }}
+          >
+            {showAll ? 'Only show recommended locations' : 'Show all locations'}
+          </button>
+        </div>
+      )}
     </>
   );
 };

--- a/src/kayenta/metricStore/atlas/atlasMetricConfigurer.tsx
+++ b/src/kayenta/metricStore/atlas/atlasMetricConfigurer.tsx
@@ -124,9 +124,6 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IAtlasMet
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(AtlasMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(AtlasMetricConfigurer);
 
 export { queryFinder };

--- a/src/kayenta/metricStore/datadog/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/datadog/metricConfigurer.tsx
@@ -26,8 +26,8 @@ export const nameFinder = (metric: ICanaryMetricConfig) => queryFinder(metric).s
 export const aggFinder = (metric: ICanaryMetricConfig) => queryFinder(metric).split(':', 2)[0];
 
 /*
-* Component for configuring a Datadog metric.
-* */
+ * Component for configuring a Datadog metric.
+ * */
 function DatadogMetricConfigurer({ changeMetricName, editingMetric }: DatadogMetricConfigurerProps) {
   return (
     <>
@@ -86,7 +86,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IDatadogM
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DatadogMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(DatadogMetricConfigurer);

--- a/src/kayenta/metricStore/datadog/metricTypeSelector.spec.tsx
+++ b/src/kayenta/metricStore/datadog/metricTypeSelector.spec.tsx
@@ -28,18 +28,12 @@ describe('<DatadogMetricTypeSelector />', () => {
       },
     };
 
-    Component = connect(
-      mapStateToProps,
-      mapDispatchToProps,
-    )(DatadogMetricTypeSelector);
+    Component = connect(mapStateToProps, mapDispatchToProps)(DatadogMetricTypeSelector);
   });
 
   it('builds options from input descriptors', () => {
     const component = mountWithState(<Component value="" onChange={noop} />, state);
-    const allProps: any = component
-      .find(Select)
-      .first()
-      .props();
+    const allProps: any = component.find(Select).first().props();
 
     expect(allProps.options.map((o: Option) => o.value)).toEqual([
       'datadog.agent.running',

--- a/src/kayenta/metricStore/datadog/metricTypeSelector.tsx
+++ b/src/kayenta/metricStore/datadog/metricTypeSelector.tsx
@@ -31,7 +31,7 @@ export const DatadogMetricTypeSelector = ({
 }: IDatadogMetricTypeSelectorDispatchProps &
   IDatadogMetricTypeSelectorStateProps &
   IDatadogMetricTypeSelectorOwnProps) => {
-  if (value && options.every(o => o.value !== value)) {
+  if (value && options.every((o) => o.value !== value)) {
     options = options.concat({ label: value, value });
   }
 
@@ -53,7 +53,7 @@ export const DatadogMetricTypeSelector = ({
 
 export const mapStateToProps = (state: ICanaryState, ownProps: IDatadogMetricTypeSelectorOwnProps) => {
   const descriptors = state.data.metricsServiceMetadata.data as IDatadogMetricDescriptor[];
-  const options: Option[] = descriptors.map(d => ({ label: d.name, value: d.name }));
+  const options: Option[] = descriptors.map((d) => ({ label: d.name, value: d.name }));
   return {
     options,
     loading: state.data.metricsServiceMetadata.load === AsyncRequestState.Requesting,
@@ -69,7 +69,4 @@ export const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DatadogMetricTypeSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(DatadogMetricTypeSelector);

--- a/src/kayenta/metricStore/graphite/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/graphite/metricConfigurer.tsx
@@ -21,8 +21,8 @@ type GraphiteMetricConfigurerProps = IGraphiteMetricConfigurerStateProps & IGrap
 export const queryFinder = (metric: ICanaryMetricConfig) => get(metric, 'query.metricName', '');
 
 /*
-* Component for configuring a Graphite metric.
-* */
+ * Component for configuring a Graphite metric.
+ * */
 function GraphiteMetricConfigurer({ changeMetricName, editingMetric }: GraphiteMetricConfigurerProps) {
   return (
     <FormRow label="Graphite Metric">
@@ -50,7 +50,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IGraphite
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GraphiteMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(GraphiteMetricConfigurer);

--- a/src/kayenta/metricStore/graphite/metricTypeSelector.tsx
+++ b/src/kayenta/metricStore/graphite/metricTypeSelector.tsx
@@ -42,11 +42,11 @@ export const GraphiteMetricTypeSelector = ({
         load(option[0]);
       }}
       defaultInputValue={value}
-      renderMenuItemChildren={option => (
+      renderMenuItemChildren={(option) => (
         <a style={{ pointerEvents: 'all', textDecoration: 'none', color: '#000000' }}>{option}</a>
       )}
       placeholder={'Enter at least three characters to search.'}
-      onInputChange={input => {
+      onInputChange={(input) => {
         onChange([input]);
         load(input);
         return input;
@@ -58,7 +58,7 @@ export const GraphiteMetricTypeSelector = ({
 
 export const mapStateToProps = (state: ICanaryState, ownProps: IGraphiteMetricTypeSelectorOwnProps) => {
   const descriptors = state.data.metricsServiceMetadata.data as IGraphiteMetricDescriptor[];
-  const options: string[] = descriptors.map(d => d.name);
+  const options: string[] = descriptors.map((d) => d.name);
 
   return {
     options,
@@ -75,7 +75,4 @@ export const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GraphiteMetricTypeSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(GraphiteMetricTypeSelector);

--- a/src/kayenta/metricStore/newrelic/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/newrelic/metricConfigurer.tsx
@@ -55,7 +55,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): INewRelic
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(NewRelicMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(NewRelicMetricConfigurer);

--- a/src/kayenta/metricStore/prometheus/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/prometheus/metricConfigurer.tsx
@@ -36,11 +36,11 @@ interface IPrometheusMetricConfigurerDispatchProps {
 const RESOURCE_TYPES = ['gce_instance', 'aws_ec2_instance'];
 
 const toReactSelectOptions = (values: string[]): Array<Option<string>> =>
-  values.map(value => ({ value, label: value }));
+  values.map((value) => ({ value, label: value }));
 
 /*
-* Component for configuring a Prometheus metric.
-* */
+ * Component for configuring a Prometheus metric.
+ * */
 function PrometheusMetricConfigurer({
   editingMetric,
   queryType,
@@ -104,8 +104,8 @@ function mapStateToProps(state: ICanaryState): IPrometheusMetricConfigurerStateP
 
 function mapDispatchToProps(dispatch: (action: Action & any) => void): IPrometheusMetricConfigurerDispatchProps {
   return {
-    updateLabelBindings: payload => dispatch(Creators.updatePrometheusLabelBindings(payload)),
-    updateGroupBy: payload => dispatch(Creators.updatePrometheusGroupBy(payload)),
+    updateLabelBindings: (payload) => dispatch(Creators.updatePrometheusLabelBindings(payload)),
+    updateGroupBy: (payload) => dispatch(Creators.updatePrometheusGroupBy(payload)),
     updatePrometheusMetricQueryField: (field, option) =>
       dispatch(Creators.updatePrometheusMetricQueryField({ field, value: option && option.value })),
     updateFilterQueryType: (value: PrometheusQueryType) => {
@@ -117,7 +117,4 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IPromethe
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(PrometheusMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(PrometheusMetricConfigurer);

--- a/src/kayenta/metricStore/prometheus/metricTypeSelector.spec.tsx
+++ b/src/kayenta/metricStore/prometheus/metricTypeSelector.spec.tsx
@@ -36,12 +36,9 @@ describe('<PrometheusMetricTypeSelector />', () => {
 
   it('displays which account will populate the search when >1 account is configured, defaulting to the first account alphabetically', () => {
     wrapper = shallow(<PrometheusMetricTypeSelector {...defaultProps} />);
-    expect(
-      wrapper
-        .find('.prometheus-metric-type-selector-account-hint span')
-        .at(0)
-        .text(),
-    ).toEqual('Metric search is currently populating from my-first-prometheus-account.');
+    expect(wrapper.find('.prometheus-metric-type-selector-account-hint span').at(0).text()).toEqual(
+      'Metric search is currently populating from my-first-prometheus-account.',
+    );
   });
 
   it('allows the user to switch which account populates the search when >1 account is configured', () => {

--- a/src/kayenta/metricStore/prometheus/metricTypeSelector.tsx
+++ b/src/kayenta/metricStore/prometheus/metricTypeSelector.tsx
@@ -54,7 +54,7 @@ export class PrometheusMetricTypeSelector extends React.Component<
     const { accountOptions, load, loading, metricOptions, onChange, value } = this.props;
 
     const metricOptionsWithSelected =
-      value && metricOptions.every(o => o.value !== value)
+      value && metricOptions.every((o) => o.value !== value)
         ? metricOptions.concat({ label: value, value })
         : metricOptions;
 
@@ -66,7 +66,7 @@ export class PrometheusMetricTypeSelector extends React.Component<
           onChange={onChange}
           value={value}
           placeholder={'Enter at least three characters to search.'}
-          onInputChange={input => {
+          onInputChange={(input) => {
             load(input, this.state.selectedAccount);
             return input;
           }}
@@ -111,9 +111,9 @@ const accountOptionsSelector = createSelector(
   (state: ICanaryState) => state.data.kayentaAccounts.data,
   (accounts): Array<Option<string>> => {
     return chain(accounts)
-      .filter(a => a.supportedTypes.includes(KayentaAccountType.MetricsStore) && a.type === 'prometheus')
-      .sortBy(a => a.name)
-      .map(a => ({ label: a.name, value: a.name }))
+      .filter((a) => a.supportedTypes.includes(KayentaAccountType.MetricsStore) && a.type === 'prometheus')
+      .sortBy((a) => a.name)
+      .map((a) => ({ label: a.name, value: a.name }))
       .value();
   },
 );
@@ -121,7 +121,7 @@ const accountOptionsSelector = createSelector(
 const metricOptionsSelector = createSelector(
   (state: ICanaryState) => state.data.metricsServiceMetadata.data,
   (descriptors: IPrometheusMetricDescriptor[]): Array<Option<string>> =>
-    descriptors.map(d => ({ label: d.name, value: d.name })),
+    descriptors.map((d) => ({ label: d.name, value: d.name })),
 );
 
 const mapStateToProps = (state: ICanaryState, ownProps: IPrometheusMetricTypeSelectorOwnProps) => {
@@ -141,7 +141,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(PrometheusMetricTypeSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(PrometheusMetricTypeSelector);

--- a/src/kayenta/metricStore/signalfx/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/signalfx/metricConfigurer.tsx
@@ -153,7 +153,7 @@ function validateQueryPairs(
 
   const queryPairs: IKeyValuePair[] = getQueryPairs(editingMetric);
 
-  queryPairs.forEach(qp => {
+  queryPairs.forEach((qp) => {
     if (!qp.key || !qp.value) {
       nextErrors.queryPairs = { message: 'All query pairs must contain a non-blank key and value.' };
     }
@@ -179,11 +179,8 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): ISignalFx
     updateAggregationMethod: (aggregationMethod: string): void => {
       dispatch(Creators.updateSignalFxAggregationMethod({ aggregationMethod }));
     },
-    updateQueryPairs: payload => dispatch(Creators.updateSignalFxQueryPairs(payload)),
+    updateQueryPairs: (payload) => dispatch(Creators.updateSignalFxQueryPairs(payload)),
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SignalFxMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(SignalFxMetricConfigurer);

--- a/src/kayenta/metricStore/stackdriver/metricConfigurer.tsx
+++ b/src/kayenta/metricStore/stackdriver/metricConfigurer.tsx
@@ -78,11 +78,11 @@ const PER_SERIES_ALIGNERS = [
 const STACKDRIVER_HELP_ID_PREFIX = 'stackdriver';
 
 const toReactSelectOptions = (values: string[]): Array<Option<string>> =>
-  values.map(value => ({ value, label: value }));
+  values.map((value) => ({ value, label: value }));
 
 /*
-* Component for configuring a Stackdriver metric.
-* */
+ * Component for configuring a Stackdriver metric.
+ * */
 function StackdriverMetricConfigurer({
   editingMetric,
   updateGroupBy,
@@ -137,11 +137,8 @@ function mapDispatchToProps(dispatch: (action: Action & any) => void): IStackdri
   return {
     updateStackdriverQueryField: (field, option) =>
       dispatch(Creators.updateStackdriverMetricResourceField({ field, value: option && option.value })),
-    updateGroupBy: payload => dispatch(Creators.updateStackdriverGroupBy(payload)),
+    updateGroupBy: (payload) => dispatch(Creators.updateStackdriverGroupBy(payload)),
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(StackdriverMetricConfigurer);
+export default connect(mapStateToProps, mapDispatchToProps)(StackdriverMetricConfigurer);

--- a/src/kayenta/metricStore/stackdriver/metricTypeSelector.spec.tsx
+++ b/src/kayenta/metricStore/stackdriver/metricTypeSelector.spec.tsx
@@ -52,10 +52,7 @@ describe('<StackdriverMetricTypeSelector />', () => {
       state,
     );
 
-    const allProps: any = component
-      .find(Select)
-      .first()
-      .props();
+    const allProps: any = component.find(Select).first().props();
 
     expect(allProps.options.map((o: Option) => o.value)).toEqual([
       'compute.googleapis.com/disk/read_ops_count',

--- a/src/kayenta/metricStore/stackdriver/metricTypeSelector.tsx
+++ b/src/kayenta/metricStore/stackdriver/metricTypeSelector.tsx
@@ -54,8 +54,8 @@ export class StackdriverMetricTypeSelector extends React.Component<IStackdriverM
   public render() {
     const { loading, load, descriptors, value, onChange } = this.props;
 
-    let options: Option[] = descriptors.map(d => ({ label: d.type, value: d.type }));
-    if (value && options.every(o => o.value !== value)) {
+    let options: Option[] = descriptors.map((d) => ({ label: d.type, value: d.type }));
+    if (value && options.every((o) => o.value !== value)) {
       options = options.concat({ label: value, value });
     }
 
@@ -66,7 +66,7 @@ export class StackdriverMetricTypeSelector extends React.Component<IStackdriverM
         onChange={onChange}
         value={value}
         optionRenderer={(option: Option<string>) => {
-          const descriptor = descriptors.find(d => d.type === option.value);
+          const descriptor = descriptors.find((d) => d.type === option.value);
           if (!descriptor) {
             return <span>{option.label}</span>;
           }
@@ -82,7 +82,7 @@ export class StackdriverMetricTypeSelector extends React.Component<IStackdriverM
           );
         }}
         placeholder={'Enter at least three characters to search.'}
-        onInputChange={input => {
+        onInputChange={(input) => {
           load(input);
           return input;
         }}
@@ -109,7 +109,4 @@ export const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(StackdriverMetricTypeSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(StackdriverMetricTypeSelector);

--- a/src/kayenta/middleware/asyncDispatch.ts
+++ b/src/kayenta/middleware/asyncDispatch.ts
@@ -3,11 +3,11 @@ import { Middleware, MiddlewareAPI, Dispatch, Action } from 'redux';
 import { ICanaryState } from '../reducers/index';
 
 /*
-* Middleware for scheduling actions from within reducers.
-* Provides every action with an `asyncDispatch` method.
-* Actions provided to `asyncDispatch` will run after all reducers have completed.
-* TODO: type actions to include `asyncDispatch`.
-* */
+ * Middleware for scheduling actions from within reducers.
+ * Provides every action with an `asyncDispatch` method.
+ * Actions provided to `asyncDispatch` will run after all reducers have completed.
+ * TODO: type actions to include `asyncDispatch`.
+ * */
 
 // TODO: replace the `any` generic passed to MiddlewareAPI with ICanaryState. The Redux typings here are wrong.
 // Should be fixed in this PR: https://github.com/reactjs/redux/pull/2563
@@ -18,7 +18,7 @@ export const asyncDispatchMiddleware: Middleware = (store: MiddlewareAPI<any>) =
   let actionQueue: Action[] = [];
 
   const flushQueue = () => {
-    actionQueue.forEach(a => store.dispatch(a));
+    actionQueue.forEach((a) => store.dispatch(a));
     actionQueue = [];
   };
 

--- a/src/kayenta/middleware/epics.ts
+++ b/src/kayenta/middleware/epics.ts
@@ -22,16 +22,16 @@ import { listMetricsServiceMetadata } from 'kayenta/service/metricsServiceMetada
 const typeMatches = (...actions: string[]) => (action: Action & any) => actions.includes(action.type);
 
 const loadConfigEpic = (action$: Observable<Action & any>) =>
-  action$.filter(typeMatches(Actions.LOAD_CONFIG_REQUEST, Actions.SAVE_CONFIG_SUCCESS)).concatMap(action =>
+  action$.filter(typeMatches(Actions.LOAD_CONFIG_REQUEST, Actions.SAVE_CONFIG_SUCCESS)).concatMap((action) =>
     Observable.fromPromise(getCanaryConfigById(action.payload.id))
-      .map(config => Creators.loadConfigSuccess({ config }))
-      .catch(error => Observable.of(Creators.loadConfigFailure({ error }))),
+      .map((config) => Creators.loadConfigSuccess({ config }))
+      .catch((error) => Observable.of(Creators.loadConfigFailure({ error }))),
   );
 
 const selectConfigEpic = (action$: Observable<Action & any>) =>
   action$
     .filter(typeMatches(Actions.LOAD_CONFIG_SUCCESS))
-    .map(action => Creators.selectConfig({ config: action.payload.config }));
+    .map((action) => Creators.selectConfig({ config: action.payload.config }));
 
 const saveConfigEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
   action$.filter(typeMatches(Actions.SAVE_CONFIG_REQUEST)).concatMap(() => {
@@ -48,10 +48,7 @@ const saveConfigEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<
       .concatMap(({ canaryConfigId }) =>
         Observable.forkJoin(
           ReactInjector.$state.go('^.configDetail', { id: canaryConfigId, copy: false, new: false }),
-          store
-            .getState()
-            .data.application.getDataSource('canaryConfigs')
-            .refresh(true),
+          store.getState().data.application.getDataSource('canaryConfigs').refresh(true),
         ).mapTo(Creators.saveConfigSuccess({ id: canaryConfigId })),
       )
       .catch((error: Error) => Observable.of(Creators.saveConfigFailure({ error })));
@@ -71,35 +68,32 @@ const deleteConfigSuccessEpic = (action$: Observable<Action & any>, store: Middl
       Observable.forkJoin(
         ReactInjector.$state.go('^.configDefault'),
         // TODO: handle config summary load failure (in general, not just here).
-        store
-          .getState()
-          .data.application.getDataSource('canaryConfigs')
-          .refresh(true),
+        store.getState().data.application.getDataSource('canaryConfigs').refresh(true),
       ),
     )
     .mapTo(Creators.closeDeleteConfigModal());
 
 const loadCanaryRunRequestEpic = (action$: Observable<Action & any>) =>
-  action$.filter(typeMatches(Actions.LOAD_RUN_REQUEST)).concatMap(action =>
+  action$.filter(typeMatches(Actions.LOAD_RUN_REQUEST)).concatMap((action) =>
     Observable.fromPromise(getCanaryRun(action.payload.configId, action.payload.runId))
-      .map(run => Creators.loadRunSuccess({ run }))
+      .map((run) => Creators.loadRunSuccess({ run }))
       .catch((error: Error) => Observable.of(Creators.loadRunFailure({ error }))),
   );
 
 const loadMetricSetPairEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
-  action$.filter(typeMatches(Actions.LOAD_METRIC_SET_PAIR_REQUEST)).concatMap(action => {
+  action$.filter(typeMatches(Actions.LOAD_METRIC_SET_PAIR_REQUEST)).concatMap((action) => {
     const run = runSelector(store.getState());
     return Observable.fromPromise(getMetricSetPair(run.metricSetPairListId, action.payload.pairId))
-      .map(metricSetPair => Creators.loadMetricSetPairSuccess({ metricSetPair }))
+      .map((metricSetPair) => Creators.loadMetricSetPairSuccess({ metricSetPair }))
       .catch((error: Error) => Observable.of(Creators.loadMetricSetPairFailure({ error })));
   });
 
 const updatePrometheusMetricDescriptionFilterEpic = (action$: Observable<Action & any>) =>
   action$
     .filter(typeMatches(Actions.UPDATE_PROMETHEUS_METRIC_DESCRIPTOR_FILTER))
-    .filter(action => action.payload.filter && action.payload.filter.length > 2)
+    .filter((action) => action.payload.filter && action.payload.filter.length > 2)
     .debounceTime(200 /* milliseconds */)
-    .map(action => {
+    .map((action) => {
       return Creators.loadMetricsServiceMetadataRequest({
         filter: action.payload.filter,
         metricsAccountName: action.payload.metricsAccountName,
@@ -112,17 +106,17 @@ const updateStackdriverMetricDescriptionFilterEpic = (
 ) =>
   action$
     .filter(typeMatches(Actions.UPDATE_STACKDRIVER_METRIC_DESCRIPTOR_FILTER))
-    .filter(action => action.payload.filter && action.payload.filter.length > 2)
+    .filter((action) => action.payload.filter && action.payload.filter.length > 2)
     .debounceTime(200 /* milliseconds */)
-    .map(action => {
+    .map((action) => {
       const [metricsAccountName] = store
         .getState()
         .data.kayentaAccounts.data.filter(
-          account =>
+          (account) =>
             account.supportedTypes.includes(KayentaAccountType.MetricsStore) &&
             account.metricsStoreType === 'stackdriver',
         )
-        .map(account => account.name);
+        .map((account) => account.name);
 
       return Creators.loadMetricsServiceMetadataRequest({
         filter: action.payload.filter,
@@ -136,15 +130,15 @@ const updateGraphiteMetricDescriptionFilterEpic = (
 ) =>
   action$
     .filter(typeMatches(Actions.UPDATE_GRAPHITE_METRIC_DESCRIPTOR_FILTER))
-    .filter(action => action.payload.filter && action.payload.filter.length > 2)
+    .filter((action) => action.payload.filter && action.payload.filter.length > 2)
     .debounceTime(200 /* milliseconds */)
-    .map(action => {
+    .map((action) => {
       const [metricsAccountName] = store
         .getState()
         .data.kayentaAccounts.data.filter(
-          account => account.supportedTypes.includes(KayentaAccountType.MetricsStore) && account.type === 'graphite',
+          (account) => account.supportedTypes.includes(KayentaAccountType.MetricsStore) && account.type === 'graphite',
         )
-        .map(account => account.name);
+        .map((account) => account.name);
 
       return Creators.loadMetricsServiceMetadataRequest({
         filter: action.payload.filter,
@@ -158,15 +152,15 @@ const updateDatadogMetricDescriptionFilterEpic = (
 ) =>
   action$
     .filter(typeMatches(Actions.UPDATE_DATADOG_METRIC_DESCRIPTOR_FILTER))
-    .filter(action => action.payload.filter && action.payload.filter.length > 2)
+    .filter((action) => action.payload.filter && action.payload.filter.length > 2)
     .debounceTime(200 /* milliseconds */)
-    .map(action => {
+    .map((action) => {
       const [metricsAccountName] = store
         .getState()
         .data.kayentaAccounts.data.filter(
-          account => account.supportedTypes.includes(KayentaAccountType.MetricsStore) && account.type === 'datadog',
+          (account) => account.supportedTypes.includes(KayentaAccountType.MetricsStore) && account.type === 'datadog',
         )
-        .map(account => account.name);
+        .map((account) => account.name);
 
       return Creators.loadMetricsServiceMetadataRequest({
         filter: action.payload.filter,
@@ -175,16 +169,16 @@ const updateDatadogMetricDescriptionFilterEpic = (
     });
 
 const loadMetricsServiceMetadataEpic = (action$: Observable<Action & any>) =>
-  action$.filter(typeMatches(Actions.LOAD_METRICS_SERVICE_METADATA_REQUEST)).concatMap(action => {
+  action$.filter(typeMatches(Actions.LOAD_METRICS_SERVICE_METADATA_REQUEST)).concatMap((action) => {
     return Observable.fromPromise(listMetricsServiceMetadata(action.payload.filter, action.payload.metricsAccountName))
-      .map(data => Creators.loadMetricsServiceMetadataSuccess({ data }))
+      .map((data) => Creators.loadMetricsServiceMetadataSuccess({ data }))
       .catch((error: Error) => Observable.of(Creators.loadMetricsServiceMetadataFailure({ error })));
   });
 
 const loadKayentaAccountsEpic = (action$: Observable<Action & any>) =>
   action$.filter(typeMatches(Actions.LOAD_KAYENTA_ACCOUNTS_REQUEST, Actions.INITIALIZE)).concatMap(() =>
     Observable.fromPromise(listKayentaAccounts())
-      .map(accounts => Creators.loadKayentaAccountsSuccess({ accounts }))
+      .map((accounts) => Creators.loadKayentaAccountsSuccess({ accounts }))
       .catch((error: Error) => Observable.of(Creators.loadKayentaAccountsFailure({ error }))),
   );
 

--- a/src/kayenta/navigation/canary.states.ts
+++ b/src/kayenta/navigation/canary.states.ts
@@ -66,7 +66,7 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
           },
         },
         children: [configDefault, configDetail],
-        redirectTo: transition => transition.to().name + '.configDefault',
+        redirectTo: (transition) => transition.to().name + '.configDefault',
       };
 
       const reportDetail: INestedState = {
@@ -108,7 +108,7 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
           },
         },
         children: [reportDetail, reportDefault],
-        redirectTo: transition => transition.to().name + '.reportDefault',
+        redirectTo: (transition) => transition.to().name + '.reportDefault',
       };
 
       const canaryRoot: INestedState = {
@@ -148,7 +148,7 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
       $uiRouter.transitionService.onBefore(
         {
           from: '**.configDetail.**',
-          to: state => !state.name.includes('configDetail'),
+          to: (state) => !state.name.includes('configDetail'),
         },
         () => {
           canaryStore.dispatch(Creators.clearSelectedConfig());
@@ -157,7 +157,7 @@ module(CANARY_STATES, [APPLICATION_STATE_PROVIDER])
 
       // Prompts confirmation for page navigation if config hasn't been saved.
       // Should be possible with a $uiRouter transition hook, but it's not.
-      $rootScope.$on('$stateChangeStart', event => {
+      $rootScope.$on('$stateChangeStart', (event) => {
         const state = canaryStore.getState();
         const warningMessage = 'You have unsaved changes.\nAre you sure you want to navigate away from this page?';
         if (state.selectedConfig && !state.selectedConfig.isInSyncWithServer) {

--- a/src/kayenta/reducers/data.ts
+++ b/src/kayenta/reducers/data.ts
@@ -59,10 +59,11 @@ export const configSummaries = handleActions(
 const configs = handleActions(
   {
     [Actions.LOAD_CONFIG_SUCCESS]: (state: ICanaryConfig[], action: Action & any): ICanaryConfig[] => {
-      if (state.some(config => config.id === action.payload.config.id)) {
-        return without(state, state.find(config => config.id === action.payload.config.id)).concat([
-          action.payload.config,
-        ]);
+      if (state.some((config) => config.id === action.payload.config.id)) {
+        return without(
+          state,
+          state.find((config) => config.id === action.payload.config.id),
+        ).concat([action.payload.config]);
       } else {
         return state.concat([action.payload.config]);
       }

--- a/src/kayenta/reducers/index.ts
+++ b/src/kayenta/reducers/index.ts
@@ -38,7 +38,7 @@ const combined = combineReducers<ICanaryState>({
 });
 
 const getRenderState = (judges: IJudge[], judgeConfig: ICanaryJudgeConfig): JudgeSelectRenderState => {
-  if (judges.some(judge => judge.name === judgeConfig.name)) {
+  if (judges.some((judge) => judge.name === judgeConfig.name)) {
     if (judges.length === 1) {
       return JudgeSelectRenderState.None;
     } else {
@@ -90,7 +90,7 @@ const isInSyncWithServerReducer = (state: ICanaryState): ICanaryState => {
         if (!editedConfig) {
           return true;
         } else {
-          const originalConfig = state.data.configs.find(c => c.id === editedConfig.id);
+          const originalConfig = state.data.configs.find((c) => c.id === editedConfig.id);
           // If we're saving the config right now, don't warn that
           // the config hasn't been saved.
           if (
@@ -124,7 +124,7 @@ const resolveSelectedMetricId = (state: ICanaryState, action: Action & any): str
       }
 
       const group = action.payload.group;
-      const filter: (r: ICanaryAnalysisResult) => boolean = group ? r => r.groups.includes(group) : () => true;
+      const filter: (r: ICanaryAnalysisResult) => boolean = group ? (r) => r.groups.includes(group) : () => true;
 
       return results.find(filter) ? results.find(filter).id : null;
     }
@@ -173,14 +173,14 @@ const selectedMetricStoreReducer = (state: ICanaryState, action: Action & any) =
     case Actions.SELECT_CONFIG:
     case Actions.LOAD_KAYENTA_ACCOUNTS_SUCCESS: {
       const stores = chain(state.data.kayentaAccounts.data)
-        .filter(account => account.supportedTypes.includes(KayentaAccountType.MetricsStore))
-        .map(account => account.metricsStoreType || account.type)
+        .filter((account) => account.supportedTypes.includes(KayentaAccountType.MetricsStore))
+        .map((account) => account.metricsStoreType || account.type)
         .uniq()
         .valueOf();
 
       let selectedStore = (state.selectedConfig.metricList || [])
-        .map(metric => metric.query.type)
-        .find(store => !!store);
+        .map((metric) => metric.query.type)
+        .find((store) => !!store);
 
       selectedStore =
         selectedStore ||

--- a/src/kayenta/reducers/prometheusMetricConfig.spec.ts
+++ b/src/kayenta/reducers/prometheusMetricConfig.spec.ts
@@ -20,7 +20,7 @@ describe('Reducer: prometheusMetricConfigReducer', () => {
     });
 
     it('deletes key/value pair if passed falsy value', () => {
-      [null, undefined, ''].forEach(falsyValue => {
+      [null, undefined, ''].forEach((falsyValue) => {
         const nextState = prometheusMetricConfigReducer({ query: { resourceType: 'aws_ec2_instance' } } as any, {
           type: Actions.UPDATE_PROMETHEUS_METRIC_QUERY_FIELD,
           payload: { field: 'resourceType', value: falsyValue },

--- a/src/kayenta/reducers/selectedConfig.spec.ts
+++ b/src/kayenta/reducers/selectedConfig.spec.ts
@@ -52,7 +52,7 @@ describe('Reducer: editGroupConfirmReducer', () => {
   it('ignores the updated group name if the value is JS false', () => {
     const editedGroupNames = ['', null, undefined];
 
-    editedGroupNames.forEach(edited => {
+    editedGroupNames.forEach((edited) => {
       const action = {
         type: Actions.EDIT_GROUP_CONFIRM,
         payload: {
@@ -111,9 +111,9 @@ describe('Reducer: changeMetricGroupConfirmReducer', () => {
 
     const updatedState = changeMetricGroupConfirmReducer(state, action);
 
-    expect(updatedState.metricList.find(m => m.id === '1').groups).toEqual(['updatedGroup']);
+    expect(updatedState.metricList.find((m) => m.id === '1').groups).toEqual(['updatedGroup']);
 
-    expect(updatedState.metricList.find(m => m.id === '2').groups).toEqual([]);
+    expect(updatedState.metricList.find((m) => m.id === '2').groups).toEqual([]);
   });
 
   it('handles metrics with multiple groups', () => {
@@ -122,14 +122,14 @@ describe('Reducer: changeMetricGroupConfirmReducer', () => {
 
     let updatedState = changeMetricGroupConfirmReducer(state, action);
 
-    expect(updatedState.metricList.find(m => m.id === '1').groups).toEqual(['c']);
+    expect(updatedState.metricList.find((m) => m.id === '1').groups).toEqual(['c']);
 
     state = createSelectedConfigState(['a', 'b'], 'b');
     action = createAction('1');
 
     updatedState = changeMetricGroupConfirmReducer(state, action);
 
-    expect(updatedState.metricList.find(m => m.id === '1').groups).toEqual(['b']);
+    expect(updatedState.metricList.find((m) => m.id === '1').groups).toEqual(['b']);
   });
 });
 

--- a/src/kayenta/reducers/selectedConfig.ts
+++ b/src/kayenta/reducers/selectedConfig.ts
@@ -111,9 +111,9 @@ const metricList = handleActions(
     [Actions.ADD_METRIC]: (state: ICanaryMetricConfig[], action: Action & any) =>
       idMetrics(state.concat([action.payload.metric])),
     [Actions.REMOVE_METRIC]: (state: ICanaryMetricConfig[], action: Action & any) =>
-      idMetrics(state.filter(metric => metric.id !== action.payload.id)),
+      idMetrics(state.filter((metric) => metric.id !== action.payload.id)),
     [Actions.DELETE_TEMPLATE]: (state: ICanaryMetricConfig[], action: Action & any) =>
-      state.map(m => removeDeletedTemplateFromMetric(m, action.payload.name)),
+      state.map((m) => removeDeletedTemplateFromMetric(m, action.payload.name)),
   },
   [],
 );
@@ -303,14 +303,14 @@ function editingMetricReducer(state: ISelectedConfigState = null, action: Action
     case Actions.EDIT_METRIC_BEGIN:
       return {
         ...state,
-        editingMetric: state.metricList.find(metric => metric.id === action.payload.id),
+        editingMetric: state.metricList.find((metric) => metric.id === action.payload.id),
       };
 
     case Actions.EDIT_METRIC_CONFIRM: {
       const editing: ICanaryMetricConfig = omit(state.editingMetric, 'isNew');
       return {
         ...state,
-        metricList: state.metricList.map(metric => (metric.id === editing.id ? editing : metric)),
+        metricList: state.metricList.map((metric) => (metric.id === editing.id ? editing : metric)),
         editingMetric: null,
       };
     }
@@ -318,7 +318,7 @@ function editingMetricReducer(state: ISelectedConfigState = null, action: Action
     case Actions.EDIT_METRIC_CANCEL:
       return {
         ...state,
-        metricList: state.metricList.filter(metric => !metric.isNew),
+        metricList: state.metricList.filter((metric) => !metric.isNew),
         editingMetric: null,
       };
 
@@ -353,7 +353,7 @@ export function editGroupConfirmReducer(
   }
 
   const { payload } = action;
-  const allGroups = flatMap(state.metricList, metric => metric.groups);
+  const allGroups = flatMap(state.metricList, (metric) => metric.groups);
   if (!payload.edit || payload.edit === ALL || allGroups.includes(payload.edit)) {
     return state;
   }
@@ -361,7 +361,7 @@ export function editGroupConfirmReducer(
   const metricUpdater = (c: ICanaryMetricConfig): ICanaryMetricConfig => ({
     ...c,
     groups: (c.groups || []).includes(payload.group)
-      ? [payload.edit].concat((c.groups || []).filter(g => g !== payload.group))
+      ? [payload.edit].concat((c.groups || []).filter((g) => g !== payload.group))
       : c.groups,
   });
 
@@ -375,7 +375,7 @@ export function editGroupConfirmReducer(
   };
 
   const listUpdater = (groupList: string[]): string[] =>
-    [payload.edit].concat((groupList || []).filter(g => g !== payload.group));
+    [payload.edit].concat((groupList || []).filter((g) => g !== payload.group));
   return {
     ...state,
     metricList: state.metricList.map(metricUpdater),
@@ -427,7 +427,7 @@ export function updateGroupWeightsReducer(state: ISelectedConfigState, action: A
   }
 
   const groups = chain(state.metricList)
-    .flatMap(metric => metric.groups)
+    .flatMap((metric) => metric.groups)
     .uniq()
     .value();
 
@@ -436,7 +436,7 @@ export function updateGroupWeightsReducer(state: ISelectedConfigState, action: A
 
   // Initialize weights for new groups.
   groupWeights = {
-    ...fromPairs(groups.map(g => [g, 0])),
+    ...fromPairs(groups.map((g) => [g, 0])),
     ...groupWeights,
   };
 

--- a/src/kayenta/reducers/stackdriverMetricConfig.spec.ts
+++ b/src/kayenta/reducers/stackdriverMetricConfig.spec.ts
@@ -20,7 +20,7 @@ describe('Reducer: stackdriverMetricConfigReducer', () => {
     });
 
     it('deletes key/value pair if passed falsy value', () => {
-      [null, undefined, ''].forEach(falsyValue => {
+      [null, undefined, ''].forEach((falsyValue) => {
         const nextState = stackdriverMetricConfigReducer({ query: { crossSeriesReducer: 'REDUCE_NONE' } } as any, {
           type: Actions.UPDATE_STACKDRIVER_METRIC_QUERY_FIELD,
           payload: { field: 'crossSeriesReducer', value: falsyValue },

--- a/src/kayenta/reducers/templates.spec.ts
+++ b/src/kayenta/reducers/templates.spec.ts
@@ -120,7 +120,7 @@ describe('Reducer: selectedConfig (templates)', () => {
         editingTemplate: { name, editedName, editedValue },
       } = reducer(state, createAction(EDIT_TEMPLATE_CONFIRM));
 
-      [name, editedName, editedValue].forEach(value => expect(value).toEqual(null));
+      [name, editedName, editedValue].forEach((value) => expect(value).toEqual(null));
     });
 
     it('deletes a template', () => {

--- a/src/kayenta/reducers/validators.ts
+++ b/src/kayenta/reducers/validators.ts
@@ -29,17 +29,17 @@ const createValidationReducer = (validator: IConfigValidator) => {
   };
 };
 
-const isConfigNameUnique: IConfigValidator = state => {
+const isConfigNameUnique: IConfigValidator = (state) => {
   const selectedConfig = state.selectedConfig.config;
   const configSummaries = state.data.configSummaries;
-  const isUnique = configSummaries.every(s => selectedConfig.name !== s.name || selectedConfig.id === s.id);
+  const isUnique = configSummaries.every((s) => selectedConfig.name !== s.name || selectedConfig.id === s.id);
 
   return isUnique ? null : { message: `Canary config '${selectedConfig.name}' already exists.` };
 };
 
 // See https://github.com/Netflix-Skunkworks/kayenta/blob/master/kayenta-web/src/main/java/com/netflix/kayenta/controllers/CanaryConfigController.java
 const pattern = /^[a-zA-Z0-9_-]*$/;
-const isConfigNameValid: IConfigValidator = state => {
+const isConfigNameValid: IConfigValidator = (state) => {
   const isValid = pattern.test(state.selectedConfig.config.name);
   return isValid
     ? null
@@ -48,7 +48,7 @@ const isConfigNameValid: IConfigValidator = state => {
       };
 };
 
-const isGroupWeightsSumValid: IConfigValidator = state => {
+const isGroupWeightsSumValid: IConfigValidator = (state) => {
   const weights = Object.values(state.selectedConfig.group.groupWeights);
   const sumOfWeights = weights.reduce((sum, weight) => sum + weight, 0);
   const groupWeightsSumIsValid = weights.length === 0 || sumOfWeights === 100;
@@ -56,25 +56,25 @@ const isGroupWeightsSumValid: IConfigValidator = state => {
   return groupWeightsSumIsValid ? null : { message: 'Metric group weights must sum to 100.' };
 };
 
-const isEveryGroupWeightValid: IConfigValidator = state => {
-  const everyGroupWeightIsValid = Object.values(state.selectedConfig.group.groupWeights).every(weight => weight >= 0);
+const isEveryGroupWeightValid: IConfigValidator = (state) => {
+  const everyGroupWeightIsValid = Object.values(state.selectedConfig.group.groupWeights).every((weight) => weight >= 0);
 
   return everyGroupWeightIsValid ? null : { message: 'A group weight must be greater than or equal to 0.' };
 };
 
-const isEveryQueriedMetricStoreAvailable: IConfigValidator = state => {
+const isEveryQueriedMetricStoreAvailable: IConfigValidator = (state) => {
   const available = chain(state.data.kayentaAccounts.data)
-    .filter(account => account.supportedTypes.includes(KayentaAccountType.MetricsStore))
-    .map(account => account.metricsStoreType || account.type)
+    .filter((account) => account.supportedTypes.includes(KayentaAccountType.MetricsStore))
+    .map((account) => account.metricsStoreType || account.type)
     .uniq()
     .valueOf();
 
   const queried = chain(state.selectedConfig.metricList)
-    .map(metric => metric.query.type)
+    .map((metric) => metric.query.type)
     .uniq()
     .valueOf();
 
-  const unavailableQueried = queried.filter(store => !available.includes(store));
+  const unavailableQueried = queried.filter((store) => !available.includes(store));
   let message: string;
   if (unavailableQueried.length === 1) {
     message = `This config contains metrics configured to query a metric
@@ -88,9 +88,9 @@ const isEveryQueriedMetricStoreAvailable: IConfigValidator = state => {
   return unavailableQueried.length ? { message } : null;
 };
 
-const areMultipleMetricStoresQueried: IConfigValidator = state => {
+const areMultipleMetricStoresQueried: IConfigValidator = (state) => {
   const queried = chain(state.selectedConfig.metricList)
-    .map(metric => metric.query.type)
+    .map((metric) => metric.query.type)
     .uniq()
     .valueOf();
 

--- a/src/kayenta/report/detail/allMetricResultsHeader.tsx
+++ b/src/kayenta/report/detail/allMetricResultsHeader.tsx
@@ -13,8 +13,8 @@ export interface IAllMetricResultsHeader {
 }
 
 /*
-* Clickable header for all metric results.
-*/
+ * Clickable header for all metric results.
+ */
 export default ({ className, onClick, score, scoreThresholds }: IAllMetricResultsHeader) => (
   <section className={className}>
     <div

--- a/src/kayenta/report/detail/clickableHeader.tsx
+++ b/src/kayenta/report/detail/clickableHeader.tsx
@@ -11,8 +11,8 @@ export interface IGroupScoreProps {
 }
 
 /*
-* Component for a labeled, clickable, colored header.
-* */
+ * Component for a labeled, clickable, colored header.
+ * */
 export default ({ label, onClick, style, className }: IGroupScoreProps) => (
   <section style={style} onClick={onClick} className={classNames('clickable', 'text-center', 'group-score', className)}>
     <h3 className="heading-3 uppercase label">{label}</h3>

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -8,8 +8,8 @@ import './detail.less';
 import ReportExplanation from './reportExplanation';
 
 /*
-* Layout for report detail view.
-* */
+ * Layout for report detail view.
+ * */
 
 export interface IDetailViewState {
   isExpanded: boolean;

--- a/src/kayenta/report/detail/detailLoader.tsx
+++ b/src/kayenta/report/detail/detailLoader.tsx
@@ -52,7 +52,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>): IResultLoaderDisp
     ),
 });
 
-export default connect(
-  null,
-  mapDispatchToProps,
-)(ResultDetailLoader);
+export default connect(null, mapDispatchToProps)(ResultDetailLoader);

--- a/src/kayenta/report/detail/graph/graph.tsx
+++ b/src/kayenta/report/detail/graph/graph.tsx
@@ -16,8 +16,8 @@ interface IMetricSetPairGraphStateProps {
 const GRAPH_IMPLEMENTATIONS = ['semiotic'];
 
 const MetricSetPairGraph = ({ pair, result, graphType }: IMetricSetPairGraphStateProps) => {
-  const delegates = GRAPH_IMPLEMENTATIONS.map(name => metricSetPairGraphService.getDelegate(name)).filter(d => !!d);
-  const delegate = delegates.find(candidate => candidate.handlesGraphType(graphType));
+  const delegates = GRAPH_IMPLEMENTATIONS.map((name) => metricSetPairGraphService.getDelegate(name)).filter((d) => !!d);
+  const delegate = delegates.find((candidate) => candidate.handlesGraphType(graphType));
   if (!delegate) {
     return <h3 className="heading-3">Could not load graph.</h3>;
   }
@@ -29,7 +29,7 @@ const mapStateToProps = (state: ICanaryState): IMetricSetPairGraphStateProps => 
   const selectedMetric = state.selectedRun.selectedMetric;
   return {
     pair: state.selectedRun.metricSetPair.pair,
-    result: metricResultsSelector(state).find(result => result.id === selectedMetric),
+    result: metricResultsSelector(state).find((result) => result.id === selectedMetric),
     graphType: state.selectedRun.graphType,
   };
 };

--- a/src/kayenta/report/detail/graph/metricSetPairGraph.service.ts
+++ b/src/kayenta/report/detail/graph/metricSetPairGraph.service.ts
@@ -18,18 +18,18 @@ export interface IMetricSetPairGraphProps {
 
 export interface IMetricSetPairGraph {
   /*
-  * Name of the graph implementation, referenced in settings.js.
-  * */
+   * Name of the graph implementation, referenced in settings.js.
+   * */
   name: string;
 
   /*
-  * Returns top-level graph component class.
-  * */
+   * Returns top-level graph component class.
+   * */
   getGraph: () => React.ComponentClass<IMetricSetPairGraphProps>;
 
   /*
-  * Returns true if the graph implementation supports a given graph type.
-  * */
+   * Returns true if the graph implementation supports a given graph type.
+   * */
   handlesGraphType: (type: GraphType) => boolean;
 }
 

--- a/src/kayenta/report/detail/graph/semiotic/boxplot.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/boxplot.tsx
@@ -58,7 +58,7 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
   };
 
   private decorateData = (dataPoints: number[], group: string): IChartDataPoint[] => {
-    return dataPoints.map(dp => ({
+    return dataPoints.map((dp) => ({
       group,
       value: dp,
       color: vizConfig.colors[group],
@@ -246,7 +246,7 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
         r: 3,
         iterations: 50,
       },
-      rExtent: extent(chartData.map(o => o.value)),
+      rExtent: extent(chartData.map((o) => o.value)),
       customHoverBehavior: this.createChartHoverHandler(),
       hoverAnnotation: false,
       annotations: this.defineAnnotations(),

--- a/src/kayenta/report/detail/graph/semiotic/declarations/semiotic.d.ts
+++ b/src/kayenta/report/detail/graph/semiotic/declarations/semiotic.d.ts
@@ -76,8 +76,8 @@ declare module 'semiotic' {
   }
 
   /*
-  * Args supplied by semiotic's OrdinalFrame to client's custom hover event callback function
-  */
+   * Args supplied by semiotic's OrdinalFrame to client's custom hover event callback function
+   */
   export interface IOrFrameHoverArgs<DataPoint> {
     column?: IOrGroup<DataPoint>;
     summary?: IOrPiece<DataPoint>[];
@@ -131,8 +131,8 @@ declare module 'semiotic' {
   }
 
   /*
-  * Args supplied by semiotic's Frame to client's custom annotation function
-  */
+   * Args supplied by semiotic's Frame to client's custom annotation function
+   */
   export interface ISemioticAnnotationArgs<AnnotationData, CategoryData> {
     d: AnnotationData; // client-defined custom annotation data
     i: number; // index

--- a/src/kayenta/report/detail/graph/semiotic/differenceArea.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/differenceArea.tsx
@@ -33,9 +33,9 @@ interface IDifferenceAreaProps extends ISemioticChartProps {
 }
 
 /*
-* Supplemental visualization in the time series view to highlight
-* Canary difference to baseline at any given timestamp
-*/
+ * Supplemental visualization in the time series view to highlight
+ * Canary difference to baseline at any given timestamp
+ */
 export default class DifferenceArea extends React.Component<IDifferenceAreaProps> {
   private margin: IMargin = {
     left: 60,
@@ -123,16 +123,16 @@ export default class DifferenceArea extends React.Component<IDifferenceAreaProps
     const { metricSetPair, parentWidth, millisBaselineSet } = this.props;
 
     /*
-    * Generate the data needed for the graph components
-    */
+     * Generate the data needed for the graph components
+     */
     const { scopes } = metricSetPair;
     const { chartData } = this.getChartData();
     const millisOffset = scopes.experiment.startTimeMillis - scopes.control.startTimeMillis;
     const shouldUseSecondaryXAxis = millisOffset !== 0;
 
     /*
-    * Build the visualization components
-    */
+     * Build the visualization components
+     */
     const xAxisTotalHeight = this.getXAxisTotalHeight(shouldUseSecondaryXAxis);
     const computedConfig = {
       lines: chartData,

--- a/src/kayenta/report/detail/graph/semiotic/histogram.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/histogram.tsx
@@ -54,18 +54,18 @@ export default class Histogram extends React.Component<ISemioticChartProps, IHis
   };
 
   private decorateData = (dataPoints: number[], group: string): IInputDataPoint[] => {
-    return dataPoints.map(dp => ({
+    return dataPoints.map((dp) => ({
       group,
       value: dp,
     }));
   };
 
   /*
-  * Semiotic actually supports histogram as a "summary type" out of the box, but the customization is
-  * currently limited (e.g. it can't display the y-axis ticks & labels)
-  * Hence we're manually generating histogram data using D3 and display it as
-  * a grouped bar chart in semiotic
-  */
+   * Semiotic actually supports histogram as a "summary type" out of the box, but the customization is
+   * currently limited (e.g. it can't display the y-axis ticks & labels)
+   * Hence we're manually generating histogram data using D3 and display it as
+   * a grouped bar chart in semiotic
+   */
   private generateChartData = () => {
     const { metricSetPair } = this.props;
     const filterFunc = (v: IInputDataPoint) => typeof v.value === 'number';
@@ -74,7 +74,7 @@ export default class Histogram extends React.Component<ISemioticChartProps, IHis
     const combinedInput = baselineInput.concat(canaryInput).filter(filterFunc);
 
     const x = scaleLinear()
-      .domain(extent(combinedInput.map(o => o.value)))
+      .domain(extent(combinedInput.map((o) => o.value)))
       .nice();
     const domain = x.domain() as [number, number];
 
@@ -86,11 +86,11 @@ export default class Histogram extends React.Component<ISemioticChartProps, IHis
     const chartData: IChartDataPoint[] = [];
 
     // Convert it to ordinal data format for bar chart in semiotic
-    histogramData.forEach(h => {
+    histogramData.forEach((h) => {
       const { x0, x1 } = h;
       const baselineBin = { group: 'baseline', x0, x1, count: 0 };
       const canaryBin = { group: 'canary', x0, x1, count: 0 };
-      h.forEach(d => (d.group === 'baseline' ? baselineBin.count++ : canaryBin.count++));
+      h.forEach((d) => (d.group === 'baseline' ? baselineBin.count++ : canaryBin.count++));
       chartData.push(baselineBin);
       chartData.push(canaryBin);
     });

--- a/src/kayenta/report/detail/graph/semiotic/index.ts
+++ b/src/kayenta/report/detail/graph/semiotic/index.ts
@@ -5,6 +5,6 @@ const supportedGraphTypes: GraphType[] = [GraphType.TimeSeries, GraphType.Histog
 // Semiotic component registration
 metricSetPairGraphService.register({
   name: 'semiotic',
-  handlesGraphType: type => supportedGraphTypes.includes(type),
+  handlesGraphType: (type) => supportedGraphTypes.includes(type),
   getGraph: () => SemioticGraph,
 });

--- a/src/kayenta/report/detail/graph/semiotic/secondaryTSXAxis.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/secondaryTSXAxis.tsx
@@ -17,10 +17,10 @@ interface ISecondaryTSXAxisProps {
 }
 
 /*
-* Secondary X Axis for Time Series Graph
-* Used when canary and baseline have different start time. We can overlay this axis component
-* on the main graph component
-*/
+ * Secondary X Axis for Time Series Graph
+ * Used when canary and baseline have different start time. We can overlay this axis component
+ * on the main graph component
+ */
 export default class SecondaryTSXAxis extends React.Component<ISecondaryTSXAxisProps> {
   public render() {
     const { margin, width, millisSet, axisLabel, bottomOffset } = this.props;
@@ -44,9 +44,7 @@ export default class SecondaryTSXAxis extends React.Component<ISecondaryTSXAxisP
           <Axis
             className="x axis bottom canary-dual-axis"
             size={[netWidth, axisTickLineHeight]}
-            scale={scaleUtc()
-              .domain(extent)
-              .range(range)}
+            scale={scaleUtc().domain(extent).range(range)}
             orient="bottom"
             label="Canary"
             tickValues={utils.calculateDateTimeTicks(millisSet)}

--- a/src/kayenta/report/detail/graph/semiotic/semioticGraph.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/semioticGraph.tsx
@@ -20,7 +20,7 @@ export default class SemioticGraph extends React.Component<IMetricSetPairGraphPr
       ...this.props,
       parentWidth,
     };
-    const filterInvalidValues = (data: number[]) => data.filter(v => typeof v === 'number');
+    const filterInvalidValues = (data: number[]) => data.filter((v) => typeof v === 'number');
 
     if (filterInvalidValues(control).length === 0 && filterInvalidValues(experiment).length === 0) {
       return <NoValidDataSign />;

--- a/src/kayenta/report/detail/graph/semiotic/timeSeries.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/timeSeries.tsx
@@ -128,12 +128,12 @@ export default class TimeSeries extends React.Component<ISemioticChartProps, ITi
   }
 
   /*
-  *  Generate chart Data
-  * In cases where the start Millis is different betwen canary and baseline, we want to:
-  * 1) If data point count is different, extend the shorter dataset to match the longer one (i.e. match the x extent)
-  * 2) normalize canary timestamp to match baseline timestamps (needed for the tooltip's
-  * voronoi overlay logic in semiotic to work properly)
-  */
+   *  Generate chart Data
+   * In cases where the start Millis is different betwen canary and baseline, we want to:
+   * 1) If data point count is different, extend the shorter dataset to match the longer one (i.e. match the x extent)
+   * 2) normalize canary timestamp to match baseline timestamps (needed for the tooltip's
+   * voronoi overlay logic in semiotic to work properly)
+   */
   private getChartData = (dataSetsAttr: IDataSetsAttributes, metricSetPair: IMetricSetPair) => {
     const { maxDataCount } = dataSetsAttr;
     const { showGroup } = this.state;
@@ -145,12 +145,12 @@ export default class TimeSeries extends React.Component<ISemioticChartProps, ITi
     const stepMillis = scopes.control.stepMillis;
 
     /*
-    * Deriving timestamps for the main line chart: use baseline's ts if baseline group or both groups are selected,
-    * else use canary ts as reference (since we only show 1 x-axis)
-    * Minimap should still consider both groups (hence using baseline's ts as reference)
-    * as we want to maintain brush state when user toggles groups
-    * Finally we also trim out timestamps with invalid values at both ends of the dataset
-    */
+     * Deriving timestamps for the main line chart: use baseline's ts if baseline group or both groups are selected,
+     * else use canary ts as reference (since we only show 1 x-axis)
+     * Minimap should still consider both groups (hence using baseline's ts as reference)
+     * as we want to maintain brush state when user toggles groups
+     * Finally we also trim out timestamps with invalid values at both ends of the dataset
+     */
     const intDataSet: IInterimDataSet[] = chain(Array(maxDataCount).fill(0))
       .map((_, i) => {
         const valueList = groups.map((g: string) => values[dataGroupMap[g]][i]);
@@ -181,7 +181,7 @@ export default class TimeSeries extends React.Component<ISemioticChartProps, ITi
       return {
         label: g,
         color: colors[g],
-        coordinates: dataPoints.filter(d => typeof d.value === 'number'),
+        coordinates: dataPoints.filter((d) => typeof d.value === 'number'),
         coordinatesUnfiltered: dataPoints,
       };
     });
@@ -314,8 +314,8 @@ export default class TimeSeries extends React.Component<ISemioticChartProps, ITi
     const { minimapDataPointsThreshold, minimapHeight } = vizConfig.timeSeries;
 
     /*
-    * Generate the data needed for the graph components
-    */
+     * Generate the data needed for the graph components
+     */
     const baselineStartTimeMillis = metricSetPair.scopes.control.startTimeMillis;
     const canaryStartTimeMillis = metricSetPair.scopes.experiment.startTimeMillis;
     const isStartTimeMillisEqual = baselineStartTimeMillis === canaryStartTimeMillis;
@@ -331,8 +331,8 @@ export default class TimeSeries extends React.Component<ISemioticChartProps, ITi
     const chartData = this.getChartData(dataSetsAttributes, metricSetPair);
 
     /*
-    * Build the visualization components
-    */
+     * Build the visualization components
+     */
     const commonChartProps = this.createCommonChartProps();
     const lineChartProps = this.createLineChartProps(chartData, dataSetsAttributes, commonChartProps);
 

--- a/src/kayenta/report/detail/graph/semiotic/tooltip.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/tooltip.tsx
@@ -10,10 +10,10 @@ export interface ITooltipProps {
 }
 
 /*
-* Custom tooltip component to render on top of any svg component.
-* It creates an invisible pixel and uses react-tooltip library
-* to point to it.
-*/
+ * Custom tooltip component to render on top of any svg component.
+ * It creates an invisible pixel and uses react-tooltip library
+ * to point to it.
+ */
 export default class Tooltip extends React.Component<ITooltipProps> {
   private tooltipTarget: HTMLDivElement;
 
@@ -45,7 +45,7 @@ export default class Tooltip extends React.Component<ITooltipProps> {
 
     return (
       <div style={containerStyle}>
-        <div data-tip={true} data-for={id} style={tooltipTargetStyle} ref={el => (this.tooltipTarget = el)} />
+        <div data-tip={true} data-for={id} style={tooltipTargetStyle} ref={(el) => (this.tooltipTarget = el)} />
         <ReactTooltip id={id} type="light" border={true}>
           {content ? content : null}
         </ReactTooltip>

--- a/src/kayenta/report/detail/graph/semiotic/utils.ts
+++ b/src/kayenta/report/detail/graph/semiotic/utils.ts
@@ -27,12 +27,7 @@ an additional date label is returned, otherwise only a single label showing hour
 */
 export const dateTimeTickFormatter = (d: number) => {
   const m = moment(d);
-  if (
-    m
-      .clone()
-      .startOf('day')
-      .unix() === m.unix()
-  ) {
+  if (m.clone().startOf('day').unix() === m.unix()) {
     return [m.format('HH:mm'), m.format('MMM DD')];
   } else {
     return [m.format('HH:mm')];
@@ -47,11 +42,11 @@ export const calculateDateTimeTicks = (millisSet: number[]) => {
   const maxMillis = millisSet[millisSet.length - 1];
 
   /*
-  * since d3 scale doesn't support custom timezone, we have to:
-  * 1)shift the UTC domain based on the tz,
-  * 2)have d3 calculate the ideal tick values as usual, and
-  * 3)shift back the result
-  */
+   * since d3 scale doesn't support custom timezone, we have to:
+   * 1)shift the UTC domain based on the tz,
+   * 2)have d3 calculate the ideal tick values as usual, and
+   * 3)shift back the result
+   */
   const offsetMillis = moment(minMillis).utcOffset() * 60000;
   const minMillisShifted = minMillis + offsetMillis;
   const maxMillisShifted = maxMillis + offsetMillis;

--- a/src/kayenta/report/detail/graphTypeSelector.tsx
+++ b/src/kayenta/report/detail/graphTypeSelector.tsx
@@ -25,7 +25,7 @@ const GraphTypeSelector = ({
           Graph:
         </label>
       </li>
-      {Object.values(GraphType).map(type => (
+      {Object.values(GraphType).map((type) => (
         <li
           style={selected === type ? { textDecoration: 'underline' } : null}
           key={type}
@@ -46,7 +46,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>): IGraphTypeSelecto
   selectGraphType: (type: GraphType) => dispatch(Creators.selectGraphType({ type })),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GraphTypeSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(GraphTypeSelector);

--- a/src/kayenta/report/detail/groupScores.tsx
+++ b/src/kayenta/report/detail/groupScores.tsx
@@ -26,8 +26,8 @@ interface IGroupScoresDispatchProps {
 }
 
 /*
-* Renders list of group scores.
-* */
+ * Renders list of group scores.
+ * */
 const GroupScores = ({
   groups,
   groupWeights,
@@ -37,7 +37,7 @@ const GroupScores = ({
   selectedGroup,
 }: IGroupScoresOwnProps & IGroupScoresDispatchProps & IGroupScoresStateProps) => (
   <section className={classNames('horizontal', className)}>
-    {groups.map(g => (
+    {groups.map((g) => (
       <ClickableHeader
         key={g.name}
         style={{
@@ -66,7 +66,4 @@ const mapDispatchToProps = (
   ...ownProps,
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GroupScores);
+export default connect(mapStateToProps, mapDispatchToProps)(GroupScores);

--- a/src/kayenta/report/detail/metricResultDetail.tsx
+++ b/src/kayenta/report/detail/metricResultDetail.tsx
@@ -8,9 +8,9 @@ export interface IMetricResultDetailProps {
 }
 
 /*
-* Top-level component for the metric result detail - i.e., the right side of the
-* screen that opens when you click on a metric result.
-* */
+ * Top-level component for the metric result detail - i.e., the right side of the
+ * screen that opens when you click on a metric result.
+ * */
 export default ({ result }: IMetricResultDetailProps) => {
   if (result) {
     return <MetricSetPairLoadStates />;

--- a/src/kayenta/report/detail/metricResultDetailLayout.tsx
+++ b/src/kayenta/report/detail/metricResultDetailLayout.tsx
@@ -6,9 +6,9 @@ import MetricResultActions from './metricResultActions';
 import GraphTypeSelector from './graphTypeSelector';
 
 /*
-* Responsible for layout of the metric result detail view after the metric set
-* pair for the result has loaded successfully.
-* */
+ * Responsible for layout of the metric result detail view after the metric set
+ * pair for the result has loaded successfully.
+ * */
 export default () => (
   <section className="vertical flex-1" style={{ overflowY: 'auto' }}>
     <GraphTypeSelector />

--- a/src/kayenta/report/detail/metricResultStats.tsx
+++ b/src/kayenta/report/detail/metricResultStats.tsx
@@ -21,7 +21,7 @@ export interface IMetricResultStatsStateProps {
 }
 
 const getStats = (run: ICanaryExecutionStatusResult, id: string, target: string): ICanaryAnalysisResultsStats => {
-  const result = run.result.judgeResult.results.find(r => r.id === id);
+  const result = run.result.judgeResult.results.find((r) => r.id === id);
   if (target === 'experiment') {
     return result.experimentMetadata.stats;
   } else if (target === 'control') {
@@ -52,11 +52,11 @@ const ResultMetadataRow = ({ row }: { row: IResultMetadataRow }) => {
 const MetricResultStats = ({ metricConfig, metricSetPair, run }: IMetricResultStatsStateProps) => {
   const tableColumns: Array<ITableColumn<string>> = [
     {
-      getContent: target => <span>{target === 'control' ? 'Baseline' : 'Canary'}</span>,
+      getContent: (target) => <span>{target === 'control' ? 'Baseline' : 'Canary'}</span>,
     },
     {
       label: 'start',
-      getContent: target => <FormattedDate dateIso={metricSetPair.scopes[target].startTimeIso} />,
+      getContent: (target) => <FormattedDate dateIso={metricSetPair.scopes[target].startTimeIso} />,
       hide: () => {
         const request = run.canaryExecutionRequest;
         const configuredControlStart = request.scopes[metricConfig.scopeName].controlScope.start;
@@ -70,19 +70,19 @@ const MetricResultStats = ({ metricConfig, metricSetPair, run }: IMetricResultSt
     },
     {
       label: 'count',
-      getContent: target => <span>{getStats(run, metricSetPair.id, target).count}</span>,
+      getContent: (target) => <span>{getStats(run, metricSetPair.id, target).count}</span>,
     },
     {
       label: 'avg',
-      getContent: target => <span>{round(getStats(run, metricSetPair.id, target).mean, 3)}</span>,
+      getContent: (target) => <span>{round(getStats(run, metricSetPair.id, target).mean, 3)}</span>,
     },
     {
       label: 'max',
-      getContent: target => <span>{round(getStats(run, metricSetPair.id, target).max, 3)}</span>,
+      getContent: (target) => <span>{round(getStats(run, metricSetPair.id, target).max, 3)}</span>,
     },
     {
       label: 'min',
-      getContent: target => <span>{round(getStats(run, metricSetPair.id, target).min, 3)}</span>,
+      getContent: (target) => <span>{round(getStats(run, metricSetPair.id, target).min, 3)}</span>,
     },
   ];
 
@@ -90,7 +90,7 @@ const MetricResultStats = ({ metricConfig, metricSetPair, run }: IMetricResultSt
     {
       label: 'classification reason',
       getContent: () => {
-        const result = run.result.judgeResult.results.find(r => r.id === metricSetPair.id);
+        const result = run.result.judgeResult.results.find((r) => r.id === metricSetPair.id);
 
         if (!result.classificationReason) {
           return null;
@@ -103,10 +103,10 @@ const MetricResultStats = ({ metricConfig, metricSetPair, run }: IMetricResultSt
 
   return (
     <div className="metric-stats vertical">
-      {metadataRows.map(row => (
+      {metadataRows.map((row) => (
         <ResultMetadataRow row={row} key={row.label} />
       ))}
-      <NativeTable columns={tableColumns} rows={['control', 'experiment']} rowKey={row => row} />
+      <NativeTable columns={tableColumns} rows={['control', 'experiment']} rowKey={(row) => row} />
     </div>
   );
 };

--- a/src/kayenta/report/detail/metricResults.tsx
+++ b/src/kayenta/report/detail/metricResults.tsx
@@ -38,12 +38,12 @@ const mapStateToProps = (state: ICanaryState): IMetricResultsStateProps => {
 
   // Build list of metric results to render.
   const filter: (r: ICanaryAnalysisResult) => boolean = selectedGroup
-    ? r => r.groups.includes(selectedGroup)
+    ? (r) => r.groups.includes(selectedGroup)
     : () => true;
 
   return {
     metricResults: Object.values(result.results).filter(filter),
-    selectedMetricResult: Object.values(result.results).find(r => r.id === selectedMetric),
+    selectedMetricResult: Object.values(result.results).find((r) => r.id === selectedMetric),
   };
 };
 

--- a/src/kayenta/report/detail/metricResultsList.tsx
+++ b/src/kayenta/report/detail/metricResultsList.tsx
@@ -64,12 +64,12 @@ const ResultsList = ({
   return (
     <section className="vertical metric-results-list flex-1">
       <Table
-        rowKey={r => r.metricName}
+        rowKey={(r) => r.metricName}
         tableBodyClassName="list-unstyled tabs-vertical flex-1"
-        rowClassName={r => classNames('horizontal', { selected: r.results[0].id === selectedMetric })}
+        rowClassName={(r) => classNames('horizontal', { selected: r.results[0].id === selectedMetric })}
         rows={rows}
         columns={metricResultsColumns}
-        onRowClick={r => select(r.results[0].id)}
+        onRowClick={(r) => select(r.results[0].id)}
         className="flex-1 vertical"
         customRow={buildRowForMetricWithMultipleResults}
       />
@@ -89,7 +89,4 @@ const mapDispatchToProps = (
   ...ownProps,
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ResultsList);
+export default connect(mapStateToProps, mapDispatchToProps)(ResultsList);

--- a/src/kayenta/report/detail/multipleResultsTable.tsx
+++ b/src/kayenta/report/detail/multipleResultsTable.tsx
@@ -30,11 +30,11 @@ const MultipleResultsTable = ({
   selectedResult,
 }: IMultipleResultsTableOwnProps & IMultipleResultsTableStateProps & IMultipleResultsTableDispatchProps) => {
   const tagKeys = chain(results)
-    .flatMap(r => Object.keys(r.tags || {}))
+    .flatMap((r) => Object.keys(r.tags || {}))
     .uniq()
     .value();
 
-  let columns: Array<ITableColumn<ICanaryAnalysisResult>> = tagKeys.map(key => ({
+  let columns: Array<ITableColumn<ICanaryAnalysisResult>> = tagKeys.map((key) => ({
     label: key,
     width: 5,
     getContent: (result: ICanaryAnalysisResult) => <span>{result.tags[key]}</span>,
@@ -57,13 +57,13 @@ const MultipleResultsTable = ({
       columns={columns}
       className="multiple-results-table"
       headerClassName="sticky-header-2"
-      rowClassName={r => classNames('horizontal', { selected: r.id === selectedResult })}
-      rowKey={r =>
+      rowClassName={(r) => classNames('horizontal', { selected: r.id === selectedResult })}
+      rowKey={(r) =>
         Object.entries(r.tags || {})
           .map(([key, value]) => `${key}:${value}`)
           .join(':')
       }
-      onRowClick={r => select(r.id)}
+      onRowClick={(r) => select(r.id)}
     />
   );
 };
@@ -77,7 +77,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>, ownProps: IMultipl
   select: (metricId: string) => dispatch(Creators.selectReportMetric({ metricId })),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MultipleResultsTable);
+export default connect(mapStateToProps, mapDispatchToProps)(MultipleResultsTable);

--- a/src/kayenta/report/detail/reportExplanation.tsx
+++ b/src/kayenta/report/detail/reportExplanation.tsx
@@ -10,12 +10,8 @@ interface IReportMetadata {
   run: ICanaryExecutionStatusResult;
 }
 
-const getReason = (run: ICanaryExecutionStatusResult): string => {
-  if (run && run.result && run.result.judgeResult && run.result.judgeResult.score) {
-    return run.result.judgeResult.score.classificationReason;
-  }
-  return null;
-};
+const getReason = (run: ICanaryExecutionStatusResult): string =>
+  run?.result?.judgeResult?.score?.classificationReason ?? null;
 
 const ReportExplanation = ({ run }: IReportMetadata) => {
   const classificationReason = getReason(run);

--- a/src/kayenta/report/detail/reportMetadata.tsx
+++ b/src/kayenta/report/detail/reportMetadata.tsx
@@ -138,7 +138,7 @@ const ReportMetadata = ({ run }: IReportMetadata) => {
         <div className={`group group-${group.label}`} key={group.label || index}>
           <Label label={group.label || ''} extraClass="label-lg" />
           <ul className="list-unstyled">
-            {group.entries.map(e => (
+            {group.entries.map((e) => (
               <li key={e.label || index}>
                 <Label label={e.label} />
                 {e.popover ? (

--- a/src/kayenta/report/detail/reportScores.tsx
+++ b/src/kayenta/report/detail/reportScores.tsx
@@ -25,8 +25,8 @@ interface IReportScoresDispatchProps {
 }
 
 /*
-* Layout for the report scores.
-* */
+ * Layout for the report scores.
+ * */
 const ReportScores = ({
   groups,
   selectedGroup,
@@ -60,7 +60,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ICanaryState>): IReportScoresDisp
   clearSelectedGroup: () => dispatch(Creators.selectReportMetricGroup({ group: null })),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ReportScores);
+export default connect(mapStateToProps, mapDispatchToProps)(ReportScores);

--- a/src/kayenta/report/list/table.tsx
+++ b/src/kayenta/report/list/table.tsx
@@ -56,7 +56,7 @@ const getScopeLocations = (scopes: ICanaryScopesByName, metrics: ICanaryMetricCo
 const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
   {
     label: 'Summary',
-    getContent: execution => (
+    getContent: (execution) => (
       <div>
         <ReportLink
           configName={execution.config.name}
@@ -80,7 +80,7 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
 
       return (
         <div className="vertical">
-          {locations.map(location => (
+          {locations.map((location) => (
             <span key={location}>{location}</span>
           ))}
         </div>
@@ -89,7 +89,7 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
   },
   {
     label: 'Config',
-    getContent: execution => (
+    getContent: (execution) => (
       <ConfigLink
         configName={execution.config.name}
         executionId={execution.pipelineId}
@@ -115,7 +115,7 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
       if (areScopesIdentical) {
         return (
           <div className="vertical" style={styles}>
-            {[...canaryScopeNames].map(scope => (
+            {[...canaryScopeNames].map((scope) => (
               <span key={scope}>{scope}</span>
             ))}
           </div>
@@ -124,13 +124,13 @@ const columns: Array<ITableColumn<ICanaryExecutionStatusResult>> = [
         return (
           <div className="vertical" style={styles}>
             <span className="heading-6 uppercase color-text-caption">Baseline</span>
-            {[...baselineScopeNames].map(scope => (
+            {[...baselineScopeNames].map((scope) => (
               <span key={scope}>{scope}</span>
             ))}
             <span className="heading-6 uppercase color-text-caption" style={{ marginTop: '5px' }}>
               Canary
             </span>
-            {[...canaryScopeNames].map(scope => (
+            {[...canaryScopeNames].map((scope) => (
               <span key={scope}>{scope}</span>
             ))}
           </div>
@@ -185,14 +185,14 @@ const ExecutionListTable = ({ executions, application, accounts }: IExecutionLis
         rows={executions}
         className="flex-1 execution-list-table"
         columns={columns}
-        rowKey={execution => execution.pipelineId}
+        rowKey={(execution) => execution.pipelineId}
       />
     </div>
   );
 };
 
 const mapStateToProps = (state: ICanaryState) => ({
-  executions: Object.values(state.data.executions.data).filter(e => e.result),
+  executions: Object.values(state.data.executions.data).filter((e) => e.result),
   application: state.data.application,
   accounts: state.data.kayentaAccounts.data,
 });

--- a/src/kayenta/selectors/filterTemplatesSelectors.ts
+++ b/src/kayenta/selectors/filterTemplatesSelectors.ts
@@ -29,18 +29,18 @@ export const queryTypeToTransformFunctions: { [queryType: string]: ITemplateTran
 
 export const queryTypeSelector = createSelector(
   (state: ICanaryState) => state.selectedConfig.editingMetric,
-  editingMetric => {
+  (editingMetric) => {
     return editingMetric && editingMetric.query.serviceType === 'prometheus'
       ? getPrometheusQueryType(editingMetric)
       : null;
   },
 );
 
-export const transformInlineTemplateForDisplay = createSelector(queryTypeSelector, queryType =>
+export const transformInlineTemplateForDisplay = createSelector(queryTypeSelector, (queryType) =>
   get(queryTypeToTransformFunctions, [queryType, 'fromValue'], identity),
 );
 
-export const transformInlineTemplateForSave = createSelector(queryTypeSelector, queryType =>
+export const transformInlineTemplateForSave = createSelector(queryTypeSelector, (queryType) =>
   get(queryTypeToTransformFunctions, [queryType, 'toValue'], identity),
 );
 
@@ -67,15 +67,15 @@ export const editingTemplateValidationSelector = createSelector(
     }),
 );
 
-export const isFilterTemplateValidSelector = createSelector(editingTemplateValidationSelector, validation =>
+export const isFilterTemplateValidSelector = createSelector(editingTemplateValidationSelector, (validation) =>
   isEmpty(Object.keys(validation.errors)),
 );
 
-export const isInlineTemplateValidSelector = createSelector(inlineTemplateValueSelector, value => !isEmpty(value));
+export const isInlineTemplateValidSelector = createSelector(inlineTemplateValueSelector, (value) => !isEmpty(value));
 
 const inlineTemplateQueryTypes = [PrometheusQueryType.PROMQL];
 
-export const useInlineTemplateEditorSelector = createSelector(queryTypeSelector, queryType =>
+export const useInlineTemplateEditorSelector = createSelector(queryTypeSelector, (queryType) =>
   inlineTemplateQueryTypes.includes(queryType),
 );
 

--- a/src/kayenta/selectors/index.ts
+++ b/src/kayenta/selectors/index.ts
@@ -8,15 +8,15 @@ import { validateMetric } from '../edit/editMetricValidation';
 
 export const runSelector = (state: ICanaryState): ICanaryExecutionStatusResult => state.selectedRun.run;
 
-export const judgeResultSelector = createSelector(runSelector, run => run.result.judgeResult);
+export const judgeResultSelector = createSelector(runSelector, (run) => run.result.judgeResult);
 
-export const configIdSelector = createSelector(runSelector, run => run.config.id);
+export const configIdSelector = createSelector(runSelector, (run) => run.config.id);
 
-export const metricResultsSelector = createSelector(runSelector, run => run.result.judgeResult.results);
+export const metricResultsSelector = createSelector(runSelector, (run) => run.result.judgeResult.results);
 
-export const canaryExecutionRequestSelector = createSelector(runSelector, run => run.canaryExecutionRequest);
+export const canaryExecutionRequestSelector = createSelector(runSelector, (run) => run.canaryExecutionRequest);
 
-export const serializedCanaryConfigSelector = createSelector(runSelector, run => run.config);
+export const serializedCanaryConfigSelector = createSelector(runSelector, (run) => run.config);
 
 export const serializedGroupWeightsSelector = createSelector(
   serializedCanaryConfigSelector,
@@ -28,27 +28,26 @@ export const selectedMetricResultIdSelector = (state: ICanaryState): string => s
 export const selectedMetricResultSelector = createSelector(
   selectedMetricResultIdSelector,
   metricResultsSelector,
-  (id, results) => results.find(result => result.id === id),
+  (id, results) => results.find((result) => result.id === id),
 );
 
 export const selectedMetricConfigSelector = createSelector(
   selectedMetricResultSelector,
   serializedCanaryConfigSelector,
-  (metric, config) => config.metrics.find(m => m.name === metric.name),
+  (metric, config) => config.metrics.find((m) => m.name === metric.name),
 );
 
 export const selectedConfigSelector = (state: ICanaryState) => state.selectedConfig.config;
 
-export const configTemplatesSelector = createSelector(
-  selectedConfigSelector,
-  config => (config ? config.templates : null),
+export const configTemplatesSelector = createSelector(selectedConfigSelector, (config) =>
+  config ? config.templates : null,
 );
 
 export const editingTemplateSelector = (state: ICanaryState) => state.selectedConfig.editingTemplate;
 
 export const resolveConfigIdFromExecutionId = (state: ICanaryState, executionId: string): string => {
   const executions = get(state, ['data', 'executions', 'data'], []);
-  const execution = executions.find(ex => ex.pipelineId === executionId);
+  const execution = executions.find((ex) => ex.pipelineId === executionId);
   return execution.canaryConfigId;
 };
 

--- a/src/kayenta/service/canaryConfig.service.ts
+++ b/src/kayenta/service/canaryConfig.service.ts
@@ -23,15 +23,11 @@ export function getCanaryConfigById(id: string): Promise<ICanaryConfig> {
 }
 
 export function getCanaryConfigSummaries(...application: string[]): Promise<ICanaryConfigSummary[]> {
-  return API.one('v2/canaryConfig')
-    .withParams({ application })
-    .get();
+  return API.one('v2/canaryConfig').withParams({ application }).get();
 }
 
 export function updateCanaryConfig(config: ICanaryConfig): Promise<ICanaryConfigUpdateResponse> {
-  return API.one('v2/canaryConfig')
-    .one(config.id)
-    .put(config);
+  return API.one('v2/canaryConfig').one(config.id).put(config);
 }
 
 export function createCanaryConfig(config: ICanaryConfig): Promise<ICanaryConfigUpdateResponse> {
@@ -39,21 +35,17 @@ export function createCanaryConfig(config: ICanaryConfig): Promise<ICanaryConfig
 }
 
 export function deleteCanaryConfig(id: string): Promise<void> {
-  return API.one('v2/canaryConfig')
-    .one(id)
-    .remove();
+  return API.one('v2/canaryConfig').one(id).remove();
 }
 
 export function listJudges(): Promise<IJudge[]> {
   return API.one('v2/canaries/judges')
     .get()
-    .then((judges: IJudge[]) => judges.filter(judge => judge.visible));
+    .then((judges: IJudge[]) => judges.filter((judge) => judge.visible));
 }
 
 export function listKayentaAccounts(): Promise<IKayentaAccount[]> {
-  return API.one('v2/canaries/credentials')
-    .useCache()
-    .get();
+  return API.one('v2/canaries/credentials').useCache().get();
 }
 
 // Not sure if this is the right way to go about this. We have pieces of the config
@@ -65,7 +57,7 @@ export function mapStateToConfig(state: ICanaryState): ICanaryConfig {
     return {
       ...selectedConfig.config,
       judge: selectedConfig.judge.judgeConfig,
-      metrics: selectedConfig.metricList.map(metric => omit(metric, 'id')),
+      metrics: selectedConfig.metricList.map((metric) => omit(metric, 'id')),
       classifier: {
         ...selectedConfig.config.classifier,
         groupWeights: selectedConfig.group.groupWeights,
@@ -79,7 +71,7 @@ export function mapStateToConfig(state: ICanaryState): ICanaryConfig {
 export function buildNewConfig(state: ICanaryState): ICanaryConfig {
   let configName = 'new-config';
   let i = 1;
-  while ((state.data.configSummaries || []).some(summary => summary.name === configName)) {
+  while ((state.data.configSummaries || []).some((summary) => summary.name === configName)) {
     configName = `new-config-${i}`;
     i++;
   }
@@ -114,7 +106,7 @@ export function buildConfigCopy(state: ICanaryState): ICanaryConfig {
   // Probably a rare case, but someone could be lazy about naming their configs.
   let configName = `${config.name}-copy`;
   let i = 1;
-  while ((state.data.configSummaries || []).some(summary => summary.name === configName)) {
+  while ((state.data.configSummaries || []).some((summary) => summary.name === configName)) {
     configName = `${config.name}-copy-${i}`;
     i++;
   }

--- a/src/kayenta/service/canaryRun.service.ts
+++ b/src/kayenta/service/canaryRun.service.ts
@@ -31,10 +31,7 @@ export const startCanaryRun = (
   executionRequest: ICanaryExecutionRequest,
   params: ICanaryExecutionRequestParams = {},
 ): Promise<ICanaryExecutionResponse> => {
-  return API.one('v2/canaries/canary')
-    .one(configId)
-    .withParams(params)
-    .post(executionRequest);
+  return API.one('v2/canaries/canary').one(configId).withParams(params).post(executionRequest);
 };
 
 export const getMetricSetPair = (metricSetPairListId: string, metricSetPairId: string): Promise<IMetricSetPair> =>
@@ -43,7 +40,7 @@ export const getMetricSetPair = (metricSetPairListId: string, metricSetPairId: s
     .withParams({ storageAccountName: CanarySettings.storageAccountName })
     .useCache()
     .get()
-    .then((list: IMetricSetPair[]) => list.find(pair => pair.id === metricSetPairId));
+    .then((list: IMetricSetPair[]) => list.find((pair) => pair.id === metricSetPairId));
 
 export const listCanaryExecutions = (
   application: string,
@@ -51,11 +48,7 @@ export const listCanaryExecutions = (
   statuses?: string,
   storageAccountName?: string,
 ): Promise<ICanaryExecutionStatusResult[]> =>
-  API.one('v2/canaries')
-    .one(application)
-    .one('executions')
-    .withParams({ limit, statuses, storageAccountName })
-    .get();
+  API.one('v2/canaries').one(application).one('executions').withParams({ limit, statuses, storageAccountName }).get();
 
 export const getHealthLabel = (health: string, result: string): string => {
   const healthLC = (health || '').toLowerCase();
@@ -63,8 +56,8 @@ export const getHealthLabel = (health: string, result: string): string => {
   return healthLC === 'unhealthy'
     ? 'unhealthy'
     : resultLC === 'success'
-      ? 'healthy'
-      : resultLC === 'failure'
-        ? 'failing'
-        : 'unknown';
+    ? 'healthy'
+    : resultLC === 'failure'
+    ? 'failing'
+    : 'unknown';
 };

--- a/src/kayenta/service/delegateFactory.ts
+++ b/src/kayenta/service/delegateFactory.ts
@@ -11,7 +11,7 @@ export const buildDelegateService = <T extends IDelegate>() => {
     }
 
     public getDelegate(name: string): T {
-      return this.delegates.find(d => d.name === name);
+      return this.delegates.find((d) => d.name === name);
     }
   }
 

--- a/src/kayenta/service/metricsServiceMetadata.service.ts
+++ b/src/kayenta/service/metricsServiceMetadata.service.ts
@@ -6,6 +6,4 @@ export const listMetricsServiceMetadata = (
   filter?: string,
   metricsAccountName?: string,
 ): Promise<IMetricsServiceMetadata[]> =>
-  API.one('v2/canaries/metadata/metricsService')
-    .withParams({ filter, metricsAccountName })
-    .get();
+  API.one('v2/canaries/metadata/metricsService').withParams({ filter, metricsAccountName }).get();

--- a/src/kayenta/stages/kayentaStage/AnalysisType.spec.tsx
+++ b/src/kayenta/stages/kayentaStage/AnalysisType.spec.tsx
@@ -5,7 +5,7 @@ import { KayentaAnalysisType } from 'kayenta/domain';
 import { AnalysisType, AnalysisTypeWarning, IAnalysisTypeProps } from './AnalysisType';
 
 describe('<AnalysisType />', () => {
-  const component = (props: IAnalysisTypeProps) => mount(<AnalysisType {...props} /> as any);
+  const component = (props: IAnalysisTypeProps) => mount((<AnalysisType {...props} />) as any);
 
   const tests = [
     {
@@ -41,7 +41,7 @@ describe('<AnalysisType />', () => {
     },
   ];
 
-  tests.forEach(test => {
+  tests.forEach((test) => {
     it(test.it, () => test.assertion(component(test.props)));
   });
 });

--- a/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
+++ b/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
@@ -23,7 +23,7 @@ export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICana
   const canaryRunColumns: Array<ITableColumn<IStage>> = [
     {
       label: 'Canary Result',
-      getContent: run => {
+      getContent: (run) => {
         return (
           <>
             <CanaryScore
@@ -44,14 +44,14 @@ export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICana
     },
     {
       label: 'Duration',
-      getContent: run => <span>{run.context.durationString || ' - '}</span>,
+      getContent: (run) => <span>{run.context.durationString || ' - '}</span>,
     },
     {
       label: 'Last Updated',
-      getContent: run => <span>{timestamp(run.context.lastUpdated)}</span>,
+      getContent: (run) => <span>{timestamp(run.context.lastUpdated)}</span>,
     },
     {
-      getContent: run => {
+      getContent: (run) => {
         const popoverTemplate = <CanaryRunTimestamps canaryRun={run} firstScopeName={firstScopeName} />;
         return (
           <section className="horizontal text-center">
@@ -75,7 +75,7 @@ export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICana
         rows={canaryRuns}
         className="header-transparent flex-1"
         columns={canaryRunColumns}
-        rowKey={run => run.id}
+        rowKey={(run) => run.id}
       />
     </Styleguide>
   );

--- a/src/kayenta/stages/kayentaStage/forAnalysisType.component.ts
+++ b/src/kayenta/stages/kayentaStage/forAnalysisType.component.ts
@@ -16,7 +16,7 @@ class ForAnalysisTypeController implements IComponentController {
 
     return (this.types || '')
       .split(',')
-      .map(type => {
+      .map((type) => {
         const val = type.trim() as KayentaAnalysisType;
         if (
           ![

--- a/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.controller.ts
@@ -195,7 +195,7 @@ export class KayentaStageController implements IComponentController {
         delete this.stage.deployments;
 
         if (this.metricStore === 'atlas') {
-          this.stage.canaryConfig.scopes.forEach(scope => {
+          this.stage.canaryConfig.scopes.forEach((scope) => {
             unset(scope, 'extendedScopeParams.dataset');
             unset(scope, 'extendedScopeParams.environment');
           });
@@ -215,7 +215,7 @@ export class KayentaStageController implements IComponentController {
         delete this.stage.deployments;
 
         if (this.metricStore === 'atlas') {
-          this.stage.canaryConfig.scopes.forEach(scope => {
+          this.stage.canaryConfig.scopes.forEach((scope) => {
             unset(scope, 'extendedScopeParams.dataset');
             unset(scope, 'extendedScopeParams.environment');
           });
@@ -265,7 +265,7 @@ export class KayentaStageController implements IComponentController {
       this.setAtlasScopeParams();
       this.$scope.$applyAsync();
     } else {
-      this.stage.canaryConfig.scopes.forEach(scope => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
         unset(scope, 'extendedScopeParams.type');
       });
     }
@@ -278,14 +278,14 @@ export class KayentaStageController implements IComponentController {
     if (!isRealTimeAutomatic) {
       this.state.atlasScopeType = existingScopeType !== 'asg' ? existingScopeType : 'cluster';
     }
-    this.stage.canaryConfig.scopes.forEach(scope => {
+    this.stage.canaryConfig.scopes.forEach((scope) => {
       set(scope, 'extendedScopeParams.type', isRealTimeAutomatic ? 'asg' : this.state.atlasScopeType);
     });
 
     if (isRealTimeAutomatic) {
       this.state.useAtlasGlobalDataset =
         get(this.stage.canaryConfig.scopes[0], 'extendedScopeParams.dataset') === 'global';
-      this.stage.canaryConfig.scopes.forEach(scope => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
         set(scope, 'extendedScopeParams.dataset', this.state.useAtlasGlobalDataset ? 'global' : 'regional');
       });
     }
@@ -301,7 +301,7 @@ export class KayentaStageController implements IComponentController {
     this.state.showAllLocations.control = this.state.showAllLocations.experiment =
       recommendedLocations.length === 0 && locations.length > 0;
 
-    this.stage.canaryConfig.scopes.forEach(scope => {
+    this.stage.canaryConfig.scopes.forEach((scope) => {
       if (!recommendedLocations.includes(scope.controlLocation) && !locations.includes(scope.controlLocation)) {
         delete scope.controlLocation;
       } else if (!recommendedLocations.includes(scope.controlLocation)) {
@@ -348,15 +348,15 @@ export class KayentaStageController implements IComponentController {
       this.state.showAllLocations.control
         ? allLocations
         : selectedAccount.recommendedLocations.length > 0
-          ? selectedAccount.recommendedLocations
-          : selectedAccount.locations,
+        ? selectedAccount.recommendedLocations
+        : selectedAccount.locations,
     );
     const experiment = uniq(
       this.state.showAllLocations.experiment
         ? allLocations
         : selectedAccount.recommendedLocations.length > 0
-          ? selectedAccount.recommendedLocations
-          : selectedAccount.locations,
+        ? selectedAccount.recommendedLocations
+        : selectedAccount.locations,
     );
 
     return {
@@ -375,7 +375,7 @@ export class KayentaStageController implements IComponentController {
 
     const locationChoices = this.getLocationChoices();
 
-    this.stage.canaryConfig.scopes.forEach(scope => {
+    this.stage.canaryConfig.scopes.forEach((scope) => {
       if (!locationChoices.combinedLocations.control.includes(scope.controlLocation)) {
         delete scope.controlLocation;
       }
@@ -390,7 +390,7 @@ export class KayentaStageController implements IComponentController {
       return;
     }
 
-    const scopeNames = uniq(map(this.selectedCanaryConfigDetails.metrics, metric => metric.scopeName || 'default'));
+    const scopeNames = uniq(map(this.selectedCanaryConfigDetails.metrics, (metric) => metric.scopeName || 'default'));
     this.scopeNames = !isEmpty(scopeNames) ? scopeNames : ['default'];
     this.setShowAdvancedSettings();
 
@@ -405,8 +405,8 @@ export class KayentaStageController implements IComponentController {
     const mapped = new Map<KayentaAccountType, IKayentaAccount[]>();
     const accounts = await listKayentaAccounts();
 
-    accounts.forEach(account => {
-      account.supportedTypes.forEach(type => {
+    accounts.forEach((account) => {
+      account.supportedTypes.forEach((type) => {
         if (mapped.has(type)) {
           mapped.set(type, mapped.get(type).concat([account]));
         } else {
@@ -421,14 +421,14 @@ export class KayentaStageController implements IComponentController {
   private deleteConfigAccountsIfMissing = (): void => {
     if (
       (this.kayentaAccounts.get(KayentaAccountType.ObjectStore) || []).every(
-        account => account.name !== this.stage.canaryConfig.storageAccountName,
+        (account) => account.name !== this.stage.canaryConfig.storageAccountName,
       )
     ) {
       delete this.stage.canaryConfig.storageAccountName;
     }
     if (
       (this.kayentaAccounts.get(KayentaAccountType.MetricsStore) || []).every(
-        account => account.name !== this.stage.canaryConfig.metricsAccountName,
+        (account) => account.name !== this.stage.canaryConfig.metricsAccountName,
       )
     ) {
       delete this.stage.canaryConfig.metricsAccountName;
@@ -436,7 +436,7 @@ export class KayentaStageController implements IComponentController {
   };
 
   private deleteCanaryConfigIdIfMissing = (): void => {
-    if (this.canaryConfigSummaries.every(s => s.id !== this.stage.canaryConfig.canaryConfigId)) {
+    if (this.canaryConfigSummaries.every((s) => s.id !== this.stage.canaryConfig.canaryConfigId)) {
       delete this.stage.canaryConfig.canaryConfigId;
     }
   };
@@ -485,7 +485,7 @@ export class KayentaStageController implements IComponentController {
   };
 
   private loadProviders = async (): Promise<string[]> => {
-    this.providers = (await AccountService.listProviders(this.$scope.application)).filter(p =>
+    this.providers = (await AccountService.listProviders(this.$scope.application)).filter((p) =>
       REAL_TIME_AUTOMATIC_PROVIDERS.includes(p),
     );
     // If none of the application's providers support real time automatic mode, don't show it!
@@ -511,10 +511,8 @@ export class KayentaStageController implements IComponentController {
   };
 
   private setClusterList = (): void => {
-    this.clusterList = AppListExtractor.getClusters(
-      [this.$scope.application],
-      sg =>
-        has(this.stage, 'deployments.baseline.account') ? sg.account === this.stage.deployments.baseline.account : true,
+    this.clusterList = AppListExtractor.getClusters([this.$scope.application], (sg) =>
+      has(this.stage, 'deployments.baseline.account') ? sg.account === this.stage.deployments.baseline.account : true,
     );
 
     this.setAtlasEnvironment();
@@ -522,7 +520,7 @@ export class KayentaStageController implements IComponentController {
 
   private setAtlasEnvironment = (): void => {
     if (this.metricStore === 'atlas' && this.stage.analysisType === KayentaAnalysisType.RealTimeAutomatic) {
-      this.stage.canaryConfig.scopes.forEach(scope => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
         if (this.stage.deployments.baseline.account) {
           const accountDetails = this.accounts.find(({ name }) => this.stage.deployments.baseline.account === name);
           accountDetails && set(scope, 'extendedScopeParams.environment', accountDetails.environment);
@@ -550,7 +548,7 @@ export class KayentaStageController implements IComponentController {
       set(
         this.stage.canaryConfig,
         'siteLocal.notificationEmail',
-        this.state.legacySiteLocalRecipients.split(',').map(email => email.trim()),
+        this.state.legacySiteLocalRecipients.split(',').map((email) => email.trim()),
       );
     } else {
       delete this.stage.canaryConfig.siteLocal;
@@ -743,7 +741,7 @@ export class KayentaStageController implements IComponentController {
   public handleAtlasDatasetChange = (event: Event): void => {
     const { checked } = event.target as HTMLInputElement;
     this.$scope.$applyAsync(() => {
-      this.stage.canaryConfig.scopes.forEach(scope => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
         set(scope, 'extendedScopeParams.dataset', checked ? 'global' : 'regional');
         set(
           scope,
@@ -756,7 +754,7 @@ export class KayentaStageController implements IComponentController {
 
   public onAtlasScopeTypeChange = (): void => {
     this.$scope.$applyAsync(() => {
-      this.stage.canaryConfig.scopes.forEach(scope => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
         set(scope, 'extendedScopeParams.type', this.state.atlasScopeType);
       });
     });
@@ -767,7 +765,7 @@ export class KayentaStageController implements IComponentController {
       return;
     }
 
-    this.stage.canaryConfig.scopes.forEach(scope => {
+    this.stage.canaryConfig.scopes.forEach((scope) => {
       set(
         scope,
         'extendedScopeParams.type',
@@ -776,7 +774,7 @@ export class KayentaStageController implements IComponentController {
     });
 
     if (this.stage.analysisType === KayentaAnalysisType.RealTimeAutomatic) {
-      this.stage.canaryConfig.scopes.forEach(scope => {
+      this.stage.canaryConfig.scopes.forEach((scope) => {
         set(scope, 'extendedScopeParams.dataset', this.state.useAtlasGlobalDataset ? 'global' : 'regional');
       });
       this.setAtlasEnvironment();

--- a/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.transformer.ts
@@ -15,7 +15,7 @@ export class KayentaStageTransformer implements ITransformer {
 
     let stagesToRenderAsTasks: IExecutionStage[] = [];
 
-    execution.stages.forEach(stage => {
+    execution.stages.forEach((stage) => {
       if (stage.type === KAYENTA_CANARY) {
         OrchestratedItemTransformer.defineProperties(stage);
 
@@ -29,8 +29,8 @@ export class KayentaStageTransformer implements ITransformer {
 
         stagesToRenderAsTasks = stagesToRenderAsTasks.concat(syntheticCanaryStages);
 
-        const runCanaryStages = syntheticCanaryStages.filter(s => s.type === RUN_CANARY);
-        syntheticCanaryStages.forEach(syntheticStage => OrchestratedItemTransformer.defineProperties(syntheticStage));
+        const runCanaryStages = syntheticCanaryStages.filter((s) => s.type === RUN_CANARY);
+        syntheticCanaryStages.forEach((syntheticStage) => OrchestratedItemTransformer.defineProperties(syntheticStage));
         this.calculateRunCanaryResults(runCanaryStages);
         this.calculateKayentaCanaryResults(stage, syntheticCanaryStages);
 
@@ -53,7 +53,7 @@ export class KayentaStageTransformer implements ITransformer {
       ({ parentStageId, type }) => kayentaStageIds.includes(parentStageId) && type === DEPLOY_CANARY_SERVER_GROUPS,
     );
 
-    deployCanaryServerGroupsStages.forEach(deployCanaryStage => {
+    deployCanaryServerGroupsStages.forEach((deployCanaryStage) => {
       const parentKayentaStage = kayentaStages.find(({ id }) => deployCanaryStage.parentStageId === id);
       if (parentKayentaStage && (deployCanaryStage.outputs.deployedServerGroups || []).length) {
         const [{ controlScope, experimentScope }] = deployCanaryStage.outputs.deployedServerGroups;
@@ -61,7 +61,7 @@ export class KayentaStageTransformer implements ITransformer {
       }
     });
     execution.stages = execution.stages.filter(
-      stage =>
+      (stage) =>
         !stagesToRenderAsTasks.includes(stage) &&
         (!this.isDescendantOf(stage, kayentaStages, execution) ||
           stageTypesToAlwaysShow.includes(stage.type) ||
@@ -86,7 +86,7 @@ export class KayentaStageTransformer implements ITransformer {
 
   // Massages each runCanary stage into what the `canaryScore` component expects.
   private calculateRunCanaryResults(runCanaryStages: IExecutionStage[]): void {
-    runCanaryStages.forEach(run => {
+    runCanaryStages.forEach((run) => {
       if (typeof run.getValueFor('canaryScore') === 'number') {
         if (run.status === 'SUCCEEDED') {
           if (run.context.canaryScore >= run.context.scoreThresholds.pass) {
@@ -134,20 +134,20 @@ export class KayentaStageTransformer implements ITransformer {
 
   private getLastCanaryRunScore(runCanaryStages: IExecutionStage[] = []): number {
     const canaryRunScores = runCanaryStages
-      .filter(s => typeof s.getValueFor('canaryScore') === 'number')
-      .map(s => s.getValueFor('canaryScore'));
+      .filter((s) => typeof s.getValueFor('canaryScore') === 'number')
+      .map((s) => s.getValueFor('canaryScore'));
     return last(canaryRunScores);
   }
 
   private getLastCanaryScoreMessage(runCanaryStages: IExecutionStage[] = []): number {
     const canaryRunMessages = runCanaryStages
-      .filter(s => s.getValueFor('canaryScoreMessage'))
-      .map(s => s.getValueFor('canaryScoreMessage'));
+      .filter((s) => s.getValueFor('canaryScoreMessage'))
+      .map((s) => s.getValueFor('canaryScoreMessage'));
     return last(canaryRunMessages);
   }
 
   private addExceptions(stages: IExecutionStage[], exceptions: string[]): void {
-    stages.forEach(stage => {
+    stages.forEach((stage) => {
       if (this.getException(stage)) {
         exceptions.push(this.getException(stage));
       }

--- a/src/kayenta/stages/kayentaStage/kayentaStage.ts
+++ b/src/kayenta/stages/kayentaStage/kayentaStage.ts
@@ -40,8 +40,8 @@ const requiredForAnalysisTypes = (
 };
 
 const allScopesMustBeConfigured = (_pipeline: IPipeline, stage: IKayentaStage): Promise<string> => {
-  return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then(configDetails => {
-    let definedScopeNames = uniq(map(configDetails.metrics, metric => metric.scopeName || 'default'));
+  return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then((configDetails) => {
+    let definedScopeNames = uniq(map(configDetails.metrics, (metric) => metric.scopeName || 'default'));
     definedScopeNames = !isEmpty(definedScopeNames) ? definedScopeNames : ['default'];
 
     const configureScopedNames: string[] = map(get(stage, 'canaryConfig.scopes'), 'scopeName');
@@ -58,8 +58,8 @@ const allScopesMustBeConfigured = (_pipeline: IPipeline, stage: IKayentaStage): 
 };
 
 const allConfiguredScopesMustBeDefined = (_pipeline: IPipeline, stage: IKayentaStage): Promise<string> => {
-  return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then(configDetails => {
-    let definedScopeNames = uniq(map(configDetails.metrics, metric => metric.scopeName || 'default'));
+  return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then((configDetails) => {
+    let definedScopeNames = uniq(map(configDetails.metrics, (metric) => metric.scopeName || 'default'));
     definedScopeNames = !isEmpty(definedScopeNames) ? definedScopeNames : ['default'];
 
     const configureScopedNames: string[] = map(get(stage, 'canaryConfig.scopes'), 'scopeName');
@@ -68,9 +68,7 @@ const allConfiguredScopesMustBeDefined = (_pipeline: IPipeline, stage: IKayentaS
     if (missingScopeNames.length > 1) {
       return `Scopes <strong>${missingScopeNames.join()}</strong> are configured but are not defined in the canary configuration.`;
     } else if (missingScopeNames.length === 1) {
-      return `Scope <strong>${
-        missingScopeNames[0]
-      }</strong> is configured but is not defined in the canary configuration.`;
+      return `Scope <strong>${missingScopeNames[0]}</strong> is configured but is not defined in the canary configuration.`;
     } else {
       return null;
     }
@@ -175,7 +173,7 @@ module(KAYENTA_CANARY_STAGE, [
               return null;
             }
 
-            return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then(configDetails => {
+            return getCanaryConfigById(get(stage, 'canaryConfig.canaryConfigId')).then((configDetails) => {
               if (
                 get(configDetails, 'metrics[0].query.type') === 'atlas' &&
                 !get(stage, 'canaryConfig.scopes[0].extendedScopeParams.type')
@@ -206,7 +204,7 @@ module(KAYENTA_CANARY_STAGE, [
               return null;
             }
             const emails = Array.isArray(notificationEmail) ? notificationEmail : [notificationEmail];
-            const invalidEmail = emails.find(email => !isValidEmail(email));
+            const invalidEmail = emails.find((email) => !isValidEmail(email));
             return invalidEmail ? `Invalid <strong>Notification Email</strong> (${invalidEmail})` : null;
           },
         },

--- a/src/kayenta/utils/duration.spec.ts
+++ b/src/kayenta/utils/duration.spec.ts
@@ -48,7 +48,7 @@ describe('Duration utils', () => {
       });
     });
     it('handles invalid input', () => {
-      invalidDurationStrings.forEach(durationString => {
+      invalidDurationStrings.forEach((durationString) => {
         expect(parseDurationString(durationString)).toEqual(defaultDurationObject);
       });
     });
@@ -61,7 +61,7 @@ describe('Duration utils', () => {
       });
     });
     it('handles invalid input', () => {
-      invalidDurationObjects.forEach(durationObject => {
+      invalidDurationObjects.forEach((durationObject) => {
         expect(getDurationString(durationObject)).toEqual(defaultDurationString);
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7528,10 +7528,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-error@^2.0.2:
   version "2.1.0"


### PR DESCRIPTION
The version of prettier that was running was too old to understand the newer typescript features like optional chaining, this does an upgrade to the latest version and formats all the files. also moved code from a recent PR that exposed this issue to use optional chaining.