### PR TITLE
feat(kayenta): enable using template for Datadog metric store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kayenta",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/kayenta/metricStore/datadog/index.ts
+++ b/src/kayenta/metricStore/datadog/index.ts
@@ -5,4 +5,5 @@ metricStoreConfigStore.register({
   name: 'datadog',
   metricConfigurer: DatadogMetricConfigurer,
   queryFinder,
+  useTemplates: true,
 });


### PR DESCRIPTION
Enable using query templates with Datadog metric store. Previously this option was available only for stackdriver and prometheus, so the user has to modify the JSON directly in order to use additional tags or metric equations with Datadog metric store.


<img width="895" alt="Screenshot 2025-04-27 at 5 12 08 PM" src="https://github.com/user-attachments/assets/63386f81-88ec-4d13-98db-f05dcb338dfa" />
