### PR TITLE
fix(build): prevent pre-publish TS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "lib/lib.js",
   "typings": "lib/kayenta/index.d.ts",
   "name": "@spinnaker/kayenta",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/kayenta/metricStore/datadog/metricTypeSelector.spec.tsx
+++ b/src/kayenta/metricStore/datadog/metricTypeSelector.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { mountWithState, mountWithStore } from 'enzyme-redux';
 import { createMockStore } from 'redux-test-utils';
-import Select, { Option, ReactSelectProps } from 'react-select';
+import Select, { Option } from 'react-select';
 
 import { noop } from '@spinnaker/core';
 import * as Actions from 'kayenta/actions';
@@ -45,8 +45,7 @@ describe('<DatadogMetricTypeSelector />', () => {
     const store = createMockStore(state);
     const component = mountWithStore(<Component value="" onChange={noop} />, store);
 
-    const allProps: ReactSelectProps = component.find(Select).props();
-    allProps.onInputChange('heartbeat');
+    component.find(Select).props().onInputChange('heartbeat');
 
     expect(
       store.isActionDispatched({

--- a/src/kayenta/metricStore/stackdriver/metricTypeSelector.spec.tsx
+++ b/src/kayenta/metricStore/stackdriver/metricTypeSelector.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { mountWithState, mountWithStore } from 'enzyme-redux';
 import { createMockStore } from 'redux-test-utils';
-import Select, { Option, ReactSelectProps } from 'react-select';
+import Select, { Option } from 'react-select';
 
 import { noop } from '@spinnaker/core';
 import * as Actions from 'kayenta/actions';
@@ -78,8 +78,8 @@ describe('<StackdriverMetricTypeSelector />', () => {
       <Component value="compute.googleapis.com/disk/read_ops_count" onChange={noop} />,
       store,
     );
-    const allProps: ReactSelectProps = component.find(Select).props();
-    allProps.onInputChange('redis');
+
+    component.find(Select).props().onInputChange('redis');
 
     expect(
       store.isActionDispatched({


### PR DESCRIPTION
@caseyhebebrand Sorry for slacking you about this earlier in the week and only following up now! Did you happen to encounter this TS error when running `npm publish` (on npm 6.13.4)? I see you changed these tests to [_resolve_ issues upon TS upgrade](https://github.com/spinnaker/deck-kayenta/pull/488), so I am guessing I am doing something wrong and happy to close this PR if that's the case... 🙈 


* fix(build): prevent pre-publish TS error 

  When trying to run `npm publish`, received the following TS error:

  ``` 
  TS2322: Type 'ReactSelectProps<unknown>' is not assignable to type 'ReactSelectProps<OptionValues>.
  ```

  Inline the call to `onInputChange` in both tests so we don't need to assign the props a type. Verified with ```npm publish --dry-run``` that this resolved the TS error.

* chore(build): bump version to 0.0.99 
