### PR TITLE
feat(atlas): include tags in Atlas legend links

### DIFF
--- a/src/kayenta/report/detail/metricResultActions.tsx
+++ b/src/kayenta/report/detail/metricResultActions.tsx
@@ -16,14 +16,20 @@ export interface IMetricResultStatsStateProps {
 }
 
 const buildAtlasGraphUrl = (metricSetPair: IMetricSetPair) => {
-  const { attributes, scopes, values } = metricSetPair;
+  const { attributes, scopes, values, tags } = metricSetPair;
   const { atlasGraphBaseUrl } = CanarySettings;
+  let legendTags = '';
+  if (Object.keys(tags).length) {
+    legendTags = ` (${Object.keys(tags)
+      .map((tag) => `$${tag}`)
+      .join('|')})`;
+  }
 
   // TODO: If the control and experiment have different baseURLs, generate two links instead of a combined one.
   const backend = encodeURIComponent(attributes.control.baseURL);
   const experimentQuery = encodeURIComponent(attributes.experiment.query);
   const controlQuery = encodeURIComponent(attributes.control.query);
-  const query = `${experimentQuery},Canary,:legend,:freeze,${controlQuery},Baseline,:legend`;
+  const query = `${experimentQuery},Canary${legendTags},:legend,:freeze,${controlQuery},Baseline${legendTags},:legend`;
 
   const startTime = Math.min(scopes.control.startTimeMillis, scopes.experiment.startTimeMillis);
   const controlEndTime = scopes.control.startTimeMillis + values.control.length * scopes.control.stepMillis;


### PR DESCRIPTION
If a metric is grouped and we generate an Atlas link, the legend is not very useful:
<img width="304" alt="Screen Shot 2020-12-09 at 12 45 53 PM" src="https://user-images.githubusercontent.com/73450/101685673-e5925580-3a1c-11eb-8228-0722bad60146.png">

We can include the tag and make it a little easier to understand what you're looking at (note the order is different than above because it's alphabetized, and this is a subset of all the entries in the legend):
<img width="309" alt="Screen Shot 2020-12-09 at 12 46 03 PM" src="https://user-images.githubusercontent.com/73450/101685757-ffcc3380-3a1c-11eb-88da-c05e41a411d8.png">
