### PR TITLE
feat(kayenta): Add Flag to Disable Canary Config UI Editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kayenta",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/kayenta/edit/changeMetricGroupModal.tsx
+++ b/src/kayenta/edit/changeMetricGroupModal.tsx
@@ -1,6 +1,7 @@
 import * as Creators from 'kayenta/actions/creators';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryMetricConfig } from 'kayenta/domain/ICanaryConfig';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
 import Styleguide from 'kayenta/layout/styleguide';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
@@ -43,7 +44,8 @@ function ChangeMetricGroupModal({
             value={toGroup || ''}
             onChange={select}
             className="form-control input-sm"
-            disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+            disabled={CanarySettings.disableConfigEdit}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
           >
             <option value={''}>-- select group --</option>
             {groups.map((g) => (

--- a/src/kayenta/edit/changeMetricGroupModal.tsx
+++ b/src/kayenta/edit/changeMetricGroupModal.tsx
@@ -1,6 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
 import { ICanaryMetricConfig } from 'kayenta/domain/ICanaryConfig';
-import { DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
 import Styleguide from 'kayenta/layout/styleguide';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
@@ -43,7 +43,7 @@ function ChangeMetricGroupModal({
             value={toGroup || ''}
             onChange={select}
             className="form-control input-sm"
-            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
           >
             <option value={''}>-- select group --</option>
             {groups.map((g) => (

--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -12,6 +12,7 @@ import ConfigDetailActionButtons from './configDetailActionButtons';
 interface IConfigDetailStateProps {
   selectedConfig: ICanaryConfig;
   editingDisabled: boolean;
+  disableConfigEdit: boolean;
 }
 
 const getOwnerAppLinks = (owners: string[]) => {
@@ -53,10 +54,21 @@ const EditingDisabledWarning = ({ owners }: { owners: string[] }) => {
   );
 };
 
+const ConfigEditingDisabledWarning = () => {
+  return (
+    <div className="horizontal middle well-compact alert alert-warning config-detail-edit-warning">
+      <i className="fa fa-exclamation-triangle sp-margin-m-right" />
+      <span>
+        <b>UI Editing is disabled</b>
+      </span>
+    </div>
+  );
+};
+
 /*
  * Config detail header layout.
  */
-function ConfigDetailHeader({ selectedConfig, editingDisabled }: IConfigDetailStateProps) {
+function ConfigDetailHeader({ selectedConfig, editingDisabled, disableConfigEdit }: IConfigDetailStateProps) {
   return (
     <div className="vertical">
       <div className="horizontal config-detail-header">
@@ -73,7 +85,10 @@ function ConfigDetailHeader({ selectedConfig, editingDisabled }: IConfigDetailSt
           <ConfigDetailActionButtons />
         </div>
       </div>
-      {selectedConfig && editingDisabled && <EditingDisabledWarning owners={selectedConfig.applications} />}
+      {selectedConfig && editingDisabled && !disableConfigEdit && (
+        <EditingDisabledWarning owners={selectedConfig.applications} />
+      )}
+      {selectedConfig && disableConfigEdit && <ConfigEditingDisabledWarning />}
     </div>
   );
 }
@@ -81,7 +96,8 @@ function ConfigDetailHeader({ selectedConfig, editingDisabled }: IConfigDetailSt
 function mapStateToProps(state: ICanaryState): IConfigDetailStateProps {
   return {
     selectedConfig: mapStateToConfig(state),
-    editingDisabled: state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
+    editingDisabled: state.app.disableConfigEdit,
+    disableConfigEdit: CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -1,4 +1,5 @@
 import { UISref } from '@uirouter/react';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryConfig } from 'kayenta/domain';
 import FormattedDate from 'kayenta/layout/formattedDate';
 import { ICanaryState } from 'kayenta/reducers';
@@ -80,7 +81,7 @@ function ConfigDetailHeader({ selectedConfig, editingDisabled }: IConfigDetailSt
 function mapStateToProps(state: ICanaryState): IConfigDetailStateProps {
   return {
     selectedConfig: mapStateToConfig(state),
-    editingDisabled: state.app.disableConfigEdit,
+    editingDisabled: state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/configDetailHeader.tsx
+++ b/src/kayenta/edit/configDetailHeader.tsx
@@ -59,7 +59,7 @@ const ConfigEditingDisabledWarning = () => {
     <div className="horizontal middle well-compact alert alert-warning config-detail-edit-warning">
       <i className="fa fa-exclamation-triangle sp-margin-m-right" />
       <span>
-        <b>UI Editing is disabled</b>
+        <b>Canary config is locked and does not allow modification</b>
       </span>
     </div>
   );

--- a/src/kayenta/edit/configJsonModal.tsx
+++ b/src/kayenta/edit/configJsonModal.tsx
@@ -1,7 +1,7 @@
 import 'brace/ext/searchbox';
 import 'brace/mode/json';
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG } from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
 import Styleguide from 'kayenta/layout/styleguide';
 import { Tab, Tabs } from 'kayenta/layout/tabs';
 import { ICanaryState } from 'kayenta/reducers';
@@ -142,7 +142,7 @@ function mapStateToProps(state: ICanaryState): IConfigJsonStateProps {
     state.selectedConfig.json.configJson ||
     JsonUtils.makeSortedStringFromObject(omit(mapStateToConfig(state) || {}, 'id'));
 
-  const disabled = get(state, DISABLE_EDIT_CONFIG, false);
+  const disabled = state.app.disableConfigEdit || CanarySettings.disableConfigEdit;
 
   return {
     configJson,

--- a/src/kayenta/edit/copyConfigButton.tsx
+++ b/src/kayenta/edit/copyConfigButton.tsx
@@ -1,4 +1,5 @@
 import { UISref } from '@uirouter/react';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { get } from 'lodash';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -25,7 +26,8 @@ function CopyConfigButton({ disabled }: ICopyConfigButtonStateProps) {
 
 function mapStateToProps(state: ICanaryState) {
   return {
-    disabled: get(state.selectedConfig, 'config.isNew') || state.app.disableConfigEdit,
+    disabled:
+      get(state.selectedConfig, 'config.isNew') || state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/createConfigButton.tsx
+++ b/src/kayenta/edit/createConfigButton.tsx
@@ -1,4 +1,5 @@
 import { UISref } from '@uirouter/react';
+import { CanarySettings } from 'kayenta/canary.settings';
 import * as React from 'react';
 import { connect } from 'react-redux';
 
@@ -26,7 +27,7 @@ function CreateConfigButton({ disabled }: ICreateConfigButtonStateProps) {
 
 function mapStateToProps(state: ICanaryState): ICreateConfigButtonStateProps {
   return {
-    disabled: state.selectedConfig.config && state.selectedConfig.config.isNew,
+    disabled: (state.selectedConfig.config && state.selectedConfig.config.isNew) || CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/editMetricEffectSizes.tsx
+++ b/src/kayenta/edit/editMetricEffectSizes.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 
 import { HelpField, robotToHuman } from '@spinnaker/core';
 
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableInput } from '../layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableInput } from '../layout/disableable';
 
 interface IEditMetricEffectSizesProps {
   metricId: string;
@@ -115,7 +115,8 @@ export function EditMetricEffectSizes({
               step={isCles ? 0.01 : 1}
               onChange={(e) => updateSize(field, e.target.value)}
               value={isCles ? value : toPercent(value, field)}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+              disabled={CanarySettings.disableConfigEdit}
+              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
             />
             {!isCles && <div className="input-group-addon">%</div>}
           </div>

--- a/src/kayenta/edit/editMetricEffectSizes.tsx
+++ b/src/kayenta/edit/editMetricEffectSizes.tsx
@@ -1,4 +1,5 @@
 import * as Creators from 'kayenta/actions/creators';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryMetricEffectSizeConfig } from 'kayenta/domain';
 import FormRow from 'kayenta/layout/formRow';
 import RadioChoice from 'kayenta/layout/radioChoice';
@@ -8,7 +9,7 @@ import { connect } from 'react-redux';
 
 import { HelpField, robotToHuman } from '@spinnaker/core';
 
-import { DISABLE_EDIT_CONFIG, DisableableInput } from '../layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableInput } from '../layout/disableable';
 
 interface IEditMetricEffectSizesProps {
   metricId: string;
@@ -114,7 +115,7 @@ export function EditMetricEffectSizes({
               step={isCles ? 0.01 : 1}
               onChange={(e) => updateSize(field, e.target.value)}
               value={isCles ? value : toPercent(value, field)}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+              disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
             />
             {!isCles && <div className="input-group-addon">%</div>}
           </div>
@@ -169,7 +170,7 @@ function mapStateToProps(state: ICanaryState): IEditMetricEffectSizesProps {
   return {
     metricId: state.selectedConfig.editingMetric.id,
     direction: state.selectedConfig.editingMetric.analysisConfigurations?.canary?.direction ?? 'either',
-    disabled: state.app.disableConfigEdit,
+    disabled: state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
     effectSizes: state.selectedConfig.editingMetric.analysisConfigurations?.canary?.effectSize ?? {},
   };
 }

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -2,7 +2,12 @@ import classNames from 'classnames';
 import * as Creators from 'kayenta/actions/creators';
 import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryMetricConfig } from 'kayenta/domain';
-import { DISABLE_EDIT_CONFIG, DisableableInput, DisableableSelect } from 'kayenta/layout/disableable';
+import {
+  CANARY_EDIT_DISABLED,
+  DISABLE_EDIT_CONFIG,
+  DisableableInput,
+  DisableableSelect,
+} from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import RadioChoice from 'kayenta/layout/radioChoice';
 import Styleguide from 'kayenta/layout/styleguide';
@@ -69,7 +74,11 @@ function EditMetricModal({
   const direction = metric.analysisConfigurations?.canary?.direction ?? 'either';
   const nanStrategy = metric.analysisConfigurations?.canary?.nanStrategy ?? 'default';
   const critical = metric.analysisConfigurations?.canary?.critical ?? false;
-  const isConfirmDisabled = !isTemplateValid || disableEdit || values(validationErrors).some((e) => !isNull(e));
+  const isConfirmDisabled =
+    !isTemplateValid ||
+    disableEdit ||
+    CanarySettings.disableConfigEdit ||
+    values(validationErrors).some((e) => !isNull(e));
 
   const metricGroup = metric.groups.length ? metric.groups[0] : groups[0];
   const templatesEnabled =
@@ -80,7 +89,9 @@ function EditMetricModal({
     <Modal bsSize="large" show={true} onHide={noop} className={classNames('kayenta-edit-metric-modal')}>
       <Styleguide>
         <Modal.Header>
-          <Modal.Title>{disableEdit ? 'Metric Details' : 'Configure Metric'}</Modal.Title>
+          <Modal.Title>
+            {disableEdit || CanarySettings.disableConfigEdit ? 'Metric Details' : 'Configure Metric'}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <FormRow label="Group" inputOnly={true}>
@@ -90,7 +101,7 @@ function EditMetricModal({
                 value={metric.groups}
                 data-id={metric.id}
                 onChange={changeGroup}
-                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
               />
             )}
             {metric.groups.length < 2 && (
@@ -98,7 +109,7 @@ function EditMetricModal({
                 value={metricGroup}
                 onChange={changeGroup}
                 className="form-control input-sm"
-                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
               >
                 {groups.map((g) => (
                   <option key={g} value={g}>
@@ -114,7 +125,7 @@ function EditMetricModal({
               value={metric.name}
               data-id={metric.id}
               onChange={rename}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+              disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
             />
           </FormRow>
           <FormRow label="Fail on">
@@ -140,7 +151,7 @@ function EditMetricModal({
                 type="checkbox"
                 checked={critical}
                 onChange={updateCriticality}
-                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
               />
               Fail the canary if this metric fails
             </label>
@@ -227,7 +238,7 @@ function mapStateToProps(state: ICanaryState): IEditMetricModalStateProps {
     isTemplateValid: isTemplateValidSelector(state),
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useInlineTemplateEditor: useInlineTemplateEditorSelector(state),
-    disableEdit: state.app.disableConfigEdit,
+    disableEdit: state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
     validationErrors: editingMetricValidationErrorsSelector(state),
   };
 }

--- a/src/kayenta/edit/editMetricModal.tsx
+++ b/src/kayenta/edit/editMetricModal.tsx
@@ -2,12 +2,7 @@ import classNames from 'classnames';
 import * as Creators from 'kayenta/actions/creators';
 import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryMetricConfig } from 'kayenta/domain';
-import {
-  CANARY_EDIT_DISABLED,
-  DISABLE_EDIT_CONFIG,
-  DisableableInput,
-  DisableableSelect,
-} from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableInput, DisableableSelect } from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import RadioChoice from 'kayenta/layout/radioChoice';
 import Styleguide from 'kayenta/layout/styleguide';
@@ -101,7 +96,8 @@ function EditMetricModal({
                 value={metric.groups}
                 data-id={metric.id}
                 onChange={changeGroup}
-                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+                disabled={CanarySettings.disableConfigEdit}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
               />
             )}
             {metric.groups.length < 2 && (
@@ -109,7 +105,8 @@ function EditMetricModal({
                 value={metricGroup}
                 onChange={changeGroup}
                 className="form-control input-sm"
-                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+                disabled={CanarySettings.disableConfigEdit}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
               >
                 {groups.map((g) => (
                   <option key={g} value={g}>
@@ -125,7 +122,8 @@ function EditMetricModal({
               value={metric.name}
               data-id={metric.id}
               onChange={rename}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+              disabled={CanarySettings.disableConfigEdit}
+              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
             />
           </FormRow>
           <FormRow label="Fail on">
@@ -151,7 +149,8 @@ function EditMetricModal({
                 type="checkbox"
                 checked={critical}
                 onChange={updateCriticality}
-                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+                disabled={CanarySettings.disableConfigEdit}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
               />
               Fail the canary if this metric fails
             </label>

--- a/src/kayenta/edit/filterTemplateSelector.tsx
+++ b/src/kayenta/edit/filterTemplateSelector.tsx
@@ -1,6 +1,7 @@
 import * as Creators from 'kayenta/actions/creators';
 import { ICanaryFilterTemplateValidationMessages } from 'kayenta/edit/filterTemplatesValidation';
 import {
+  CANARY_EDIT_DISABLED,
   DISABLE_EDIT_CONFIG,
   DisableableInput,
   DisableableReactSelect,
@@ -94,7 +95,7 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
           {!isEditing && (
             <DisableableReactSelect
               value={selectedTemplateName}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+              disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
               onChange={selectTemplate}
               options={this.getOptions()}
               optionRenderer={this.optionRenderer}
@@ -105,7 +106,7 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
           <>
             <FormRow label="Name" error={get(validation, 'errors.templateName.message')} inputOnly={true}>
               <DisableableInput
-                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
                 onChange={editTemplateName}
                 value={editedTemplateName}
               />
@@ -118,7 +119,7 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
             >
               <DisableableTextarea
                 className="template-editor-textarea"
-                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
                 onChange={editTemplateValue}
                 value={editedTemplateValue}
               />

--- a/src/kayenta/edit/filterTemplateSelector.tsx
+++ b/src/kayenta/edit/filterTemplateSelector.tsx
@@ -1,7 +1,7 @@
 import * as Creators from 'kayenta/actions/creators';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryFilterTemplateValidationMessages } from 'kayenta/edit/filterTemplatesValidation';
 import {
-  CANARY_EDIT_DISABLED,
   DISABLE_EDIT_CONFIG,
   DisableableInput,
   DisableableReactSelect,
@@ -95,7 +95,8 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
           {!isEditing && (
             <DisableableReactSelect
               value={selectedTemplateName}
-              disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+              disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+              disabled={CanarySettings.disableConfigEdit}
               onChange={selectTemplate}
               options={this.getOptions()}
               optionRenderer={this.optionRenderer}
@@ -106,7 +107,8 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
           <>
             <FormRow label="Name" error={get(validation, 'errors.templateName.message')} inputOnly={true}>
               <DisableableInput
-                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabled={CanarySettings.disableConfigEdit}
                 onChange={editTemplateName}
                 value={editedTemplateName}
               />
@@ -119,7 +121,8 @@ export class FilterTemplateSelector extends React.Component<IFilterTemplateSelec
             >
               <DisableableTextarea
                 className="template-editor-textarea"
-                disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+                disabled={CanarySettings.disableConfigEdit}
                 onChange={editTemplateValue}
                 value={editedTemplateValue}
               />

--- a/src/kayenta/edit/groupName.tsx
+++ b/src/kayenta/edit/groupName.tsx
@@ -1,5 +1,5 @@
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -42,7 +42,7 @@ function GroupName({
           autoFocus={true}
           value={edit}
           onChange={handleUpdate}
-          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
         />
       </form>
     );

--- a/src/kayenta/edit/groupName.tsx
+++ b/src/kayenta/edit/groupName.tsx
@@ -1,5 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -42,7 +43,8 @@ function GroupName({
           autoFocus={true}
           value={edit}
           onChange={handleUpdate}
-          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+          disabled={CanarySettings.disableConfigEdit}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
         />
       </form>
     );

--- a/src/kayenta/edit/groupTabs.tsx
+++ b/src/kayenta/edit/groupTabs.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
 import { Tab, Tabs } from 'kayenta/layout/tabs';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
@@ -46,8 +47,10 @@ function GroupTabs({
         {selected && editable && !editing && (
           <i
             data-group={group}
-            onClick={disableConfigEdit ? noop : editGroupBegin}
-            className={classNames('fas', 'fa-pencil-alt', { disabled: disableConfigEdit })}
+            onClick={disableConfigEdit || CanarySettings.disableConfigEdit ? noop : editGroupBegin}
+            className={classNames('fas', 'fa-pencil-alt', {
+              disabled: disableConfigEdit || CanarySettings.disableConfigEdit,
+            })}
           />
         )}
       </Tab>
@@ -60,7 +63,11 @@ function GroupTabs({
         {groupList.map((group) => (
           <GroupTab key={group} group={group} editable={true} />
         ))}
-        <DisableableButton className="passive float-right" onClick={addGroup} disabledStateKeys={[DISABLE_EDIT_CONFIG]}>
+        <DisableableButton
+          className="passive float-right"
+          onClick={addGroup}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        >
           Add Group
         </DisableableButton>
       </Tabs>
@@ -73,7 +80,7 @@ function mapStateToProps(state: ICanaryState): IGroupTabsStateProps {
     groupList: state.selectedConfig.group.list,
     selectedGroup: state.selectedConfig.group.selected,
     editing: !!state.selectedConfig.group.edit || state.selectedConfig.group.edit === '',
-    disableConfigEdit: state.app.disableConfigEdit,
+    disableConfigEdit: state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/groupTabs.tsx
+++ b/src/kayenta/edit/groupTabs.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import * as Creators from 'kayenta/actions/creators';
 import { CanarySettings } from 'kayenta/canary.settings';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
 import { Tab, Tabs } from 'kayenta/layout/tabs';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
@@ -66,7 +66,8 @@ function GroupTabs({
         <DisableableButton
           className="passive float-right"
           onClick={addGroup}
-          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+          disabled={CanarySettings.disableConfigEdit}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
         >
           Add Group
         </DisableableButton>

--- a/src/kayenta/edit/groupWeight.tsx
+++ b/src/kayenta/edit/groupWeight.tsx
@@ -1,6 +1,7 @@
 import * as Creators from 'kayenta/actions/creators';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryConfig } from 'kayenta/domain/ICanaryConfig';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import { mapStateToConfig } from 'kayenta/service/canaryConfig.service';
 import { get, isNumber } from 'lodash';
@@ -39,7 +40,8 @@ function GroupWeight({
         onChange={handleInputChange}
         min={0}
         max={100}
-        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        disabled={CanarySettings.disableConfigEdit}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
       />
     </FormRow>
   );

--- a/src/kayenta/edit/groupWeight.tsx
+++ b/src/kayenta/edit/groupWeight.tsx
@@ -1,6 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
 import { ICanaryConfig } from 'kayenta/domain/ICanaryConfig';
-import { DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableInput } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import { mapStateToConfig } from 'kayenta/service/canaryConfig.service';
 import { get, isNumber } from 'lodash';
@@ -39,7 +39,7 @@ function GroupWeight({
         onChange={handleInputChange}
         min={0}
         max={100}
-        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
       />
     </FormRow>
   );

--- a/src/kayenta/edit/inlineTemplateEditor.tsx
+++ b/src/kayenta/edit/inlineTemplateEditor.tsx
@@ -1,5 +1,5 @@
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG, DisableableTextarea } from 'kayenta/layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableTextarea } from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
 import {
@@ -35,7 +35,7 @@ export function InlineTemplateEditor({
     >
       <DisableableTextarea
         className="template-editor-textarea"
-        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
         onChange={(e: any) => editTemplateValue(transformValueForSave(e.target.value))}
         value={templateValue}
       />

--- a/src/kayenta/edit/inlineTemplateEditor.tsx
+++ b/src/kayenta/edit/inlineTemplateEditor.tsx
@@ -1,5 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableTextarea } from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { DISABLE_EDIT_CONFIG, DisableableTextarea } from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
 import {
@@ -35,7 +36,8 @@ export function InlineTemplateEditor({
     >
       <DisableableTextarea
         className="template-editor-textarea"
-        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        disabled={CanarySettings.disableConfigEdit}
         onChange={(e: any) => editTemplateValue(transformValueForSave(e.target.value))}
         value={templateValue}
       />

--- a/src/kayenta/edit/judgeSelect.tsx
+++ b/src/kayenta/edit/judgeSelect.tsx
@@ -1,10 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
-import {
-  CANARY_EDIT_DISABLED,
-  DISABLE_EDIT_CONFIG,
-  DisableableInput,
-  DisableableReactSelect,
-} from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { DISABLE_EDIT_CONFIG, DisableableInput, DisableableReactSelect } from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
@@ -46,7 +42,8 @@ function JudgeSelect({
             options={judgeOptions}
             clearable={false}
             onChange={handleJudgeSelect}
-            disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+            disabled={CanarySettings.disableConfigEdit}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
           />
         </FormRow>
       );
@@ -57,7 +54,7 @@ function JudgeSelect({
             type="text"
             value={selectedJudge}
             disabled={true}
-            disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
           />
         </FormRow>
       );

--- a/src/kayenta/edit/judgeSelect.tsx
+++ b/src/kayenta/edit/judgeSelect.tsx
@@ -1,5 +1,10 @@
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG, DisableableInput, DisableableReactSelect } from 'kayenta/layout/disableable';
+import {
+  CANARY_EDIT_DISABLED,
+  DISABLE_EDIT_CONFIG,
+  DisableableInput,
+  DisableableReactSelect,
+} from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
@@ -41,7 +46,7 @@ function JudgeSelect({
             options={judgeOptions}
             clearable={false}
             onChange={handleJudgeSelect}
-            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
           />
         </FormRow>
       );
@@ -52,7 +57,7 @@ function JudgeSelect({
             type="text"
             value={selectedJudge}
             disabled={true}
-            disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+            disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
           />
         </FormRow>
       );

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
 import * as Creators from 'kayenta/actions/creators';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryMetricConfig } from 'kayenta/domain';
-import { DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
 import { ITableColumn, NativeTable } from 'kayenta/layout/table';
 import { ICanaryState } from 'kayenta/reducers';
 import { cloneDeep } from 'lodash';
@@ -97,15 +98,30 @@ function MetricList({
       getContent: (metric) => (
         <div className="horizontal pull-right metrics-action-buttons">
           <button className="link" data-id={metric.id} onClick={editMetric}>
-            {disableEdit ? 'View' : 'Edit'}
+            {disableEdit || CanarySettings.disableConfigEdit ? 'View' : 'Edit'}
           </button>
-          <button className="link" data-id={metric.id} disabled={disableEdit} onClick={openChangeMetricGroupModal}>
+          <button
+            className="link"
+            data-id={metric.id}
+            disabled={disableEdit || CanarySettings.disableConfigEdit}
+            onClick={openChangeMetricGroupModal}
+          >
             Move Group
           </button>
-          <button className="link" data-id={metric.id} disabled={disableEdit} onClick={() => copyMetric(metric)}>
+          <button
+            className="link"
+            data-id={metric.id}
+            disabled={disableEdit || CanarySettings.disableConfigEdit}
+            onClick={() => copyMetric(metric)}
+          >
             Copy
           </button>
-          <button className="link" data-id={metric.id} disabled={disableEdit} onClick={removeMetric}>
+          <button
+            className="link"
+            data-id={metric.id}
+            disabled={disableEdit || CanarySettings.disableConfigEdit}
+            onClick={removeMetric}
+          >
             Delete
           </button>
         </div>
@@ -129,7 +145,7 @@ function MetricList({
         data-default={groupList[0]}
         data-metric-store={metricStore}
         onClick={addMetric}
-        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
       >
         Add Metric
       </DisableableButton>
@@ -151,7 +167,7 @@ function mapStateToProps(state: ICanaryState): IMetricListStateProps {
       (m) => m.id === state.selectedConfig.changeMetricGroup.metric,
     ),
     metricStore: state.selectedConfig.selectedStore,
-    disableEdit: state.app.disableConfigEdit,
+    disableEdit: state.app.disableConfigEdit || CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/metricList.tsx
+++ b/src/kayenta/edit/metricList.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import * as Creators from 'kayenta/actions/creators';
 import { CanarySettings } from 'kayenta/canary.settings';
 import { ICanaryMetricConfig } from 'kayenta/domain';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
 import { ITableColumn, NativeTable } from 'kayenta/layout/table';
 import { ICanaryState } from 'kayenta/reducers';
 import { cloneDeep } from 'lodash';
@@ -145,7 +145,8 @@ function MetricList({
         data-default={groupList[0]}
         data-metric-store={metricStore}
         onClick={addMetric}
-        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        disabled={CanarySettings.disableConfigEdit}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
       >
         Add Metric
       </DisableableButton>

--- a/src/kayenta/edit/metricStoreSelector.tsx
+++ b/src/kayenta/edit/metricStoreSelector.tsx
@@ -1,6 +1,7 @@
 import * as Creators from 'kayenta/actions/creators';
+import { CanarySettings } from 'kayenta/canary.settings';
 import { KayentaAccountType } from 'kayenta/domain';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
 import { chain } from 'lodash';
@@ -31,7 +32,8 @@ const MetricStoreSelector = ({
         value={selectedStore || ''}
         onChange={select}
         className="form-control input-sm"
-        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        disabled={CanarySettings.disableConfigEdit}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
       >
         {stores.map((s) => (
           <option key={s} value={s}>

--- a/src/kayenta/edit/metricStoreSelector.tsx
+++ b/src/kayenta/edit/metricStoreSelector.tsx
@@ -1,6 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
 import { KayentaAccountType } from 'kayenta/domain';
-import { DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableSelect } from 'kayenta/layout/disableable';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
 import { chain } from 'lodash';
@@ -31,7 +31,7 @@ const MetricStoreSelector = ({
         value={selectedStore || ''}
         onChange={select}
         className="form-control input-sm"
-        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
       >
         {stores.map((s) => (
           <option key={s} value={s}>

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -1,5 +1,10 @@
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG, DisableableInput, DisableableTextarea } from 'kayenta/layout/disableable';
+import {
+  CANARY_EDIT_DISABLED,
+  DISABLE_EDIT_CONFIG,
+  DisableableInput,
+  DisableableTextarea,
+} from 'kayenta/layout/disableable';
 import FormList from 'kayenta/layout/formList';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
@@ -31,7 +36,12 @@ function NameAndDescription({
   return (
     <FormList>
       <FormRow label="Configuration Name" inputOnly={true}>
-        <DisableableInput type="text" value={name} onChange={changeName} disabledStateKeys={[DISABLE_EDIT_CONFIG]} />
+        <DisableableInput
+          type="text"
+          value={name}
+          onChange={changeName}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        />
       </FormRow>
       <MetricStoreSelector />
       <FormRow label="Description" inputOnly={true}>
@@ -39,7 +49,7 @@ function NameAndDescription({
           className="form-control input-sm"
           value={description}
           onChange={changeDescription}
-          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
         />
       </FormRow>
     </FormList>

--- a/src/kayenta/edit/nameAndDescription.tsx
+++ b/src/kayenta/edit/nameAndDescription.tsx
@@ -1,10 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
-import {
-  CANARY_EDIT_DISABLED,
-  DISABLE_EDIT_CONFIG,
-  DisableableInput,
-  DisableableTextarea,
-} from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { DISABLE_EDIT_CONFIG, DisableableInput, DisableableTextarea } from 'kayenta/layout/disableable';
 import FormList from 'kayenta/layout/formList';
 import FormRow from 'kayenta/layout/formRow';
 import { ICanaryState } from 'kayenta/reducers';
@@ -40,7 +36,8 @@ function NameAndDescription({
           type="text"
           value={name}
           onChange={changeName}
-          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+          disabled={CanarySettings.disableConfigEdit}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
         />
       </FormRow>
       <MetricStoreSelector />
@@ -49,7 +46,8 @@ function NameAndDescription({
           className="form-control input-sm"
           value={description}
           onChange={changeDescription}
-          disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+          disabled={CanarySettings.disableConfigEdit}
+          disabledStateKeys={[DISABLE_EDIT_CONFIG]}
         />
       </FormRow>
     </FormList>

--- a/src/kayenta/edit/openDeleteModalButton.tsx
+++ b/src/kayenta/edit/openDeleteModalButton.tsx
@@ -1,5 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
-import { DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
+import { CanarySettings } from 'kayenta/canary.settings';
+import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -22,9 +23,9 @@ function DeleteConfigButton({ openDeleteConfigModal, disabled }: IDeleteButtonDi
     <div>
       <DisableableButton
         className="passive"
-        disabled={disabled}
+        disabled={disabled || CanarySettings.disableConfigEdit}
         onClick={openDeleteConfigModal}
-        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
       >
         <i className="fa fa-trash" />
         <span>Delete</span>
@@ -36,7 +37,7 @@ function DeleteConfigButton({ openDeleteConfigModal, disabled }: IDeleteButtonDi
 
 function mapStateToProps(state: ICanaryState) {
   return {
-    disabled: state.selectedConfig.config && state.selectedConfig.config.isNew,
+    disabled: (state.selectedConfig.config && state.selectedConfig.config.isNew) || CanarySettings.disableConfigEdit,
   };
 }
 

--- a/src/kayenta/edit/openDeleteModalButton.tsx
+++ b/src/kayenta/edit/openDeleteModalButton.tsx
@@ -1,6 +1,6 @@
 import * as Creators from 'kayenta/actions/creators';
 import { CanarySettings } from 'kayenta/canary.settings';
-import { CANARY_EDIT_DISABLED, DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
+import { DISABLE_EDIT_CONFIG, DisableableButton } from 'kayenta/layout/disableable';
 import { ICanaryState } from 'kayenta/reducers';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -25,7 +25,7 @@ function DeleteConfigButton({ openDeleteConfigModal, disabled }: IDeleteButtonDi
         className="passive"
         disabled={disabled || CanarySettings.disableConfigEdit}
         onClick={openDeleteConfigModal}
-        disabledStateKeys={[DISABLE_EDIT_CONFIG, CANARY_EDIT_DISABLED]}
+        disabledStateKeys={[DISABLE_EDIT_CONFIG]}
       >
         <i className="fa fa-trash" />
         <span>Delete</span>

--- a/src/kayenta/edit/saveConfigButton.tsx
+++ b/src/kayenta/edit/saveConfigButton.tsx
@@ -1,3 +1,4 @@
+import { CanarySettings } from 'kayenta/canary.settings';
 import * as React from 'react';
 import { connect } from 'react-redux';
 
@@ -37,7 +38,7 @@ function SaveConfigButton({
       <SubmitButton
         label="Save Changes"
         onClick={saveConfig}
-        isDisabled={disable}
+        isDisabled={disable || CanarySettings.disableConfigEdit}
         submitting={saveConfigState === AsyncRequestState.Requesting}
       />
     );
@@ -45,7 +46,7 @@ function SaveConfigButton({
 }
 
 function mapStateToProps(state: ICanaryState): ISaveButtonStateProps {
-  const disable = !!state.selectedConfig.validationErrors.length;
+  const disable = !!state.selectedConfig.validationErrors.length || CanarySettings.disableConfigEdit;
   return {
     saveConfigState: state.selectedConfig.save.state,
     inSyncWithServer: state.selectedConfig.isInSyncWithServer,

--- a/src/kayenta/layout/disableable.tsx
+++ b/src/kayenta/layout/disableable.tsx
@@ -8,6 +8,7 @@ import Select, { ReactSelectProps } from 'react-select';
 
 // Well-known keys that flag if a component should be disabled.
 export const DISABLE_EDIT_CONFIG = 'app.disableConfigEdit';
+export const CANARY_EDIT_DISABLED = 'CanarySettings.disableConfigEdit';
 
 interface IDisableable {
   disabled?: boolean;

--- a/src/kayenta/layout/disableable.tsx
+++ b/src/kayenta/layout/disableable.tsx
@@ -8,7 +8,6 @@ import Select, { ReactSelectProps } from 'react-select';
 
 // Well-known keys that flag if a component should be disabled.
 export const DISABLE_EDIT_CONFIG = 'app.disableConfigEdit';
-export const CANARY_EDIT_DISABLED = 'CanarySettings.disableConfigEdit';
 
 interface IDisableable {
   disabled?: boolean;

--- a/src/kayenta/reducers/app.ts
+++ b/src/kayenta/reducers/app.ts
@@ -45,7 +45,7 @@ const configJsonModalTabState = handleActions(
   ConfigJsonModalTabState.Edit,
 );
 
-const disableConfigEdit = handleActions<boolean>({}, CanarySettings.disableConfigEdit ?? false);
+const disableConfigEdit = handleActions<boolean>({}, false);
 
 export const app: Reducer<IAppState> = combineReducers<IAppState>({
   executionsCount,


### PR DESCRIPTION
Adds a "disableConfigEdit" flag into the "Canary" settings of deck which will make the config edit portions of the canary config ui read only for all configs if the flag is set to true. This feature is intended for cases where the canary configs are being managed via code and deployed/updated via api calls to prevent drift and issues arising from manually made canary changes.

Images below show the state of the edit panels with the flag enabled.

<img width="1225" alt="image" src="https://github.com/spinnaker/deck-kayenta/assets/110042874/d02a1658-f614-4750-89a8-f02425d10def">

<img width="895" alt="image" src="https://github.com/spinnaker/deck-kayenta/assets/110042874/d9e6688e-fc89-445b-afe1-038bae651682">
