### PR TITLE
fix(config): use non-legacy canary flag to gate data source

### DIFF
--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -16,7 +16,7 @@ module(CANARY_DATA_SOURCE, []).run([
   ($q: IQService) => {
     'ngInject';
 
-    if (!SETTINGS.feature.canary) {
+    if (CanarySettings.featureDisabled) {
       return;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/spinnaker/spinnaker/issues/5939

In a [previous PR](https://github.com/spinnaker/deck-kayenta/pull/494), I gated registration of the canary data source using the `SETTINGS.feature.canary` flag, which I have since learned is actually intended to only gate the legacy canary modules in Deck. Fix this by reading from the correct CanarySettings flag.