### PR TITLE
feat(analysis): show error messages on manual analysis modal

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -141,6 +141,7 @@ function configure(IS_TEST, IS_INSTRUMENTED) {
           FEEDBACK_URL: 'https://hootch.test.netflix.net/submit',
           FIAT_ENABLED: false,
           INFRA_STAGES: false,
+          MANUAL_CANARY_ANALYSIS_ENABLED: false,
           METRIC_STORE: 'atlas',
           REDUX_LOGGER: false,
           TEMPLATES_ENABLED: false,


### PR DESCRIPTION
I ended up spending way more time on this than I meant to but did not go so far as to rewrite it using the Deck form library stuff.

* surfacing validation errors for each field
* adding a popover with the errors to the disabled submit button

**Some error messages (only showing on fields that have been filled out)**
<img width="897" alt="Screen Shot 2020-07-29 at 12 01 57 PM" src="https://user-images.githubusercontent.com/73450/88842169-e627ff00-d193-11ea-9c76-2bcae00b49e3.png">

**Error messages in popover on disabled submit button**
<img width="526" alt="Screen Shot 2020-07-29 at 12 02 04 PM" src="https://user-images.githubusercontent.com/73450/88842179-e922ef80-d193-11ea-97e6-7486a675f958.png">

**Properly filled out, button is enabled**
<img width="892" alt="Screen Shot 2020-07-29 at 12 02 52 PM" src="https://user-images.githubusercontent.com/73450/88842184-e9bb8600-d193-11ea-84ba-0732ff1f337b.png">
