### PR TITLE
feat(report): add metric filters

### DIFF
--- a/src/kayenta/actions/creators.ts
+++ b/src/kayenta/actions/creators.ts
@@ -15,6 +15,7 @@ import {
   ICanaryConfig,
   ICanaryMetricConfig,
   ICanaryMetricEffectSizeConfig,
+  MetricClassificationLabel,
 } from 'kayenta/domain';
 import { IUpdateKeyValueListPayload } from '../layout/keyValueList';
 import { IStackdriverCanaryMetricSetQueryConfig } from '../metricStore/stackdriver/domain/IStackdriverCanaryMetricSetQueryConfig';
@@ -24,6 +25,9 @@ export interface IKayentaAction<T> extends Action {
   payload: T;
 }
 
+export const toggleMetricClassificationFilter = createAction<{ classification: MetricClassificationLabel }>(
+  Actions.TOGGLE_METRIC_CLASSIFICATION_FILTER,
+);
 export const setExecutionsCount = createAction<{ count: number }>(Actions.SET_EXECUTIONS_COUNT);
 export const openDeleteConfigModal = createAction(Actions.DELETE_CONFIG_MODAL_OPEN);
 export const closeDeleteConfigModal = createAction(Actions.DELETE_CONFIG_MODAL_CLOSE);

--- a/src/kayenta/actions/index.ts
+++ b/src/kayenta/actions/index.ts
@@ -60,6 +60,7 @@ export const CHANGE_METRIC_GROUP_CONFIRM = 'change_metric_group_confirm';
 export const LOAD_RUN_REQUEST = 'load_run_request';
 export const LOAD_RUN_SUCCESS = 'load_run_success';
 export const LOAD_RUN_FAILURE = 'load_run_failure';
+export const TOGGLE_METRIC_CLASSIFICATION_FILTER = 'toggle_metric_classification_filter';
 export const SELECT_REPORT_METRIC_GROUP = 'select_result_metric_group';
 export const SELECT_REPORT_METRIC = 'select_result_metric';
 export const LOAD_METRIC_SET_PAIR_REQUEST = 'load_metric_set_pair_request';

--- a/src/kayenta/edit/metricList.less
+++ b/src/kayenta/edit/metricList.less
@@ -3,3 +3,12 @@
     padding: 0 12px;
   }
 }
+
+.metric-filter-options {
+  label {
+    font-weight: 600;
+    margin: 6px;
+    padding: 6px 12px;
+    border: 1px solid var(--color-divider);
+  }
+}

--- a/src/kayenta/reducers/selectedRun.ts
+++ b/src/kayenta/reducers/selectedRun.ts
@@ -3,7 +3,7 @@ import { handleActions } from 'redux-actions';
 
 import * as Actions from 'kayenta/actions';
 import { AsyncRequestState } from './asyncRequest';
