### PR TITLE
feat(report): allow users to control number of reports shown

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -23,6 +23,7 @@ export interface IKayentaAction<T> extends Action {
   payload: T;
 }
 
+export const setExecutionsCount = createAction<{ count: number }>(Actions.SET_EXECUTIONS_COUNT);
 export const openDeleteConfigModal = createAction(Actions.DELETE_CONFIG_MODAL_OPEN);
 export const closeDeleteConfigModal = createAction(Actions.DELETE_CONFIG_MODAL_CLOSE);
 export const deleteConfig = createAction(Actions.DELETE_CONFIG_REQUEST);

--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -10,6 +10,7 @@ export const SAVE_CONFIG_FAILURE = 'save_config_failure';
 export const DELETE_CONFIG_MODAL_OPEN = 'delete_config_modal_open';
 export const DELETE_CONFIG_MODAL_CLOSE = 'delete_config_modal_close';
 export const DISMISS_SAVE_CONFIG_ERROR = 'dismiss_save_config_error';
+export const SET_EXECUTIONS_COUNT = 'set_executions_count';
 export const INITIALIZE = 'initialize';
 export const ADD_METRIC = 'add_metric';
 export const RENAME_METRIC = 'rename_metric';

--- a/src/kayenta/canary.dataSource.ts
+++ b/src/kayenta/canary.dataSource.ts
@@ -89,8 +89,7 @@ module(CANARY_DATA_SOURCE, []).run([
     });
 
     const loadCanaryExecutions = (application: Application) => {
-      // TODO(dpeach): make the number of canary executions rendered configurable from the UI.
-      const listExecutionsRequest = listCanaryExecutions(application.name, 20);
+      const listExecutionsRequest = listCanaryExecutions(application.name);
 
       listExecutionsRequest.catch((error) => {
         canaryStore.dispatch(Creators.loadExecutionsFailure({ error }));
@@ -125,7 +124,6 @@ module(CANARY_DATA_SOURCE, []).run([
       onLoad: canaryExecutionsLoaded,
       afterLoad: afterCanaryExecutionsLoaded,
       lazy: true,
-      autoActivate: true,
       defaultData: [],
       iconName: 'spMenuCanaryReport',
     });

--- a/src/kayenta/canary.settings.ts
+++ b/src/kayenta/canary.settings.ts
@@ -9,6 +9,8 @@ export interface ICanarySettings {
   metricStore: string;
   stagesEnabled: boolean;
   stageName: string;
+  executionsCountOptions: number[];
+  defaultExecutionCount: number;
   stageDescription: string;
   featureDisabled: boolean;
   optInAll: boolean;

--- a/src/kayenta/canary.tsx
+++ b/src/kayenta/canary.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { createStore, applyMiddleware } from 'redux';
 import { logger } from 'redux-logger';
 import { UIView } from '@uirouter/react';
-import { Observable } from 'rxjs/Observable';
 
 import { Application } from '@spinnaker/core';
 
@@ -16,7 +15,6 @@ import { CanarySettings } from './canary.settings';
 
 export interface ICanaryProps {
   app: Application;
-  success$: Observable<void>;
 }
 
 const middleware = [epicMiddleware, actionInterceptingMiddleware, asyncDispatchMiddleware];

--- a/src/kayenta/reducers/app.ts
+++ b/src/kayenta/reducers/app.ts
@@ -3,13 +3,22 @@ import { handleActions, combineActions } from 'redux-actions';
 
 import * as Actions from '../actions';
 import { ConfigJsonModalTabState } from '../edit/configJsonModal';
+import { CanarySettings } from '../canary.settings';
 
 export interface IAppState {
   deleteConfigModalOpen: boolean;
   configJsonModalOpen: boolean;
   configJsonModalTabState: ConfigJsonModalTabState;
   disableConfigEdit: boolean;
+  executionsCount: number;
 }
+
+const executionsCount = handleActions(
+  {
+    [Actions.SET_EXECUTIONS_COUNT]: (_state: IAppState, action: Action & any) => action.payload.count,
+  },
+  CanarySettings.defaultExecutionCount ?? CanarySettings.executionsCountOptions?.[0] ?? 20,
+);
 
 const deleteConfigModalOpen = handleActions(
   {
@@ -39,6 +48,7 @@ const configJsonModalTabState = handleActions(
 const disableConfigEdit = handleActions<boolean>({}, false);
 
 export const app: Reducer<IAppState> = combineReducers<IAppState>({
+  executionsCount,
   deleteConfigModalOpen,
   configJsonModalOpen,
   configJsonModalTabState,

--- a/src/kayenta/reducers/data.ts
+++ b/src/kayenta/reducers/data.ts
@@ -94,7 +94,7 @@ const executions = combineReducers<IExecutionsState>({
       [Actions.LOAD_EXECUTIONS_SUCCESS]: () => AsyncRequestState.Fulfilled,
       [Actions.LOAD_EXECUTIONS_FAILURE]: () => AsyncRequestState.Failed,
     },
-    AsyncRequestState.Requesting,
+    AsyncRequestState.Fulfilled,
   ),
 });
 

--- a/src/kayenta/service/canaryRun.service.ts
+++ b/src/kayenta/service/canaryRun.service.ts
@@ -1,4 +1,4 @@
-import { API } from '@spinnaker/core';
+import { API, ReactInjector } from '@spinnaker/core';
 
 import { CanarySettings } from 'kayenta/canary.settings';
 import {
@@ -40,13 +40,10 @@ export const getMetricSetPair = (metricSetPairListId: string, metricSetPairId: s
     .get()
     .then((list: IMetricSetPair[]) => list.find((pair) => pair.id === metricSetPairId));
 
-export const listCanaryExecutions = (
-  application: string,
-  limit: number,
-  statuses?: string,
-  storageAccountName?: string,
-): Promise<ICanaryExecutionStatusResult[]> =>
-  API.one('v2/canaries').one(application).one('executions').withParams({ limit, statuses, storageAccountName }).get();
+export const listCanaryExecutions = (application: string): Promise<ICanaryExecutionStatusResult[]> => {
+  const limit = ReactInjector.$stateParams.count || 20;
+  return API.one('v2/canaries').one(application).one('executions').withParams({ limit }).getList();
+};
 
 export const getHealthLabel = (health: string, result: string): string => {
   const healthLC = (health || '').toLowerCase();


### PR DESCRIPTION
Resolves a TODO from two years ago and lets users show more than the most recent 20 canary reports for a given application.

By default, we'll show the most recent 20, but users can pick 50, 100, 200. Some people will notice the count is in the URL and will try to change it to some very large number and will feel very smart that they did that and it worked.

There is still no way to filter the report list, and there is no pagination. Those might come later. Honestly, this was about 100 times harder than I expected, but that was mostly because I don't work with redux enough to know it well.

Also, the `autoActivate` functionality of the data source appears to be broken: when navigating within a data source, intra-source navigation will fire both the activate and de-activate calls right after each other, disabling the data source. This is not a big deal, as it's only used in kayenta and the internal Netflix build, but it's probably worth fixing. I think the fix is just a matter of switching the order the handlers are registered in spinnaker/core [here](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/application/service/applicationDataSource.ts#L364) but @christopherthielen would know better.

_Default view: showing 20 reports_
<img width="1440" alt="Screen Shot 2020-08-11 at 4 48 11 PM" src="https://user-images.githubusercontent.com/73450/90054451-bb0fd600-dc90-11ea-881d-79ea4f59fda0.png">

_showing 50 reports_
<img width="1132" alt="Screen Shot 2020-08-11 at 4 48 27 PM" src="https://user-images.githubusercontent.com/73450/90054441-b77c4f00-dc90-11ea-8612-000fed546a5c.png">

_hand-editing the URL_
<img width="1089" alt="Screen Shot 2020-08-11 at 4 48 39 PM" src="https://user-images.githubusercontent.com/73450/90054518-d4188700-dc90-11ea-977a-b85d8fafde4c.png">
