### PR TITLE
feat: Expose spinnaker/kayenta to plugin system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kayenta",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './stub';
+export * from './kayenta';


### PR DESCRIPTION
In order to be able to create plugins for Deck-Kayenta we need the classes exported in order for them to be available to the Deck plugin framework. 