-import { IMetricSetPair, ICanaryExecutionStatusResult } from 'kayenta/domain';
+import { IMetricSetPair, ICanaryExecutionStatusResult, MetricClassificationLabel } from 'kayenta/domain';
 import { GraphType } from 'kayenta/report/detail/graph/metricSetPairGraph.service';
 
 interface IMetricSetPairState {
@@ -18,7 +18,21 @@ export interface ISelectedRunState {
   selectedMetric: string;
   metricSetPair: IMetricSetPairState;
   graphType: GraphType;
+  metricFilters: MetricClassificationLabel[];
 }
+
+const metricFilters = handleActions(
+  {
+    [Actions.TOGGLE_METRIC_CLASSIFICATION_FILTER]: (_state: MetricClassificationLabel[], action: Action & any) => {
+      const { classification } = action.payload;
+      if (_state.includes(classification)) {
+        return _state.filter((s) => s !== classification);
+      }
+      return _state.concat([classification]);
+    },
+  },
+  [],
+);
 
 const run = handleActions(
   {
@@ -83,4 +97,5 @@ export const selectedRun: Reducer<ISelectedRunState> = combineReducers<ISelected
   selectedMetric,
   metricSetPair,
   graphType,
+  metricFilters,
 });

--- a/src/kayenta/report/detail/metricResultsClassificationFilters.tsx
+++ b/src/kayenta/report/detail/metricResultsClassificationFilters.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { connect, Dispatch } from 'react-redux';
+import { ICanaryAnalysisResult, MetricClassificationLabel } from '../../domain';
+import { ICanaryState } from '../../reducers';
+import * as Creators from '../../actions/creators';
+
+export interface IMetricFiltersOwnProps {
+  results: ICanaryAnalysisResult[];
+}
+
+interface IMetricFiltersStateProps {
+  metricFilters: MetricClassificationLabel[];
+}
+
+interface IMetricFiltersDispatchProps {
+  toggle: (classification: MetricClassificationLabel) => void;
+}
+
+const MetricFilters = ({
+  results,
+  metricFilters,
+  toggle,
+}: IMetricFiltersOwnProps & IMetricFiltersStateProps & IMetricFiltersDispatchProps) => {
+  const options = [
+    MetricClassificationLabel.Error,
+    MetricClassificationLabel.High,
+    MetricClassificationLabel.Low,
+    MetricClassificationLabel.Nodata,
+    MetricClassificationLabel.Pass,
+  ]
+    .map((classification) => ({
+      classification,
+      count: results.filter((r) => r.classification === classification).length,
+    }))
+    .filter((option) => option.count);
+
+  const checkboxes = options.map((o) => (
+    <label key={o.classification}>
+      <input
+        type="checkbox"
+        checked={metricFilters.includes(o.classification)}
+        onClick={() => toggle(o.classification)}
+      />{' '}
+      {o.classification} ({o.count}){' '}
+    </label>
+  ));
+
+  return <div className="metric-filter-options horizontal center">{checkboxes}</div>;
+};
+
+const mapStateToProps = (state: ICanaryState): IMetricFiltersStateProps => ({
+  metricFilters: state.selectedRun.metricFilters,
+});
+
+const mapDispatchToProps = (
+  dispatch: Dispatch<ICanaryState>,
+  ownProps: IMetricFiltersOwnProps,
+): IMetricFiltersOwnProps & IMetricFiltersDispatchProps => ({
+  toggle: (classification: MetricClassificationLabel) =>
+    dispatch(Creators.toggleMetricClassificationFilter({ classification })),
+  ...ownProps,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricFilters);

--- a/src/kayenta/report/detail/metricResultsList.tsx
+++ b/src/kayenta/report/detail/metricResultsList.tsx
@@ -10,6 +10,8 @@ import { metricResultsColumns } from './metricResultsColumns';
 import MultipleResultsTable from './multipleResultsTable';
 
 import './metricResultsList.less';
+import { MetricClassificationLabel } from '../../domain';
+import MetricFilters from './metricResultsClassificationFilters';
 
 export interface IResultsListOwnProps {
   results: ICanaryAnalysisResult[];
@@ -21,6 +23,7 @@ interface IResultsListDispatchProps {
 
 interface IResultsListStateProps {
   selectedMetric: string;
+  metricFilters: MetricClassificationLabel[];
 }
 
 export interface IMetricResultsTableRow {
@@ -28,14 +31,19 @@ export interface IMetricResultsTableRow {
   results: ICanaryAnalysisResult[];
 }
 
-const buildTableRows = (results: ICanaryAnalysisResult[]): IMetricResultsTableRow[] => {
-  const tableRowsByMetricName = results.reduce(
-    (map, result) =>
-      map.has(result.name)
-        ? map.set(result.name, { metricName: result.name, results: map.get(result.name).results.concat(result) })
-        : map.set(result.name, { metricName: result.name, results: [result] }),
-    new Map<string, IMetricResultsTableRow>(),
-  );
+const buildTableRows = (
+  results: ICanaryAnalysisResult[],
+  metricFilters: MetricClassificationLabel[],
+): IMetricResultsTableRow[] => {
+  const tableRowsByMetricName = results
+    .filter((result) => !metricFilters.length || metricFilters.includes(result.classification))
+    .reduce(
+      (map, result) =>
+        map.has(result.name)
+          ? map.set(result.name, { metricName: result.name, results: map.get(result.name).results.concat(result) })
+          : map.set(result.name, { metricName: result.name, results: [result] }),
+      new Map<string, IMetricResultsTableRow>(),
+    );
 
   return Array.from(tableRowsByMetricName.values());
 };
@@ -59,10 +67,12 @@ const ResultsList = ({
   results,
   select,
   selectedMetric,
+  metricFilters,
 }: IResultsListOwnProps & IResultsListDispatchProps & IResultsListStateProps) => {
-  const rows = buildTableRows(results);
+  const rows = buildTableRows(results, metricFilters);
   return (
     <section className="vertical metric-results-list flex-1">
+      <MetricFilters results={results} />
       <Table
         rowKey={(r) => r.metricName}
         tableBodyClassName="list-unstyled tabs-vertical flex-1 sp-padding-xl-bottom"
@@ -79,6 +89,7 @@ const ResultsList = ({
 
 const mapStateToProps = (state: ICanaryState): IResultsListStateProps => ({
   selectedMetric: state.selectedRun.selectedMetric,
+  metricFilters: state.selectedRun.metricFilters,
 });
 
 const mapDispatchToProps = (


### PR DESCRIPTION
We have a lot of big reports. When something fails, it can be really hard right now to see what caused it:
<img width="556" alt="Screen Shot 2020-12-10 at 2 31 05 PM" src="https://user-images.githubusercontent.com/73450/101837748-61130600-3af4-11eb-8c43-14e254d55e43.png">
Was it just the one metric at the top that failed? There are almost 300 metrics in this list, who knows!

This PR adds very simple filters based on metric classification:
<img width="520" alt="Screen Shot 2020-12-10 at 2 29 14 PM" src="https://user-images.githubusercontent.com/73450/101837909-a33c4780-3af4-11eb-8dfa-4c53980389bd.png">
