### PR TITLE
feat(reports): add rerun report action

### DIFF
--- a/src/kayenta/domain/ICanaryExecutionStatusResult.ts
+++ b/src/kayenta/domain/ICanaryExecutionStatusResult.ts
@@ -6,16 +6,19 @@ export const CANARY_EXECUTION_NO_PIPELINE_STATUS = 'no-parent-pipeline-execution
 
 export interface ICanaryExecutionStatusResult {
   id: string; // Added by Deck on load.
+  canaryConfigId: string;
   complete: boolean;
   status: string;
   result: ICanaryResult;
   exception?: ICanaryExecutionException;
   stageStatus: { [key: string]: string };
   startTimeIso: string;
+  endTimeIso: string;
   application: string;
   pipelineId: string;
   parentPipelineExecutionId: string;
   metricSetPairListId: string;
+  metricsAccountName: string;
   config: ICanaryConfig;
   canaryExecutionRequest: ICanaryExecutionRequest;
   storageAccountName: string;
@@ -65,4 +68,5 @@ export interface ICanaryScope {
   end: string;
   step: number;
   extendedScopeParams?: { [param: string]: string };
+  resourceType?: string;
 }


### PR DESCRIPTION
If a user wants to tweak a canary config, then regenerate a report, it's tedious right now, and it shouldn't be. We have all the information we need in the report execution.

This PR adds the ability to re-run a report by mapping the values from the original report to the initial values in the Start Manual Execution modal.

I've only tested this against Atlas. It's possible there are problems or issues with these mappings for other metric stores.

<img width="1445" alt="Screen Shot 2020-08-25 at 9 40 14 PM" src="https://user-images.githubusercontent.com/73450/91256836-348dd680-e71d-11ea-896e-2ac6d04743dc.png">
