### PR TITLE
fix(rerun): do not override scope type when re-running analysis

### DIFF
--- a/src/kayenta/manualAnalysis/ManualAnalysisModal.tsx
+++ b/src/kayenta/manualAnalysis/ManualAnalysisModal.tsx
@@ -84,7 +84,7 @@ const transformFormPropsToExecutionRequest = (
     accountSpecificParams.resourceType = values.resourceType;
   }
 
-  if (metricsAccount.type === 'atlas') {
+  if (metricsAccount.type === 'atlas' && !values.extendedScopeParams?.type) {
     accountSpecificParams.type = 'cluster';
   }
 


### PR DESCRIPTION
When clicking the "Start Manual Analysis" button, it makes sense to default the scope type to "cluster". But, if the user is re-running an existing report, we should just use whatever was set in the initial run.