### PR TITLE
chore(rxjs): switch back to bundling rxjs 5.x instead of migrating to rxjs 6

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,13 +17,12 @@ const externals = [
   'prop-types',
   'react',
   'react-dom',
-  'rxjs',
   'semiotic',
 ];
 
 basePluginConfig.input = 'src/index.ts';
 basePluginConfig.external = function (id) {
-  return externals.includes(id) || id.startsWith('rxjs/');
+  return externals.includes(id);
 };
 
 export default basePluginConfig;

--- a/src/kayenta/middleware/epics.ts
+++ b/src/kayenta/middleware/epics.ts
@@ -16,6 +16,14 @@ import { Action, MiddlewareAPI } from 'redux';
 import { combineEpics, createEpicMiddleware, EpicMiddleware } from 'redux-observable';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/concat';
+import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/observable/fromPromise';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/concatMap';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/mapTo';
 
 import { ReactInjector } from '@spinnaker/core';
 


### PR DESCRIPTION
There are breaking changes in `rxjs` 6, which deck is upgrading to. However, if we upgrade to `rxjs` 6 we also have to update to `redux-observable` 1.0 and that requires us to upgrade `redux` as well. 

I can't commit to that effort, so we'll pin `rxjs` to 5.x in kayenta and include it in the bundle.