### PR TITLE
fix(report): break long metric names in list view

### DIFF
--- a/src/kayenta/report/detail/metricResultsColumns.tsx
+++ b/src/kayenta/report/detail/metricResultsColumns.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { BreakString } from '@spinnaker/core';
 import { ITableColumn } from 'kayenta/layout/table';
 import { IMetricResultsTableRow } from './metricResultsList';
 import MetricResultClassification from './metricResultClassification';
@@ -7,7 +8,7 @@ import MetricResultDeviation from './metricResultDeviation';
 export const metricResultsColumns: Array<ITableColumn<IMetricResultsTableRow>> = [
   {
     label: 'metric name',
-    getContent: ({ metricName }) => <span>{metricName}</span>,
+    getContent: ({ metricName }) => <BreakString>{metricName}</BreakString>,
     width: 5,
   },
   {

--- a/src/kayenta/report/detail/multipleResultsTable.tsx
+++ b/src/kayenta/report/detail/multipleResultsTable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { chain } from 'lodash';
 import { connect, Dispatch } from 'react-redux';
 import * as classNames from 'classnames';
+import { BreakString } from '@spinnaker/core';
 
 import { ICanaryAnalysisResult } from 'kayenta/domain/ICanaryJudgeResult';
 import { ITableColumn, Table } from 'kayenta/layout/table';
@@ -37,7 +38,7 @@ const MultipleResultsTable = ({
   let columns: Array<ITableColumn<ICanaryAnalysisResult>> = tagKeys.map((key) => ({
     label: key,
     width: 5,
-    getContent: (result: ICanaryAnalysisResult) => <span>{result.tags[key]}</span>,
+    getContent: (result: ICanaryAnalysisResult) => <BreakString>{result.tags[key]}</BreakString>,
   }));
 
   columns = columns.concat([


### PR DESCRIPTION
There are long metric names right now that blow out the side of the list.

The changes introduced in this PR are not perfect, but I think it's about as good as we can get with the current layout.

_Before:_
<img width="700" alt="Screen Shot 2020-08-26 at 1 07 14 PM" src="https://user-images.githubusercontent.com/73450/91351493-41eaa580-e79d-11ea-8d52-549323850c6b.png">

_After:_
<img width="662" alt="Screen Shot 2020-08-26 at 1 05 52 PM" src="https://user-images.githubusercontent.com/73450/91351523-4a42e080-e79d-11ea-9b8f-1de91e19eac6.png">
