### PR TITLE
fix(charts): fix axes key

### DIFF
--- a/src/kayenta/report/detail/graph/semiotic/boxplot.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/boxplot.tsx
@@ -257,7 +257,7 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
       rAccessor: (d: IChartDataPoint) => d.value,
       svgAnnotationRules: this.customAnnotationFunction,
       summaryClass: 'boxplot-summary',
-      axis: {
+      axes: {
         orient: 'left',
         label: 'metric value',
         tickFormat: (d: number) => utils.formatMetricValue(d),

--- a/src/kayenta/report/detail/graph/semiotic/histogram.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/histogram.tsx
@@ -218,7 +218,7 @@ export default class Histogram extends React.Component<ISemioticChartProps, IHis
       },
       customHoverBehavior: this.createChartHoverHandler(chartData),
       data: this.generateChartData(),
-      axis: [
+      axes: [
         {
           orient: 'left',
           label: 'measurement count',


### PR DESCRIPTION
semiotic 2.0.0 uses a different key for `axes`