### PR TITLE
fix(report): surface exceptions when generating report

### DIFF
--- a/src/kayenta/domain/ICanaryExecutionStatusResult.ts
+++ b/src/kayenta/domain/ICanaryExecutionStatusResult.ts
@@ -9,6 +9,7 @@ export interface ICanaryExecutionStatusResult {
   complete: boolean;
   status: string;
   result: ICanaryResult;
+  exception?: ICanaryExecutionException;
   stageStatus: { [key: string]: string };
   startTimeIso: string;
   application: string;
@@ -18,6 +19,13 @@ export interface ICanaryExecutionStatusResult {
   config: ICanaryConfig;
   canaryExecutionRequest: ICanaryExecutionRequest;
   storageAccountName: string;
+}
+
+export interface ICanaryExecutionException {
+  exceptionType: string;
+  operation: string;
+  details: { [key: string]: any };
+  timestamp: string;
 }
 
 export interface ICanaryResult {

--- a/src/kayenta/report/detail/detail.tsx
+++ b/src/kayenta/report/detail/detail.tsx
@@ -1,39 +1,48 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 
+import { ICanaryExecutionStatusResult } from 'kayenta/domain';
+import { ICanaryState } from 'kayenta/reducers';
 import ReportHeader from './header';
 import ReportScores from './reportScores';
 import MetricResults from './metricResults';
+import ReportExplanation from './reportExplanation';
+import ReportException from './reportException';
 
 import './detail.less';
-import ReportExplanation from './reportExplanation';
 
 /*
  * Layout for report detail view.
  * */
 
-export interface IDetailViewState {
-  isExpanded: boolean;
+interface IDetailViewProps {
+  run: ICanaryExecutionStatusResult;
 }
 
-export default class DetailView extends React.Component<any, IDetailViewState> {
-  public state: IDetailViewState = { isExpanded: true };
+function DetailView({ run }: IDetailViewProps) {
+  const [isExpanded, setIsExpanded] = React.useState<boolean>(true);
 
-  private toggleDetailHeader = (): void => {
-    this.setState({ isExpanded: !this.state.isExpanded });
-  };
-
-  public render() {
-    const { isExpanded } = this.state;
-
-    return (
-      <>
-        <div className="vertical flex-1">
-          {isExpanded && <ReportHeader />}
-          <ReportExplanation />
-          <ReportScores isExpanded={isExpanded} toggleHeader={this.toggleDetailHeader} />
-          <MetricResults />
-        </div>
-      </>
-    );
+  if (!run.result?.judgeResult.results?.length && run.exception) {
+    return <ReportException />;
   }
+
+  const toggleDetailHeader = () => {
+    setIsExpanded(!isExpanded);
+  };
+  return (
+    <>
+      <div className="vertical flex-1">
+        {isExpanded && <ReportHeader />}
+        <ReportExplanation />
+        <ReportScores isExpanded={isExpanded} toggleHeader={toggleDetailHeader} />
+        <MetricResults />
+      </div>
+    </>
+  );
 }
+
+const mapStateToProps = (state: ICanaryState) => ({
+  run: state.selectedRun.run,
+});
+
+export default connect(mapStateToProps)(DetailView);

--- a/src/kayenta/report/detail/reportException.tsx
+++ b/src/kayenta/report/detail/reportException.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import { ICanaryState } from 'kayenta/reducers';
+import { ICanaryExecutionException } from 'kayenta/domain';
+import SourceLinks from './sourceLinks';
+
+import './reportExplanation.less';
+
+interface IReportExceptionProps {
+  exception: ICanaryExecutionException;
+}
+
+const ReportException = ({ exception }: IReportExceptionProps) => {
+  const message =
+    exception.details?.error ??
+    exception.details.errors?.join('\n') ??
+    'No error message provided. Click the "Report" link to see more details.';
+  return (
+    <>
+      <h3 className="text-center">Canary report failed</h3>
+      <dl>
+        <dt>Details</dt>
+        <dd>
+          <code>{message}</code>
+        </dd>
+        <dt>Source</dt>
+        <dd>
+          <SourceLinks />
+        </dd>
+      </dl>
+    </>
+  );
+};
+
+const mapStateToProps = (state: ICanaryState) => ({
+  exception: state.selectedRun.run.exception,
+});
+
+export default connect(mapStateToProps)(ReportException);

--- a/src/kayenta/report/detail/reportException.tsx
+++ b/src/kayenta/report/detail/reportException.tsx
@@ -12,17 +12,34 @@ interface IReportExceptionProps {
 }
 
 const ReportException = ({ exception }: IReportExceptionProps) => {
-  const message =
-    exception.details?.error ??
-    exception.details.errors?.join('\n') ??
-    'No error message provided. Click the "Report" link to see more details.';
+  const errorMessages = [];
+  if (exception.details) {
+    // error messages can be in an array on the details, or a single field, or possibly both?
+    // it's unclear based on Orca where the error message might be
+    const { error, errors } = exception.details;
+    if (error) {
+      errorMessages.push(error);
+    }
+    if (errors?.length) {
+      errors.forEach((m: string) => errorMessages.push(m));
+    }
+  }
+  // if there were no errors, set a default message
+  if (!errorMessages.length) {
+    errorMessages.push('No error message provided. Click the "Report" link to see more details.');
+  }
+
   return (
     <>
       <h3 className="text-center">Canary report failed</h3>
       <dl>
         <dt>Details</dt>
         <dd>
-          <code>{message}</code>
+          {errorMessages.map((message, i) => (
+            <div key={i}>
+              <code>{message}</code>
+            </div>
+          ))}
         </dd>
         <dt>Source</dt>
         <dd>

--- a/src/kayenta/report/detail/sourceLinks.tsx
+++ b/src/kayenta/report/detail/sourceLinks.tsx
@@ -19,13 +19,15 @@ const SourceLinks = ({ reportUrl, metricListUrl }: ISourceJsonStateProps) => {
           Report
         </a>
       </li>
-      <li>
-        <p>
-          <a target="_blank" href={metricListUrl}>
-            Metrics
-          </a>
-        </p>
-      </li>
+      {metricListUrl && (
+        <li>
+          <p>
+            <a target="_blank" href={metricListUrl}>
+              Metrics
+            </a>
+          </p>
+        </li>
+      )}
     </ul>
   );
 };
@@ -45,6 +47,9 @@ const resolveReportUrl = (state: ICanaryState): string => {
 const resolveMetricListUrl = (state: ICanaryState): string => {
   const status = runSelector(state);
   const { metricSetPairListId } = status;
+  if (!metricSetPairListId) {
+    return null;
+  }
   let url = `${SETTINGS.gateUrl}/v2/canaries/metricSetPairList/${metricSetPairListId}`;
   const storageAccountName = status.storageAccountName || CanarySettings.storageAccountName;
   if (storageAccountName) {

--- a/src/kayenta/selectors/index.ts
+++ b/src/kayenta/selectors/index.ts
@@ -8,11 +8,11 @@ import { validateMetric } from '../edit/editMetricValidation';
 
 export const runSelector = (state: ICanaryState): ICanaryExecutionStatusResult => state.selectedRun.run;
 
-export const judgeResultSelector = createSelector(runSelector, (run) => run.result.judgeResult);
+export const judgeResultSelector = createSelector(runSelector, (run) => run.result?.judgeResult);
 
 export const configIdSelector = createSelector(runSelector, (run) => run.config.id);
 
-export const metricResultsSelector = createSelector(runSelector, (run) => run.result.judgeResult.results);
+export const metricResultsSelector = createSelector(runSelector, (run) => run.result?.judgeResult.results ?? []);
 
 export const canaryExecutionRequestSelector = createSelector(runSelector, (run) => run.canaryExecutionRequest);
 

--- a/src/kayenta/service/canaryRun.service.ts
+++ b/src/kayenta/service/canaryRun.service.ts
@@ -1,5 +1,3 @@
-import { sortBy } from 'lodash';
-
 import { API } from '@spinnaker/core';
 
 import { CanarySettings } from 'kayenta/canary.settings';
@@ -22,7 +20,7 @@ export const getCanaryRun = (configId: string, canaryExecutionId: string): Promi
       const { config } = run;
       config.id = configId;
       run.id = canaryExecutionId;
-      run.result.judgeResult.results = sortBy(run.result.judgeResult.results, 'name');
+      run.result?.judgeResult.results.sort((a, b) => a.name.localeCompare(b.name));
       return run;
     });
 


### PR DESCRIPTION
We sometimes see a `Could not load canary report.` message when there was an error generating the report.

The change here: if an `exception` object is present, and there are no results in the report, display the error message.

This is one of those annoying things in Spinnaker where there is no clear contract for error messages, but they typically seem to be in the detail object, so we'll try to extract it from there.

Example:
<img width="1515" alt="Screen Shot 2020-08-10 at 10 54 58 AM" src="https://user-images.githubusercontent.com/73450/89818319-66d4ec80-dafe-11ea-92a4-49e7ac807280.png">

Also including a link to the JSON source of the report.
