### PR TITLE
feat(metrics): include metric failure direction info in metric list

### DIFF
--- a/src/kayenta/edit/metricList.less
+++ b/src/kayenta/edit/metricList.less
@@ -12,3 +12,10 @@
     border: 1px solid var(--color-divider);
   }
 }
+
+.metric-fail-on-icon {
+  color: var(--color-warning);
+  &.critical {
+    color: var(--color-danger);
+  }
+}

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Action } from 'redux';
 import { connect } from 'react-redux';
 import { cloneDeep } from 'lodash';
+import * as classNames from 'classnames';
+import { Tooltip } from '@spinnaker/core';
 import { ICanaryMetricConfig } from 'kayenta/domain';
 import { ICanaryState } from 'kayenta/reducers';
 import * as Creators from 'kayenta/actions/creators';
@@ -29,6 +31,35 @@ interface IMetricListDispatchProps {
   openChangeMetricGroupModal: (event: any) => void;
 }
 
+function FailOn({ metric }: { metric: ICanaryMetricConfig }) {
+  const direction = metric.analysisConfigurations?.canary?.direction;
+  const isCritical = metric.analysisConfigurations?.canary?.critical;
+  const tooltipSuffix = isCritical ? '(critical — if this metric fails, the entire canary will fail)' : '';
+  const classes = classNames('metric-fail-on-icon', 'fas', 'sp-margin-xs-right', { critical: isCritical });
+  if (direction === 'decrease') {
+    return (
+      <Tooltip value={`decrease ${tooltipSuffix}`}>
+        <i className={`fa-caret-square-down ${classes}`} />
+      </Tooltip>
+    );
+  }
+  if (direction === 'increase') {
+    return (
+      <Tooltip value={`increase ${tooltipSuffix}`}>
+        <i className={`fa-caret-square-up ${classes}`} />
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip value={`increase OR decrease ${tooltipSuffix}`}>
+      <span>
+        <i className={`fa-caret-square-down ${classes}`} />
+        <i className={`fa-caret-square-up ${classes}`} />
+      </span>
+    </Tooltip>
+  );
+}
+
 /*
  * Configures an entire list of metrics.
  */
@@ -50,6 +81,10 @@ function MetricList({
     {
       label: 'Metric Name',
       getContent: (metric) => <span>{metric.name || '(new)'}</span>,
+    },
+    {
+      label: 'Fail On',
+      getContent: (metric) => <FailOn metric={metric} />,
     },
     {
       label: 'Groups',


### PR DESCRIPTION
It's hard to tell how a metric behaves without clicking "Edit":
<img width="749" alt="Screen Shot 2021-01-11 at 4 26 25 PM" src="https://user-images.githubusercontent.com/73450/104253893-75675d00-542a-11eb-844c-6bf15af0248e.png">

This PR addresses this by including the direction of the metric. If it's critical, the indicators are shown in red and the tooltip indicates the criticality:
<img width="840" alt="Screen Shot 2021-01-11 at 4 26 02 PM" src="https://user-images.githubusercontent.com/73450/104253859-641e5080-542a-11eb-893b-8d1d2940db12.png">
