### PR TITLE
fix(tooltip): fixed uncaught invariant violation, when deck-kayenta is used in custom deck wrapper

### DIFF
--- a/src/kayenta/report/detail/graph/semiotic/tooltip.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactTooltip from 'react-tooltip';
+import ReactTooltip from 'react-tooltip';
 
 export interface ITooltipProps {
   x?: number;


### PR DESCRIPTION
Running into the following error with v0.0.89 in our custom deck wrapper project

![image](https://user-images.githubusercontent.com/711726/83930426-66118a00-a74c-11ea-9119-10efaf1f8fb9.png)

I was able to fix it by checking out the v0.0.89 code base and adding the following patch.

https://github.com/spinnaker/deck-kayenta/compare/v0.0.89...armory:v0.0.89-hotfix-1

@erikmunson, I was not able to run `yarn lib` on master to test this with `yarn link`

```
ERROR in ./src/kayenta/report/detail/reportExplanation.tsx
Module parse failed: /Users/fieldju/dev/spinnaker/deck-kayenta/node_modules/happypack/loader.js?id=ts!/Users/fieldju/dev/spinnaker/deck-kayenta/src/kayenta/report/detail/reportExplanation.tsx Unexpected token (6:33)
You may need an appropriate loader to handle this file type.
| const react_redux_1 = require("react-redux");
| require("./reportExplanation.less");
...
...
```

With the fix and was able to test in spinnaker/deck and armory/deck with `yarn link` and confirm that the canary reports load and the tooltips work:

![image](https://user-images.githubusercontent.com/711726/83930578-29925e00-a74d-11ea-81ad-cf8cbf0842d5.png)

