### PR TITLE
fix(boxplot): hack boxplot into correct rendering using semiotic rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "redux-observable": "^0.14.1",
     "reselect": "^3.0.1",
     "rxjs": "^5.4.2",
-    "semiotic": "^2.0.0-rc.5",
+    "semiotic": "2.0.0-rc.12",
     "spel2js": "^0.2.6",
     "ui-select": "^0.19.6"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "yarn": ">=1.21.1"
   },
   "scripts": {
-    "build": "npm run clean && rollup -c",
+    "build": "npm run clean && NODE_ENV=production rollup -c",
     "test": "jest",
     "test:debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
     "prepublishOnly": "npm run build",
@@ -79,7 +79,7 @@
     "@rollup/plugin-url": "6.0.0",
     "@spinnaker/core": "0.0.563",
     "@spinnaker/eslint-plugin": "1.0.13",
-    "@spinnaker/pluginsdk": "0.0.25",
+    "@spinnaker/pluginsdk": "0.0.26",
     "@spinnaker/pluginsdk-peerdeps": "0.0.11",
     "@spinnaker/presentation": "0.0.4",
     "@types/angular": "1.6.26",

--- a/src/kayenta/report/detail/graph/semiotic/boxplot.less
+++ b/src/kayenta/report/detail/graph/semiotic/boxplot.less
@@ -1,4 +1,15 @@
 .boxplot {
+  /* TODO: Remove the .hover-summary rule when Semiotic V2 gets released and we switch back to the Tooltip */
+  .hover-summary {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    opacity: 0.9;
+    font-size: 90%;
+    padding: 4px 8px;
+    border: 1px solid var(--color-dovegray);
+    background-color: var(--color-white);
+  }
   .tooltip-container {
     .columns {
       display: flex;

--- a/src/kayenta/report/detail/graph/semiotic/boxplot.tsx
+++ b/src/kayenta/report/detail/graph/semiotic/boxplot.tsx
@@ -175,8 +175,10 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
       const createNoteElement = (posY: number, dataPoint: IOrSummaryPiece) => {
         const name = dataPoint.summaryPieceName;
         const label = statLabelMap[name];
+        // TODO: If Semiotic fixes the x value in v2, remove this line and set x to dataPoint.x in the noteData
+        const x = d.group === 'baseline' ? boxPlotWidth - 75 : 2 * boxPlotWidth + 70;
         const noteData = {
-          x: dataPoint.x,
+          x: x /* dataPoint.x */,
           y: posY,
           dx: boxPlotWidth / 2,
           dy: 0,
@@ -190,7 +192,7 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
           },
           className: 'boxplot-annotation',
         };
-        return <Annotation key={name} noteData={noteData} />;
+        return <Annotation key={`${d.group}: ${name}`} noteData={noteData} />;
       };
 
       const nodes = d.summaryKeys
@@ -226,7 +228,7 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
       projection: 'vertical',
       summaryType: 'boxplot',
       oLabel: false,
-      oPadding: 160,
+      oPadding: 142, // TODO: try changing this back to 160 when Semiotic v2 gets released
       style: (d: IChartDataPoint) => {
         return {
           fill: d.color,
@@ -275,7 +277,9 @@ export default class BoxPlot extends React.Component<ISemioticChartProps, IBoxPl
           <div className="boxplot-chart">
             <OrdinalFrame {...this.getChartProps()} />
           </div>
-          <Tooltip {...this.state.tooltip} />
+          {/* TODO: Remove this block, use the Tooltip when Semiotic V2 gets released */}
+          {this.state.tooltip && <div className="hover-summary">{this.state.tooltip.content}</div>}
+          {/*<Tooltip {...this.state.tooltip} />*/}
         </div>
       </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2273,7 +2273,7 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@^2.0.0, asap@~2.0.3, asap@~2.0.6:
+asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -3280,16 +3280,16 @@ d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
   integrity sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==
 
-d3-brush@^1.0.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.1.6.tgz#b0a22c7372cabec128bdddf9bddc058592f89e9b"
-  integrity sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==
+d3-brush@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-2.1.0.tgz#adadfbb104e8937af142e9a6e2028326f0471065"
+  integrity sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==
   dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
+    d3-dispatch "1 - 2"
+    d3-drag "2"
+    d3-interpolate "1 - 2"
+    d3-selection "2"
+    d3-transition "2"
 
 d3-chord@^1.0.4:
   version "1.0.6"
@@ -3309,6 +3309,11 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
+"d3-color@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+
 d3-contour@^1.1.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
@@ -3321,18 +3326,23 @@ d3-dispatch@1:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
   integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
 
-d3-drag@1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
-  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
-  dependencies:
-    d3-dispatch "1"
-    d3-selection "1"
+"d3-dispatch@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
+  integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
 
-d3-ease@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
-  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+d3-drag@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-2.0.0.tgz#9eaf046ce9ed1c25c88661911c1d5a4d8eb7ea6d"
+  integrity sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-selection "2"
+
+"d3-ease@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-2.0.0.tgz#fd1762bfca00dae4bacea504b1d628ff290ac563"
+  integrity sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==
 
 d3-force@^1.0.2:
   version "1.2.1"
@@ -3370,6 +3380,13 @@ d3-interpolate@1:
   integrity sha1-pD7Fs77jUNhRbv34GaTAjAU9swI=
   dependencies:
     d3-color "1"
+
+"d3-interpolate@1 - 2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
+  dependencies:
+    d3-color "1 - 2"
 
 d3-interpolate@^1.1.5:
   version "1.3.2"
@@ -3415,15 +3432,10 @@ d3-scale@^1.0.3:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@1, d3-selection@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.0.tgz#ab9ac1e664cf967ebf1b479cc07e28ce9908c474"
-  integrity sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg==
-
-d3-selection@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.1.tgz#98eedbbe085fbda5bafa2f9e3f3a2f4d7d622a98"
-  integrity sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA==
+d3-selection@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-2.0.0.tgz#94a11638ea2141b7565f883780dabc7ef6a61066"
+  integrity sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==
 
 d3-shape@^1.2.0, d3-shape@^1.3.5:
   version "1.3.7"
@@ -3456,17 +3468,21 @@ d3-timer@1:
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
 
-d3-transition@1, d3-transition@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
-  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+"d3-timer@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0.tgz#055edb1d170cfe31ab2da8968deee940b56623e6"
+  integrity sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==
+
+d3-transition@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-2.0.0.tgz#366ef70c22ef88d1e34105f507516991a291c94c"
+  integrity sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==
   dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "^1.1.0"
-    d3-timer "1"
+    d3-color "1 - 2"
+    d3-dispatch "1 - 2"
+    d3-ease "1 - 2"
+    d3-interpolate "1 - 2"
+    d3-timer "1 - 2"
 
 d3-voronoi@^1.0.2:
   version "1.1.4"
@@ -7633,13 +7649,6 @@ promise.series@^0.2.0:
   resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
   integrity sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=
 
-promise@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
-  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
-  dependencies:
-    asap "~2.0.6"
-
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -8665,21 +8674,21 @@ select@^1.1.2:
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
   integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
-semiotic-mark@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/semiotic-mark/-/semiotic-mark-0.4.5.tgz#544c3603b425dc719f55eedced29577a081b8e1c"
-  integrity sha512-vnEKLsJmjy+lDo5a0ENkKQCY2kzZ1IZYjWlF0VQZ1AFW/0FIU624ggcfJnYBAQ6mlUoM67wHGV4yj7jTP9Gagw==
+semiotic-mark@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/semiotic-mark/-/semiotic-mark-0.5.0.tgz#074f20a28673dc630ee01d13bc032f015152b606"
+  integrity sha512-cLeAUR3lCeCU6XSssFJiqxthJqq+k6KbZCD7AtRvyQJg42knYM1Wvk0GPE6pyoJf9PLXkIZ5wjqDV2tcXlyPqQ==
   dependencies:
-    d3-selection "^1.4.0"
-    d3-transition "^1.2.0"
+    d3-selection "2"
+    d3-transition "2"
 
-semiotic@^2.0.0-rc.5:
-  version "2.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-2.0.0-rc.5.tgz#b47e82671037283407f4e100a48619d299c51033"
-  integrity sha512-+va0b49RbvhkgC6irfrMQmmXQNHVmOe5uH84zT0iaxeLObHKwQs5ozdZkqTukOGis7/WT3bDYYo5jQj7plZ3Ug==
+semiotic@2.0.0-rc.12:
+  version "2.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-2.0.0-rc.12.tgz#1063833d932ad4de46aac147820d7009c02dcdc5"
+  integrity sha512-OUqa3hUqz84SnVeiketpCIx83aa6CSXKKaxkp33rY+QGBuix94FluLGr2d3cRcfLsAAHOe4O8wWvz35r3obiqg==
   dependencies:
     d3-array "^1.2.0"
-    d3-brush "^1.0.6"
+    d3-brush "^2.1.0"
     d3-chord "^1.0.4"
     d3-collection "^1.0.1"
     d3-contour "^1.1.1"
@@ -8691,7 +8700,7 @@ semiotic@^2.0.0-rc.5:
     d3-polygon "^1.0.5"
     d3-sankey-circular "0.25.0"
     d3-scale "^1.0.3"
-    d3-selection "^1.4.0"
+    d3-selection "2"
     d3-shape "^1.3.5"
     d3-voronoi "^1.0.2"
     element-resize-event "^3.0.3"
@@ -8699,10 +8708,9 @@ semiotic@^2.0.0-rc.5:
     memoize-one "^5.1.1"
     object-assign "4.1.1"
     polygon-offset "0.3.1"
-    promise "8.1.0"
     react-annotation "3.0.0-beta.4"
     regression "^2.0.1"
-    semiotic-mark "0.4.5"
+    semiotic-mark "0.5.0"
     svg-path-bounding-box "1.0.4"
 
 semver-compare@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   resolved "https://registry.yarnpkg.com/@spinnaker/pluginsdk-peerdeps/-/pluginsdk-peerdeps-0.0.11.tgz#e92f2bbee735ca18147c688a9c5bfefe2920383e"
   integrity sha512-FWtKY2g8rZhKZ0QF/CQDoZ241PCNq+wfadFLIdG7LYlmiHPRNWPJ9DLXjXNHBnXsgG6Om8sOgqnRHxifShnpDQ==
 
-"@spinnaker/pluginsdk@0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@spinnaker/pluginsdk/-/pluginsdk-0.0.25.tgz#e21d905b4737db7d7ac31ff1cb0daa614da55667"
-  integrity sha512-T9HklzyDn6NcfeQGzN2RpMrFfHsm8MZZyltbj3/YkKHKbWKijQSvhzKf6NTCU09GuQ/IDYUyZLF39em6b3cNow==
+"@spinnaker/pluginsdk@0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@spinnaker/pluginsdk/-/pluginsdk-0.0.26.tgz#2867330d03f02ccb1896e17a45ee6908b6a922b4"
+  integrity sha512-kvpW905OkrSUJ0o1Ch1BYIvPcEkqFv64RX/WAZNrqY83tigl2cVusochcokelfINeqwTHBudXUBqdvjo4XBCuA==
   dependencies:
     check-peer-dependencies "^4.0.0"
     chokidar "^3.5.1"


### PR DESCRIPTION
Semiotic V2 is always returning `0` for `x` on data points and hover annotations, which causes very bad graph rendering.

These changes are very tactical, very brittle, I am not proud of them, and I hope they go away once Semiotic cuts a new release.

__Behavior with Semiotic V1.x__
<img width="965" alt="Screen Shot 2021-04-14 at 2 15 44 PM" src="https://user-images.githubusercontent.com/73450/114781113-1963eb80-9d2d-11eb-88c9-1edab59c720b.png">

__With this PR__
<img width="967" alt="Screen Shot 2021-04-14 at 2 15 54 PM" src="https://user-images.githubusercontent.com/73450/114781118-1a951880-9d2d-11eb-8ce5-44f2e185e2b5.png">

__Without this PR__
<img width="1043" alt="Screen Shot 2021-04-14 at 2 25 52 PM" src="https://user-images.githubusercontent.com/73450/114781280-54661f00-9d2d-11eb-9273-1c745564cae2.png">
