### PR TITLE
chore(modules): exporting modules for extensibility

### DIFF
--- a/src/kayenta/index.ts
+++ b/src/kayenta/index.ts
@@ -1,1 +1,7 @@
 export { KAYENTA_MODULE } from './canary.module';
+export * from './actions';
+export * from './domain';
+export * from './metricStore';
+export * from './selectors';
+export * from './layout';
+export * from './reducers';

--- a/src/kayenta/layout/index.ts
+++ b/src/kayenta/layout/index.ts
@@ -1,0 +1,2 @@
+export { default as FormRow } from './formRow';
+export * from './disableable';

--- a/src/kayenta/metricStore/index.ts
+++ b/src/kayenta/metricStore/index.ts
@@ -5,3 +5,4 @@ import './signalfx';
 import './stackdriver';
 import './graphite';
 import './newrelic';
+export { default as metricStoreConfigStore } from './metricStoreConfig.service';


### PR DESCRIPTION
Hi, exporting modules and naming default objects on Deck-Kayenta, to make the project easy to extend